### PR TITLE
Refactor/backup config

### DIFF
--- a/docker-frigate/docker-compose-frigate.yaml
+++ b/docker-frigate/docker-compose-frigate.yaml
@@ -25,8 +25,4 @@ services:
       - "8564:8554" # RTSP feeds
       - "8565:8555/tcp" # WebRTC over tcp
       - "8565:8555/udp" # WebRTC over udp
-    environment:
-      FRIGATE_RTSP_PASSWORD: "password"
-      PLUS_API_KEY: ""
-      FRIGATE_MQTT_USER: "mqtt_user"
-      FRIGATE_MQTT_PASSWORD: "mqtt_pass"
+    env_file: "frigate.env"

--- a/docker-frigate/frigate.env
+++ b/docker-frigate/frigate.env
@@ -1,0 +1,5 @@
+# Frigate environment variables
+FRIGATE_RTSP_PASSWORD="password"
+PLUS_API_KEY=""
+FRIGATE_MQTT_USER="mqtt_user"
+FRIGATE_MQTT_PASSWORD="mqtt_pass"

--- a/node-red-project/flows.json
+++ b/node-red-project/flows.json
@@ -221,7 +221,7 @@
         ],
         "x": 14,
         "y": 559,
-        "w": 1062,
+        "w": 1052,
         "h": 222
     },
     {
@@ -242,9 +242,9 @@
             "cbb3b02ca505a55b",
             "7db4b197df9eb075"
         ],
-        "x": 24,
+        "x": 14,
         "y": 839,
-        "w": 1168,
+        "w": 1178,
         "h": 508
     },
     {
@@ -315,9 +315,9 @@
             "9cf49f0891d25df1",
             "6d81c8e3c89b68f6"
         ],
-        "x": 64,
+        "x": 54,
         "y": 2519,
-        "w": 1242,
+        "w": 1252,
         "h": 242
     },
     {
@@ -660,7 +660,9 @@
             "9beaf948294acd98",
             "2b82d4b028657058",
             "099df29d699f405e",
-            "8fa3692b8c3f14a5"
+            "8fa3692b8c3f14a5",
+            "11b875e91b3d32a6",
+            "18b0dfda0489c5b4"
         ],
         "x": 14,
         "y": 99,
@@ -824,21 +826,16 @@
         },
         "nodes": [
             "371b831295a65179",
-            "1fdb03a6035a494c",
-            "2b8c15613685457b",
             "f2256e28de366878",
-            "bd75a8b7203331a0",
-            "0b6c06cde710a592",
             "f49c1d345cdfef57",
-            "8bc712d2bf7d7608",
             "c503122374a2fd6b",
             "bd0b99f0ea3996bf",
             "c5f739aac1d9e9a3"
         ],
         "x": 124,
-        "y": 131.5,
+        "y": 139,
         "w": 1168,
-        "h": 475.5
+        "h": 468
     },
     {
         "id": "dff0470b2ba97020",
@@ -873,14 +870,9 @@
             "01dff3893eb39da1",
             "4e8936db02bb178f",
             "19436a7a52d909d9",
-            "e324cdf01167b6b4",
-            "31bacedd56738550",
-            "d8f03f03f310add8",
-            "29a676d1bd02f536",
             "cb044bcc7761877e",
             "bd1fd07675061bc2",
             "da7f36e9a5928977",
-            "13395b5909a63e3c",
             "cb52210b00dca61d",
             "9278adb1ef92bb02",
             "09658d6c6e8e65cc",
@@ -891,16 +883,18 @@
             "8d1cea31ecc5505f",
             "3a9976a42e040827",
             "b0661dcf1869265d",
-            "7d85d4124ac35321",
-            "4cabf52349ebd694",
             "43092f22b971c203",
             "0fc0afa3cbbde9da",
-            "b6073793c9d88df9"
+            "b6073793c9d88df9",
+            "15cafffd34946386",
+            "bc68fe5b7f067110",
+            "2a45286ac680158f",
+            "d79a1bccb7cda804"
         ],
         "x": 154,
         "y": 659,
-        "w": 1152,
-        "h": 702
+        "w": 1992,
+        "h": 602
     },
     {
         "id": "0e1614cf2e5f9942",
@@ -1021,6 +1015,28 @@
         "x": 744,
         "y": 339,
         "w": 522,
+        "h": 242
+    },
+    {
+        "id": "a38a90c36a0abfc3",
+        "type": "group",
+        "z": "791e8b1f84050e40",
+        "name": "restore TM Frigate config from ThingsBoard",
+        "style": {
+            "label": true
+        },
+        "nodes": [
+            "56cafb11de5348b2",
+            "9aa93ed98869015b",
+            "9ea228bc25d4e59b",
+            "25515211bb8cecb4",
+            "64467a90df93e582",
+            "3c02407020db3c4a",
+            "65a881b4715da5ef"
+        ],
+        "x": 154,
+        "y": 1299,
+        "w": 892,
         "h": 242
     },
     {
@@ -6570,7 +6586,9 @@
         "x": 270,
         "y": 700,
         "wires": [
-            []
+            [
+                "11b875e91b3d32a6"
+            ]
         ],
         "info": "// nrlint function-eslint:off\n"
     },
@@ -8425,6 +8443,51 @@
         "wires": []
     },
     {
+        "id": "11b875e91b3d32a6",
+        "type": "change",
+        "z": "05fcb02c571dcfee",
+        "g": "dc2934def36c6285",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "#:(config)::homeDir",
+                "pt": "global",
+                "to": "payload",
+                "tot": "msg"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 490,
+        "y": 700,
+        "wires": [
+            [
+                "18b0dfda0489c5b4"
+            ]
+        ]
+    },
+    {
+        "id": "18b0dfda0489c5b4",
+        "type": "debug",
+        "z": "05fcb02c571dcfee",
+        "g": "dc2934def36c6285",
+        "name": "debug 2",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "false",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 680,
+        "y": 700,
+        "wires": []
+    },
+    {
         "id": "e6461a7fdeef48a2",
         "type": "ui_form",
         "z": "fa9f914901f79645",
@@ -9564,7 +9627,8 @@
         "name": "link out 2",
         "mode": "link",
         "links": [
-            "e9545b23f4e4cd35"
+            "e9545b23f4e4cd35",
+            "65a881b4715da5ef"
         ],
         "x": 455,
         "y": 1220,
@@ -10075,58 +10139,6 @@
         "y": 180,
         "wires": [
             [
-                "1fdb03a6035a494c",
-                "8bc712d2bf7d7608"
-            ]
-        ]
-    },
-    {
-        "id": "1fdb03a6035a494c",
-        "type": "exec",
-        "z": "791e8b1f84050e40",
-        "g": "b781cb3d6df38fed",
-        "command": "pwd",
-        "addpay": "",
-        "append": "",
-        "useSpawn": "false",
-        "timer": "",
-        "winHide": false,
-        "oldrc": false,
-        "name": "",
-        "x": 280,
-        "y": 180,
-        "wires": [
-            [
-                "2b8c15613685457b"
-            ],
-            [],
-            []
-        ]
-    },
-    {
-        "id": "2b8c15613685457b",
-        "type": "change",
-        "z": "791e8b1f84050e40",
-        "g": "b781cb3d6df38fed",
-        "name": "set Frigate config file path",
-        "rules": [
-            {
-                "t": "set",
-                "p": "payload",
-                "pt": "msg",
-                "to": "$substring(msg.payload,0, $length(msg.payload)-1) & \"/code/frigate/config/config.yml\"",
-                "tot": "jsonata"
-            }
-        ],
-        "action": "",
-        "property": "",
-        "from": "",
-        "to": "",
-        "reg": false,
-        "x": 500,
-        "y": 180,
-        "wires": [
-            [
                 "f2256e28de366878"
             ]
         ]
@@ -10137,46 +10149,18 @@
         "z": "791e8b1f84050e40",
         "g": "b781cb3d6df38fed",
         "name": "read Frigate config file",
-        "filename": "payload",
-        "filenameType": "msg",
+        "filename": "$flowContext(\"frigateConfigDir\") & \"/config.yml\"\t",
+        "filenameType": "jsonata",
         "format": "utf8",
         "chunk": false,
         "sendError": false,
         "encoding": "none",
         "allProps": false,
-        "x": 810,
+        "x": 320,
         "y": 180,
         "wires": [
             [
-                "bd75a8b7203331a0"
-            ]
-        ]
-    },
-    {
-        "id": "bd75a8b7203331a0",
-        "type": "change",
-        "z": "791e8b1f84050e40",
-        "g": "b781cb3d6df38fed",
-        "name": "set Frigate config payload",
-        "rules": [
-            {
-                "t": "set",
-                "p": "topic",
-                "pt": "msg",
-                "to": "Frigate",
-                "tot": "str"
-            }
-        ],
-        "action": "",
-        "property": "",
-        "from": "",
-        "to": "",
-        "reg": false,
-        "x": 1060,
-        "y": 180,
-        "wires": [
-            [
-                "0b6c06cde710a592"
+                "f49c1d345cdfef57"
             ]
         ]
     },
@@ -10211,36 +10195,6 @@
         "x": 500,
         "y": 40,
         "wires": []
-    },
-    {
-        "id": "0b6c06cde710a592",
-        "type": "join",
-        "z": "791e8b1f84050e40",
-        "g": "b781cb3d6df38fed",
-        "name": "",
-        "mode": "custom",
-        "build": "object",
-        "property": "payload",
-        "propertyType": "msg",
-        "key": "topic",
-        "joiner": "\\n",
-        "joinerType": "str",
-        "useparts": false,
-        "accumulate": false,
-        "timeout": "",
-        "count": "2",
-        "reduceRight": false,
-        "reduceExp": "",
-        "reduceInit": "",
-        "reduceInitType": "",
-        "reduceFixup": "",
-        "x": 340,
-        "y": 340,
-        "wires": [
-            [
-                "f49c1d345cdfef57"
-            ]
-        ]
     },
     {
         "id": "f64e7801aa071234",
@@ -10346,14 +10300,21 @@
         "type": "change",
         "z": "791e8b1f84050e40",
         "g": "b781cb3d6df38fed",
-        "name": "",
+        "name": "set up backup payload for TB",
         "rules": [
             {
                 "t": "set",
-                "p": "payload",
+                "p": "payload.backup.frigate",
                 "pt": "msg",
-                "to": "{    \"backup\": payload}",
-                "tot": "jsonata"
+                "to": "payload",
+                "tot": "msg"
+            },
+            {
+                "t": "set",
+                "p": "payload.backup.dateTime",
+                "pt": "msg",
+                "to": "",
+                "tot": "date"
             }
         ],
         "action": "",
@@ -10361,47 +10322,12 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 510,
-        "y": 340,
+        "x": 380,
+        "y": 220,
         "wires": [
             [
                 "f64e7801aa071234",
                 "c503122374a2fd6b"
-            ]
-        ]
-    },
-    {
-        "id": "8bc712d2bf7d7608",
-        "type": "change",
-        "z": "791e8b1f84050e40",
-        "g": "b781cb3d6df38fed",
-        "name": "set timestamp",
-        "rules": [
-            {
-                "t": "set",
-                "p": "payload",
-                "pt": "msg",
-                "to": "",
-                "tot": "date"
-            },
-            {
-                "t": "set",
-                "p": "topic",
-                "pt": "msg",
-                "to": "\"date\"",
-                "tot": "str"
-            }
-        ],
-        "action": "",
-        "property": "",
-        "from": "",
-        "to": "",
-        "reg": false,
-        "x": 310,
-        "y": 260,
-        "wires": [
-            [
-                "0b6c06cde710a592"
             ]
         ]
     },
@@ -10419,8 +10345,8 @@
         "targetType": "msg",
         "statusVal": "",
         "statusType": "auto",
-        "x": 850,
-        "y": 300,
+        "x": 680,
+        "y": 220,
         "wires": []
     },
     {
@@ -10445,6 +10371,7 @@
         "id": "e9545b23f4e4cd35",
         "type": "link in",
         "z": "791e8b1f84050e40",
+        "d": true,
         "g": "906735606a5ebdd5",
         "name": "start restore",
         "links": [
@@ -10454,7 +10381,7 @@
         "y": 740,
         "wires": [
             [
-                "e324cdf01167b6b4"
+                "bc68fe5b7f067110"
             ]
         ]
     },
@@ -10462,6 +10389,7 @@
         "id": "01dff3893eb39da1",
         "type": "http request",
         "z": "791e8b1f84050e40",
+        "d": true,
         "g": "906735606a5ebdd5",
         "name": "read config file from ThingsBoard",
         "method": "use",
@@ -10475,8 +10403,8 @@
         "authType": "",
         "senderr": false,
         "headers": [],
-        "x": 740,
-        "y": 880,
+        "x": 760,
+        "y": 780,
         "wires": [
             [
                 "19436a7a52d909d9"
@@ -10487,6 +10415,7 @@
         "id": "4e8936db02bb178f",
         "type": "function",
         "z": "791e8b1f84050e40",
+        "d": true,
         "g": "906735606a5ebdd5",
         "name": "set up tb client-side attributes for GET ",
         "func": "let serverUrl = global.get(\"serverUrl\", \"config\")\nlet serverPort = global.get(\"serverPort\", \"config\")\nlet accessToken = global.get(\"accessToken\", \"config\")\nmsg.url = `${serverUrl}:${serverPort}/api/v1/${accessToken}/attributes?clientKeys=backup`\n\nmsg.method = \"GET\";\nreturn msg;",
@@ -10496,8 +10425,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 390,
-        "y": 880,
+        "x": 710,
+        "y": 740,
         "wires": [
             [
                 "01dff3893eb39da1"
@@ -10508,13 +10437,14 @@
         "id": "19436a7a52d909d9",
         "type": "json",
         "z": "791e8b1f84050e40",
+        "d": true,
         "g": "906735606a5ebdd5",
         "name": "Convert string to JSON object",
         "property": "payload",
         "action": "",
         "pretty": false,
-        "x": 1070,
-        "y": 880,
+        "x": 790,
+        "y": 820,
         "wires": [
             [
                 "da7f36e9a5928977"
@@ -10522,115 +10452,14 @@
         ]
     },
     {
-        "id": "e324cdf01167b6b4",
-        "type": "exec",
-        "z": "791e8b1f84050e40",
-        "g": "906735606a5ebdd5",
-        "command": "pwd",
-        "addpay": "",
-        "append": "",
-        "useSpawn": "false",
-        "timer": "",
-        "winHide": false,
-        "oldrc": false,
-        "name": "",
-        "x": 290,
-        "y": 740,
-        "wires": [
-            [
-                "31bacedd56738550"
-            ],
-            [],
-            []
-        ]
-    },
-    {
-        "id": "31bacedd56738550",
-        "type": "change",
-        "z": "791e8b1f84050e40",
-        "g": "906735606a5ebdd5",
-        "name": "",
-        "rules": [
-            {
-                "t": "set",
-                "p": "pwd",
-                "pt": "flow",
-                "to": "$substring(msg.payload,0, $length(msg.payload)-1)",
-                "tot": "jsonata"
-            }
-        ],
-        "action": "",
-        "property": "",
-        "from": "",
-        "to": "",
-        "reg": false,
-        "x": 430,
-        "y": 740,
-        "wires": [
-            [
-                "d8f03f03f310add8"
-            ]
-        ]
-    },
-    {
-        "id": "d8f03f03f310add8",
-        "type": "change",
-        "z": "791e8b1f84050e40",
-        "g": "906735606a5ebdd5",
-        "name": "set up cp arguments",
-        "rules": [
-            {
-                "t": "set",
-                "p": "payload",
-                "pt": "msg",
-                "to": "$flowContext('pwd') & \"/code/frigate/config/config.yml \" & $flowContext('pwd') & \"/code/frigate/config/config.yml.backup\"",
-                "tot": "jsonata"
-            }
-        ],
-        "action": "",
-        "property": "",
-        "from": "",
-        "to": "",
-        "reg": false,
-        "x": 640,
-        "y": 740,
-        "wires": [
-            [
-                "29a676d1bd02f536"
-            ]
-        ]
-    },
-    {
-        "id": "29a676d1bd02f536",
-        "type": "exec",
-        "z": "791e8b1f84050e40",
-        "g": "906735606a5ebdd5",
-        "command": "/bin/cp ",
-        "addpay": "payload",
-        "append": "",
-        "useSpawn": "false",
-        "timer": "",
-        "winHide": false,
-        "oldrc": false,
-        "name": "make local backup of existing config file",
-        "x": 1000,
-        "y": 740,
-        "wires": [
-            [
-                "4e8936db02bb178f"
-            ],
-            [],
-            []
-        ]
-    },
-    {
         "id": "cb044bcc7761877e",
         "type": "comment",
         "z": "791e8b1f84050e40",
+        "d": true,
         "g": "906735606a5ebdd5",
         "name": "backup existing config file",
         "info": "",
-        "x": 650,
+        "x": 350,
         "y": 700,
         "wires": []
     },
@@ -10638,10 +10467,11 @@
         "id": "bd1fd07675061bc2",
         "type": "comment",
         "z": "791e8b1f84050e40",
+        "d": true,
         "g": "906735606a5ebdd5",
         "name": "read config text from ThingsBoard",
         "info": "",
-        "x": 600,
+        "x": 360,
         "y": 820,
         "wires": []
     },
@@ -10649,42 +10479,22 @@
         "id": "da7f36e9a5928977",
         "type": "change",
         "z": "791e8b1f84050e40",
+        "d": true,
         "g": "906735606a5ebdd5",
-        "name": "extract config string",
+        "name": "set up temp file params",
         "rules": [
             {
                 "t": "set",
                 "p": "payload",
                 "pt": "msg",
-                "to": "payload.client.backup.Frigate",
+                "to": "payload.client.backup.frigate",
                 "tot": "msg"
-            }
-        ],
-        "action": "",
-        "property": "",
-        "from": "",
-        "to": "",
-        "reg": false,
-        "x": 340,
-        "y": 1000,
-        "wires": [
-            [
-                "13395b5909a63e3c"
-            ]
-        ]
-    },
-    {
-        "id": "13395b5909a63e3c",
-        "type": "change",
-        "z": "791e8b1f84050e40",
-        "g": "906735606a5ebdd5",
-        "name": "set temp filename",
-        "rules": [
+            },
             {
                 "t": "set",
                 "p": "filename",
                 "pt": "msg",
-                "to": "$flowContext('pwd') & \"/code/frigate/config/temp.yml\"",
+                "to": "$flowContext(\"frigateConfigDir\") & \"/code/frigate/config/config.temp.yml\"",
                 "tot": "jsonata"
             }
         ],
@@ -10693,8 +10503,8 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 570,
-        "y": 1000,
+        "x": 830,
+        "y": 860,
         "wires": [
             [
                 "cb52210b00dca61d"
@@ -10705,6 +10515,7 @@
         "id": "cb52210b00dca61d",
         "type": "file",
         "z": "791e8b1f84050e40",
+        "d": true,
         "g": "906735606a5ebdd5",
         "name": "store temporary file",
         "filename": "filename",
@@ -10713,8 +10524,8 @@
         "createDir": false,
         "overwriteFile": "true",
         "encoding": "none",
-        "x": 790,
-        "y": 1000,
+        "x": 890,
+        "y": 900,
         "wires": [
             [
                 "1cd09de4ae651c87",
@@ -10726,38 +10537,41 @@
         "id": "9278adb1ef92bb02",
         "type": "comment",
         "z": "791e8b1f84050e40",
+        "d": true,
         "g": "906735606a5ebdd5",
-        "name": "store in temporary file",
+        "name": "get Frigate config.yml, store in temporary file",
         "info": "",
-        "x": 600,
-        "y": 940,
+        "x": 730,
+        "y": 700,
         "wires": []
     },
     {
         "id": "09658d6c6e8e65cc",
         "type": "comment",
         "z": "791e8b1f84050e40",
+        "d": true,
         "g": "906735606a5ebdd5",
-        "name": "validate config in temporary file",
+        "name": "validate Frigate config with temporary file",
         "info": "",
-        "x": 610,
-        "y": 1060,
+        "x": 980,
+        "y": 940,
         "wires": []
     },
     {
         "id": "3146435b51b57036",
         "type": "template",
         "z": "791e8b1f84050e40",
+        "d": true,
         "g": "906735606a5ebdd5",
         "name": "Setup arguments for docker run command",
         "field": "payload",
         "fieldType": "msg",
         "format": "handlebars",
         "syntax": "mustache",
-        "template": "-v {{{flow.pwd}}}/code/frigate/config/temp.yml:/config/config.yml --env-file {{{flow.pwd}}}/code/frigate/frigate.env  --entrypoint python3 ghcr.io/blakeblackshear/frigate:0.14.0 -u -m frigate --validate-config",
+        "template": "-v {{{flow.frigateConfigDir}}}/config.temp.yml:/config/config.yml --env-file {{{flow.frigateConfigDir}}}/frigate.env  --entrypoint python3 ghcr.io/blakeblackshear/frigate:0.14.0 -u -m frigate --validate-config",
         "output": "str",
-        "x": 390,
-        "y": 1120,
+        "x": 1000,
+        "y": 1000,
         "wires": [
             [
                 "f5bdcb22651184a6"
@@ -10768,6 +10582,7 @@
         "id": "1cd09de4ae651c87",
         "type": "debug",
         "z": "791e8b1f84050e40",
+        "d": true,
         "g": "906735606a5ebdd5",
         "name": "print file contents",
         "active": true,
@@ -10778,14 +10593,15 @@
         "targetType": "msg",
         "statusVal": "",
         "statusType": "auto",
-        "x": 1030,
-        "y": 1000,
+        "x": 1330,
+        "y": 960,
         "wires": []
     },
     {
         "id": "f5bdcb22651184a6",
         "type": "exec",
         "z": "791e8b1f84050e40",
+        "d": true,
         "g": "906735606a5ebdd5",
         "command": "docker run",
         "addpay": "payload",
@@ -10795,8 +10611,8 @@
         "winHide": false,
         "oldrc": false,
         "name": "validate Frigate config file",
-        "x": 750,
-        "y": 1120,
+        "x": 1070,
+        "y": 1060,
         "wires": [
             [
                 "3f95ff9f7d51b28d",
@@ -10812,6 +10628,7 @@
         "id": "3f95ff9f7d51b28d",
         "type": "debug",
         "z": "791e8b1f84050e40",
+        "d": true,
         "g": "906735606a5ebdd5",
         "name": "show iniital rc",
         "active": true,
@@ -10822,14 +10639,15 @@
         "targetType": "msg",
         "statusVal": "",
         "statusType": "auto",
-        "x": 1020,
-        "y": 1080,
+        "x": 1320,
+        "y": 1040,
         "wires": []
     },
     {
         "id": "8d1cea31ecc5505f",
         "type": "debug",
         "z": "791e8b1f84050e40",
+        "d": true,
         "g": "906735606a5ebdd5",
         "name": "show validation error messages",
         "active": true,
@@ -10840,25 +10658,27 @@
         "targetType": "msg",
         "statusVal": "",
         "statusType": "auto",
-        "x": 1070,
-        "y": 1120,
+        "x": 1370,
+        "y": 1080,
         "wires": []
     },
     {
         "id": "3a9976a42e040827",
         "type": "comment",
         "z": "791e8b1f84050e40",
+        "d": true,
         "g": "906735606a5ebdd5",
         "name": "check result, replace real config file, and restart Frigate",
         "info": "",
-        "x": 680,
-        "y": 1200,
+        "x": 1720,
+        "y": 1060,
         "wires": []
     },
     {
         "id": "b0661dcf1869265d",
         "type": "switch",
         "z": "791e8b1f84050e40",
+        "d": true,
         "g": "906735606a5ebdd5",
         "name": "test rc from validation of Frigate config",
         "property": "rc.code",
@@ -10878,11 +10698,11 @@
         "checkall": "true",
         "repair": false,
         "outputs": 2,
-        "x": 350,
-        "y": 1260,
+        "x": 1390,
+        "y": 1120,
         "wires": [
             [
-                "7d85d4124ac35321"
+                "2a45286ac680158f"
             ],
             [
                 "0fc0afa3cbbde9da"
@@ -10890,60 +10710,10 @@
         ]
     },
     {
-        "id": "7d85d4124ac35321",
-        "type": "change",
-        "z": "791e8b1f84050e40",
-        "g": "906735606a5ebdd5",
-        "name": "set up cp arguments",
-        "rules": [
-            {
-                "t": "set",
-                "p": "payload",
-                "pt": "msg",
-                "to": "$flowContext('pwd') & \"/code/frigate/config/temp.yml \" & $flowContext('pwd') &\t \"/code/frigate/config/config.yml\"",
-                "tot": "jsonata"
-            }
-        ],
-        "action": "",
-        "property": "",
-        "from": "",
-        "to": "",
-        "reg": false,
-        "x": 660,
-        "y": 1260,
-        "wires": [
-            [
-                "4cabf52349ebd694"
-            ]
-        ]
-    },
-    {
-        "id": "4cabf52349ebd694",
-        "type": "exec",
-        "z": "791e8b1f84050e40",
-        "g": "906735606a5ebdd5",
-        "command": "/bin/cp ",
-        "addpay": "payload",
-        "append": "",
-        "useSpawn": "false",
-        "timer": "",
-        "winHide": false,
-        "oldrc": false,
-        "name": "replace existing config file",
-        "x": 930,
-        "y": 1260,
-        "wires": [
-            [
-                "43092f22b971c203"
-            ],
-            [],
-            []
-        ]
-    },
-    {
         "id": "43092f22b971c203",
         "type": "exec",
         "z": "791e8b1f84050e40",
+        "d": true,
         "g": "906735606a5ebdd5",
         "command": "docker restart frigate",
         "addpay": "",
@@ -10953,8 +10723,8 @@
         "winHide": false,
         "oldrc": false,
         "name": "",
-        "x": 1180,
-        "y": 1260,
+        "x": 1960,
+        "y": 1160,
         "wires": [
             [
                 "b6073793c9d88df9"
@@ -10967,6 +10737,7 @@
         "id": "0fc0afa3cbbde9da",
         "type": "debug",
         "z": "791e8b1f84050e40",
+        "d": true,
         "g": "906735606a5ebdd5",
         "name": "Print failure msg",
         "active": true,
@@ -10977,14 +10748,15 @@
         "targetType": "jsonata",
         "statusVal": "",
         "statusType": "auto",
-        "x": 640,
-        "y": 1320,
+        "x": 1680,
+        "y": 1220,
         "wires": []
     },
     {
         "id": "b6073793c9d88df9",
         "type": "debug",
         "z": "791e8b1f84050e40",
+        "d": true,
         "g": "906735606a5ebdd5",
         "name": "Print success msg",
         "active": true,
@@ -10995,8 +10767,8 @@
         "targetType": "jsonata",
         "statusVal": "",
         "statusType": "auto",
-        "x": 1150,
-        "y": 1320,
+        "x": 2010,
+        "y": 1220,
         "wires": []
     },
     {
@@ -11015,5 +10787,302 @@
         "x": 1160,
         "y": 380,
         "wires": []
+    },
+    {
+        "id": "4a62f39107d10a25",
+        "type": "change",
+        "z": "791e8b1f84050e40",
+        "name": "set frigate config directory flow.frigateConfigDir",
+        "rules": [
+            {
+                "t": "set",
+                "p": "configDir",
+                "pt": "flow",
+                "to": "$globalContext('homeDir', 'config') & \"/code/frigate/config\"",
+                "tot": "jsonata"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 600,
+        "y": 100,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "38fd03504247825b",
+        "type": "inject",
+        "z": "791e8b1f84050e40",
+        "name": "init-flow-frigate-config-path",
+        "props": [],
+        "repeat": "",
+        "crontab": "",
+        "once": true,
+        "onceDelay": "5",
+        "topic": "",
+        "x": 260,
+        "y": 100,
+        "wires": [
+            [
+                "4a62f39107d10a25"
+            ]
+        ]
+    },
+    {
+        "id": "15cafffd34946386",
+        "type": "file",
+        "z": "791e8b1f84050e40",
+        "d": true,
+        "g": "906735606a5ebdd5",
+        "name": "write backup config file",
+        "filename": "$flowContext(\"frigateConfigDir\") & \"/config.bak.yml\"",
+        "filenameType": "jsonata",
+        "appendNewline": true,
+        "createDir": false,
+        "overwriteFile": "true",
+        "encoding": "none",
+        "x": 400,
+        "y": 780,
+        "wires": [
+            [
+                "4e8936db02bb178f"
+            ]
+        ]
+    },
+    {
+        "id": "bc68fe5b7f067110",
+        "type": "file in",
+        "z": "791e8b1f84050e40",
+        "d": true,
+        "g": "906735606a5ebdd5",
+        "name": "read Frigate config file",
+        "filename": "$flowContext(\"frigateConfigDir\") & \"/config.yml\"\t",
+        "filenameType": "jsonata",
+        "format": "utf8",
+        "chunk": false,
+        "sendError": false,
+        "encoding": "none",
+        "allProps": false,
+        "x": 340,
+        "y": 740,
+        "wires": [
+            [
+                "15cafffd34946386"
+            ]
+        ]
+    },
+    {
+        "id": "d79a1bccb7cda804",
+        "type": "file",
+        "z": "791e8b1f84050e40",
+        "d": true,
+        "g": "906735606a5ebdd5",
+        "name": "write backup config file",
+        "filename": "$flowContext(\"frigateConfigDir\") & \"/config.bak.yml\"",
+        "filenameType": "jsonata",
+        "appendNewline": true,
+        "createDir": false,
+        "overwriteFile": "true",
+        "encoding": "none",
+        "x": 1740,
+        "y": 1160,
+        "wires": [
+            [
+                "43092f22b971c203"
+            ]
+        ]
+    },
+    {
+        "id": "2a45286ac680158f",
+        "type": "file in",
+        "z": "791e8b1f84050e40",
+        "d": true,
+        "g": "906735606a5ebdd5",
+        "name": "read Frigate config file",
+        "filename": "$flowContext(\"frigateConfigDir\") & \"/config.yml\"\t",
+        "filenameType": "jsonata",
+        "format": "utf8",
+        "chunk": false,
+        "sendError": false,
+        "encoding": "none",
+        "allProps": false,
+        "x": 1700,
+        "y": 1120,
+        "wires": [
+            [
+                "d79a1bccb7cda804"
+            ]
+        ]
+    },
+    {
+        "id": "56cafb11de5348b2",
+        "type": "http request",
+        "z": "791e8b1f84050e40",
+        "g": "a38a90c36a0abfc3",
+        "name": "read config file from ThingsBoard",
+        "method": "use",
+        "ret": "txt",
+        "paytoqs": "ignore",
+        "url": "",
+        "tls": "",
+        "persist": false,
+        "proxy": "",
+        "insecureHTTPParser": false,
+        "authType": "",
+        "senderr": false,
+        "headers": [],
+        "x": 440,
+        "y": 1380,
+        "wires": [
+            [
+                "9ea228bc25d4e59b"
+            ]
+        ]
+    },
+    {
+        "id": "9aa93ed98869015b",
+        "type": "function",
+        "z": "791e8b1f84050e40",
+        "g": "a38a90c36a0abfc3",
+        "name": "set up tb client-side attributes for GET ",
+        "func": "let serverUrl = global.get(\"serverUrl\", \"config\")\nlet serverPort = global.get(\"serverPort\", \"config\")\nlet accessToken = global.get(\"accessToken\", \"config\")\nmsg.url = `${serverUrl}:${serverPort}/api/v1/${accessToken}/attributes?clientKeys=backup`\n\nmsg.method = \"GET\";\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 390,
+        "y": 1340,
+        "wires": [
+            [
+                "56cafb11de5348b2"
+            ]
+        ]
+    },
+    {
+        "id": "9ea228bc25d4e59b",
+        "type": "change",
+        "z": "791e8b1f84050e40",
+        "g": "a38a90c36a0abfc3",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "payload.client.backup.frigate",
+                "tot": "msg"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 540,
+        "y": 1420,
+        "wires": [
+            [
+                "25515211bb8cecb4"
+            ]
+        ]
+    },
+    {
+        "id": "25515211bb8cecb4",
+        "type": "http request",
+        "z": "791e8b1f84050e40",
+        "g": "a38a90c36a0abfc3",
+        "name": "validate Frigate config, save and restart",
+        "method": "POST",
+        "ret": "txt",
+        "paytoqs": "ignore",
+        "url": "http://localhost:5000/config/save?save_option=restart",
+        "tls": "",
+        "persist": false,
+        "proxy": "",
+        "insecureHTTPParser": false,
+        "authType": "",
+        "senderr": true,
+        "headers": [
+            {
+                "keyType": "Content-Type",
+                "keyValue": "",
+                "valueType": "text/plain",
+                "valueValue": ""
+            }
+        ],
+        "x": 620,
+        "y": 1460,
+        "wires": [
+            [
+                "64467a90df93e582"
+            ]
+        ]
+    },
+    {
+        "id": "64467a90df93e582",
+        "type": "switch",
+        "z": "791e8b1f84050e40",
+        "g": "a38a90c36a0abfc3",
+        "name": "check for validation error",
+        "property": "statusCode",
+        "propertyType": "msg",
+        "rules": [
+            {
+                "t": "eq",
+                "v": "400",
+                "vt": "str"
+            }
+        ],
+        "checkall": "true",
+        "repair": false,
+        "outputs": 1,
+        "x": 710,
+        "y": 1500,
+        "wires": [
+            [
+                "3c02407020db3c4a"
+            ]
+        ]
+    },
+    {
+        "id": "3c02407020db3c4a",
+        "type": "debug",
+        "z": "791e8b1f84050e40",
+        "g": "a38a90c36a0abfc3",
+        "name": "validation error",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "payload",
+        "targetType": "msg",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 920,
+        "y": 1500,
+        "wires": []
+    },
+    {
+        "id": "65a881b4715da5ef",
+        "type": "link in",
+        "z": "791e8b1f84050e40",
+        "g": "a38a90c36a0abfc3",
+        "name": "start restore",
+        "links": [
+            "e4475a4fd4eb47ea"
+        ],
+        "x": 195,
+        "y": 1340,
+        "wires": [
+            [
+                "9aa93ed98869015b"
+            ]
+        ]
     }
 ]

--- a/node-red-project/flows.json
+++ b/node-red-project/flows.json
@@ -828,14 +828,13 @@
             "371b831295a65179",
             "f2256e28de366878",
             "f49c1d345cdfef57",
-            "c503122374a2fd6b",
             "bd0b99f0ea3996bf",
             "c5f739aac1d9e9a3"
         ],
         "x": 124,
         "y": 139,
-        "w": 1168,
-        "h": 468
+        "w": 968,
+        "h": 308
     },
     {
         "id": "dff0470b2ba97020",
@@ -856,45 +855,6 @@
         "y": 1099,
         "w": 462,
         "h": 162
-    },
-    {
-        "id": "906735606a5ebdd5",
-        "type": "group",
-        "z": "791e8b1f84050e40",
-        "name": "restore TM configuration from ThingsBoard",
-        "style": {
-            "label": true
-        },
-        "nodes": [
-            "e9545b23f4e4cd35",
-            "01dff3893eb39da1",
-            "4e8936db02bb178f",
-            "19436a7a52d909d9",
-            "cb044bcc7761877e",
-            "bd1fd07675061bc2",
-            "da7f36e9a5928977",
-            "cb52210b00dca61d",
-            "9278adb1ef92bb02",
-            "09658d6c6e8e65cc",
-            "3146435b51b57036",
-            "1cd09de4ae651c87",
-            "f5bdcb22651184a6",
-            "3f95ff9f7d51b28d",
-            "8d1cea31ecc5505f",
-            "3a9976a42e040827",
-            "b0661dcf1869265d",
-            "43092f22b971c203",
-            "0fc0afa3cbbde9da",
-            "b6073793c9d88df9",
-            "15cafffd34946386",
-            "bc68fe5b7f067110",
-            "2a45286ac680158f",
-            "d79a1bccb7cda804"
-        ],
-        "x": 154,
-        "y": 659,
-        "w": 1992,
-        "h": 602
     },
     {
         "id": "0e1614cf2e5f9942",
@@ -1009,12 +969,11 @@
             "f64e7801aa071234",
             "37bb791e1cfa7ffb",
             "9726f6154932eeed",
-            "02c5bc95c26b6024",
-            "d1e4b174776b2e77"
+            "02c5bc95c26b6024"
         ],
-        "x": 744,
-        "y": 339,
-        "w": 522,
+        "x": 634,
+        "y": 179,
+        "w": 432,
         "h": 242
     },
     {
@@ -1028,15 +987,16 @@
         "nodes": [
             "56cafb11de5348b2",
             "9aa93ed98869015b",
-            "9ea228bc25d4e59b",
             "25515211bb8cecb4",
             "64467a90df93e582",
-            "3c02407020db3c4a",
-            "65a881b4715da5ef"
+            "65a881b4715da5ef",
+            "7555653f37b1cd50",
+            "0d394a2d73d138d6",
+            "5b7fe362e2e6b35d"
         ],
-        "x": 154,
-        "y": 1299,
-        "w": 892,
+        "x": 134,
+        "y": 479,
+        "w": 992,
         "h": 242
     },
     {
@@ -10149,7 +10109,7 @@
         "z": "791e8b1f84050e40",
         "g": "b781cb3d6df38fed",
         "name": "read Frigate config file",
-        "filename": "$flowContext(\"frigateConfigDir\") & \"/config.yml\"\t",
+        "filename": "$flowContext(\"frigateConfigDir\") & \"/config.yml\"",
         "filenameType": "jsonata",
         "format": "utf8",
         "chunk": false,
@@ -10209,12 +10169,11 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 910,
-        "y": 380,
+        "x": 800,
+        "y": 220,
         "wires": [
             [
-                "02c5bc95c26b6024",
-                "d1e4b174776b2e77"
+                "02c5bc95c26b6024"
             ]
         ]
     },
@@ -10242,8 +10201,8 @@
                 "valueValue": ""
             }
         ],
-        "x": 980,
-        "y": 500,
+        "x": 870,
+        "y": 340,
         "wires": [
             [
                 "9726f6154932eeed"
@@ -10264,8 +10223,8 @@
         "targetType": "full",
         "statusVal": "",
         "statusType": "auto",
-        "x": 1000,
-        "y": 540,
+        "x": 890,
+        "y": 380,
         "wires": []
     },
     {
@@ -10286,8 +10245,8 @@
         "drop": true,
         "allowrate": false,
         "outputs": 2,
-        "x": 920,
-        "y": 440,
+        "x": 810,
+        "y": 280,
         "wires": [
             [
                 "37bb791e1cfa7ffb"
@@ -10303,10 +10262,10 @@
         "name": "set up backup payload for TB",
         "rules": [
             {
-                "t": "set",
-                "p": "payload.backup.frigate",
+                "t": "move",
+                "p": "payload",
                 "pt": "msg",
-                "to": "payload",
+                "to": "payload.backup.frigate",
                 "tot": "msg"
             },
             {
@@ -10326,28 +10285,9 @@
         "y": 220,
         "wires": [
             [
-                "f64e7801aa071234",
-                "c503122374a2fd6b"
+                "f64e7801aa071234"
             ]
         ]
-    },
-    {
-        "id": "c503122374a2fd6b",
-        "type": "debug",
-        "z": "791e8b1f84050e40",
-        "g": "b781cb3d6df38fed",
-        "name": "debug attribute msg",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "payload",
-        "targetType": "msg",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 680,
-        "y": 220,
-        "wires": []
     },
     {
         "id": "bd0b99f0ea3996bf",
@@ -10358,435 +10298,13 @@
         "links": [
             "8fa3692b8c3f14a5"
         ],
-        "x": 555,
-        "y": 420,
+        "x": 475,
+        "y": 280,
         "wires": [
             [
-                "f64e7801aa071234",
-                "c503122374a2fd6b"
+                "f64e7801aa071234"
             ]
         ]
-    },
-    {
-        "id": "e9545b23f4e4cd35",
-        "type": "link in",
-        "z": "791e8b1f84050e40",
-        "d": true,
-        "g": "906735606a5ebdd5",
-        "name": "start restore",
-        "links": [
-            "e4475a4fd4eb47ea"
-        ],
-        "x": 195,
-        "y": 740,
-        "wires": [
-            [
-                "bc68fe5b7f067110"
-            ]
-        ]
-    },
-    {
-        "id": "01dff3893eb39da1",
-        "type": "http request",
-        "z": "791e8b1f84050e40",
-        "d": true,
-        "g": "906735606a5ebdd5",
-        "name": "read config file from ThingsBoard",
-        "method": "use",
-        "ret": "txt",
-        "paytoqs": "ignore",
-        "url": "",
-        "tls": "",
-        "persist": false,
-        "proxy": "",
-        "insecureHTTPParser": false,
-        "authType": "",
-        "senderr": false,
-        "headers": [],
-        "x": 760,
-        "y": 780,
-        "wires": [
-            [
-                "19436a7a52d909d9"
-            ]
-        ]
-    },
-    {
-        "id": "4e8936db02bb178f",
-        "type": "function",
-        "z": "791e8b1f84050e40",
-        "d": true,
-        "g": "906735606a5ebdd5",
-        "name": "set up tb client-side attributes for GET ",
-        "func": "let serverUrl = global.get(\"serverUrl\", \"config\")\nlet serverPort = global.get(\"serverPort\", \"config\")\nlet accessToken = global.get(\"accessToken\", \"config\")\nmsg.url = `${serverUrl}:${serverPort}/api/v1/${accessToken}/attributes?clientKeys=backup`\n\nmsg.method = \"GET\";\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 710,
-        "y": 740,
-        "wires": [
-            [
-                "01dff3893eb39da1"
-            ]
-        ]
-    },
-    {
-        "id": "19436a7a52d909d9",
-        "type": "json",
-        "z": "791e8b1f84050e40",
-        "d": true,
-        "g": "906735606a5ebdd5",
-        "name": "Convert string to JSON object",
-        "property": "payload",
-        "action": "",
-        "pretty": false,
-        "x": 790,
-        "y": 820,
-        "wires": [
-            [
-                "da7f36e9a5928977"
-            ]
-        ]
-    },
-    {
-        "id": "cb044bcc7761877e",
-        "type": "comment",
-        "z": "791e8b1f84050e40",
-        "d": true,
-        "g": "906735606a5ebdd5",
-        "name": "backup existing config file",
-        "info": "",
-        "x": 350,
-        "y": 700,
-        "wires": []
-    },
-    {
-        "id": "bd1fd07675061bc2",
-        "type": "comment",
-        "z": "791e8b1f84050e40",
-        "d": true,
-        "g": "906735606a5ebdd5",
-        "name": "read config text from ThingsBoard",
-        "info": "",
-        "x": 360,
-        "y": 820,
-        "wires": []
-    },
-    {
-        "id": "da7f36e9a5928977",
-        "type": "change",
-        "z": "791e8b1f84050e40",
-        "d": true,
-        "g": "906735606a5ebdd5",
-        "name": "set up temp file params",
-        "rules": [
-            {
-                "t": "set",
-                "p": "payload",
-                "pt": "msg",
-                "to": "payload.client.backup.frigate",
-                "tot": "msg"
-            },
-            {
-                "t": "set",
-                "p": "filename",
-                "pt": "msg",
-                "to": "$flowContext(\"frigateConfigDir\") & \"/code/frigate/config/config.temp.yml\"",
-                "tot": "jsonata"
-            }
-        ],
-        "action": "",
-        "property": "",
-        "from": "",
-        "to": "",
-        "reg": false,
-        "x": 830,
-        "y": 860,
-        "wires": [
-            [
-                "cb52210b00dca61d"
-            ]
-        ]
-    },
-    {
-        "id": "cb52210b00dca61d",
-        "type": "file",
-        "z": "791e8b1f84050e40",
-        "d": true,
-        "g": "906735606a5ebdd5",
-        "name": "store temporary file",
-        "filename": "filename",
-        "filenameType": "msg",
-        "appendNewline": false,
-        "createDir": false,
-        "overwriteFile": "true",
-        "encoding": "none",
-        "x": 890,
-        "y": 900,
-        "wires": [
-            [
-                "1cd09de4ae651c87",
-                "3146435b51b57036"
-            ]
-        ]
-    },
-    {
-        "id": "9278adb1ef92bb02",
-        "type": "comment",
-        "z": "791e8b1f84050e40",
-        "d": true,
-        "g": "906735606a5ebdd5",
-        "name": "get Frigate config.yml, store in temporary file",
-        "info": "",
-        "x": 730,
-        "y": 700,
-        "wires": []
-    },
-    {
-        "id": "09658d6c6e8e65cc",
-        "type": "comment",
-        "z": "791e8b1f84050e40",
-        "d": true,
-        "g": "906735606a5ebdd5",
-        "name": "validate Frigate config with temporary file",
-        "info": "",
-        "x": 980,
-        "y": 940,
-        "wires": []
-    },
-    {
-        "id": "3146435b51b57036",
-        "type": "template",
-        "z": "791e8b1f84050e40",
-        "d": true,
-        "g": "906735606a5ebdd5",
-        "name": "Setup arguments for docker run command",
-        "field": "payload",
-        "fieldType": "msg",
-        "format": "handlebars",
-        "syntax": "mustache",
-        "template": "-v {{{flow.frigateConfigDir}}}/config.temp.yml:/config/config.yml --env-file {{{flow.frigateConfigDir}}}/frigate.env  --entrypoint python3 ghcr.io/blakeblackshear/frigate:0.14.0 -u -m frigate --validate-config",
-        "output": "str",
-        "x": 1000,
-        "y": 1000,
-        "wires": [
-            [
-                "f5bdcb22651184a6"
-            ]
-        ]
-    },
-    {
-        "id": "1cd09de4ae651c87",
-        "type": "debug",
-        "z": "791e8b1f84050e40",
-        "d": true,
-        "g": "906735606a5ebdd5",
-        "name": "print file contents",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "payload",
-        "targetType": "msg",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 1330,
-        "y": 960,
-        "wires": []
-    },
-    {
-        "id": "f5bdcb22651184a6",
-        "type": "exec",
-        "z": "791e8b1f84050e40",
-        "d": true,
-        "g": "906735606a5ebdd5",
-        "command": "docker run",
-        "addpay": "payload",
-        "append": "",
-        "useSpawn": "false",
-        "timer": "",
-        "winHide": false,
-        "oldrc": false,
-        "name": "validate Frigate config file",
-        "x": 1070,
-        "y": 1060,
-        "wires": [
-            [
-                "3f95ff9f7d51b28d",
-                "b0661dcf1869265d"
-            ],
-            [
-                "8d1cea31ecc5505f"
-            ],
-            []
-        ]
-    },
-    {
-        "id": "3f95ff9f7d51b28d",
-        "type": "debug",
-        "z": "791e8b1f84050e40",
-        "d": true,
-        "g": "906735606a5ebdd5",
-        "name": "show iniital rc",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "rc",
-        "targetType": "msg",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 1320,
-        "y": 1040,
-        "wires": []
-    },
-    {
-        "id": "8d1cea31ecc5505f",
-        "type": "debug",
-        "z": "791e8b1f84050e40",
-        "d": true,
-        "g": "906735606a5ebdd5",
-        "name": "show validation error messages",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "payload",
-        "targetType": "msg",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 1370,
-        "y": 1080,
-        "wires": []
-    },
-    {
-        "id": "3a9976a42e040827",
-        "type": "comment",
-        "z": "791e8b1f84050e40",
-        "d": true,
-        "g": "906735606a5ebdd5",
-        "name": "check result, replace real config file, and restart Frigate",
-        "info": "",
-        "x": 1720,
-        "y": 1060,
-        "wires": []
-    },
-    {
-        "id": "b0661dcf1869265d",
-        "type": "switch",
-        "z": "791e8b1f84050e40",
-        "d": true,
-        "g": "906735606a5ebdd5",
-        "name": "test rc from validation of Frigate config",
-        "property": "rc.code",
-        "propertyType": "msg",
-        "rules": [
-            {
-                "t": "eq",
-                "v": "0",
-                "vt": "num"
-            },
-            {
-                "t": "neq",
-                "v": "0",
-                "vt": "num"
-            }
-        ],
-        "checkall": "true",
-        "repair": false,
-        "outputs": 2,
-        "x": 1390,
-        "y": 1120,
-        "wires": [
-            [
-                "2a45286ac680158f"
-            ],
-            [
-                "0fc0afa3cbbde9da"
-            ]
-        ]
-    },
-    {
-        "id": "43092f22b971c203",
-        "type": "exec",
-        "z": "791e8b1f84050e40",
-        "d": true,
-        "g": "906735606a5ebdd5",
-        "command": "docker restart frigate",
-        "addpay": "",
-        "append": "",
-        "useSpawn": "false",
-        "timer": "",
-        "winHide": false,
-        "oldrc": false,
-        "name": "",
-        "x": 1960,
-        "y": 1160,
-        "wires": [
-            [
-                "b6073793c9d88df9"
-            ],
-            [],
-            []
-        ]
-    },
-    {
-        "id": "0fc0afa3cbbde9da",
-        "type": "debug",
-        "z": "791e8b1f84050e40",
-        "d": true,
-        "g": "906735606a5ebdd5",
-        "name": "Print failure msg",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "\"Config file not replaced and Frigate not restarted\"",
-        "targetType": "jsonata",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 1680,
-        "y": 1220,
-        "wires": []
-    },
-    {
-        "id": "b6073793c9d88df9",
-        "type": "debug",
-        "z": "791e8b1f84050e40",
-        "d": true,
-        "g": "906735606a5ebdd5",
-        "name": "Print success msg",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "\"Config file restored and Frigate restarted\"",
-        "targetType": "jsonata",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 2010,
-        "y": 1220,
-        "wires": []
-    },
-    {
-        "id": "d1e4b174776b2e77",
-        "type": "debug",
-        "z": "791e8b1f84050e40",
-        "g": "c5f739aac1d9e9a3",
-        "name": "debug 1",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "false",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 1160,
-        "y": 380,
-        "wires": []
     },
     {
         "id": "4a62f39107d10a25",
@@ -10796,7 +10314,7 @@
         "rules": [
             {
                 "t": "set",
-                "p": "configDir",
+                "p": "frigateConfigDir",
                 "pt": "flow",
                 "to": "$globalContext('homeDir', 'config') & \"/code/frigate/config\"",
                 "tot": "jsonata"
@@ -10833,92 +10351,6 @@
         ]
     },
     {
-        "id": "15cafffd34946386",
-        "type": "file",
-        "z": "791e8b1f84050e40",
-        "d": true,
-        "g": "906735606a5ebdd5",
-        "name": "write backup config file",
-        "filename": "$flowContext(\"frigateConfigDir\") & \"/config.bak.yml\"",
-        "filenameType": "jsonata",
-        "appendNewline": true,
-        "createDir": false,
-        "overwriteFile": "true",
-        "encoding": "none",
-        "x": 400,
-        "y": 780,
-        "wires": [
-            [
-                "4e8936db02bb178f"
-            ]
-        ]
-    },
-    {
-        "id": "bc68fe5b7f067110",
-        "type": "file in",
-        "z": "791e8b1f84050e40",
-        "d": true,
-        "g": "906735606a5ebdd5",
-        "name": "read Frigate config file",
-        "filename": "$flowContext(\"frigateConfigDir\") & \"/config.yml\"\t",
-        "filenameType": "jsonata",
-        "format": "utf8",
-        "chunk": false,
-        "sendError": false,
-        "encoding": "none",
-        "allProps": false,
-        "x": 340,
-        "y": 740,
-        "wires": [
-            [
-                "15cafffd34946386"
-            ]
-        ]
-    },
-    {
-        "id": "d79a1bccb7cda804",
-        "type": "file",
-        "z": "791e8b1f84050e40",
-        "d": true,
-        "g": "906735606a5ebdd5",
-        "name": "write backup config file",
-        "filename": "$flowContext(\"frigateConfigDir\") & \"/config.bak.yml\"",
-        "filenameType": "jsonata",
-        "appendNewline": true,
-        "createDir": false,
-        "overwriteFile": "true",
-        "encoding": "none",
-        "x": 1740,
-        "y": 1160,
-        "wires": [
-            [
-                "43092f22b971c203"
-            ]
-        ]
-    },
-    {
-        "id": "2a45286ac680158f",
-        "type": "file in",
-        "z": "791e8b1f84050e40",
-        "d": true,
-        "g": "906735606a5ebdd5",
-        "name": "read Frigate config file",
-        "filename": "$flowContext(\"frigateConfigDir\") & \"/config.yml\"\t",
-        "filenameType": "jsonata",
-        "format": "utf8",
-        "chunk": false,
-        "sendError": false,
-        "encoding": "none",
-        "allProps": false,
-        "x": 1700,
-        "y": 1120,
-        "wires": [
-            [
-                "d79a1bccb7cda804"
-            ]
-        ]
-    },
-    {
         "id": "56cafb11de5348b2",
         "type": "http request",
         "z": "791e8b1f84050e40",
@@ -10935,11 +10367,11 @@
         "authType": "",
         "senderr": false,
         "headers": [],
-        "x": 440,
-        "y": 1380,
+        "x": 420,
+        "y": 560,
         "wires": [
             [
-                "9ea228bc25d4e59b"
+                "7555653f37b1cd50"
             ]
         ]
     },
@@ -10956,39 +10388,11 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 390,
-        "y": 1340,
+        "x": 370,
+        "y": 520,
         "wires": [
             [
                 "56cafb11de5348b2"
-            ]
-        ]
-    },
-    {
-        "id": "9ea228bc25d4e59b",
-        "type": "change",
-        "z": "791e8b1f84050e40",
-        "g": "a38a90c36a0abfc3",
-        "name": "",
-        "rules": [
-            {
-                "t": "set",
-                "p": "payload",
-                "pt": "msg",
-                "to": "payload.client.backup.frigate",
-                "tot": "msg"
-            }
-        ],
-        "action": "",
-        "property": "",
-        "from": "",
-        "to": "",
-        "reg": false,
-        "x": 540,
-        "y": 1420,
-        "wires": [
-            [
-                "25515211bb8cecb4"
             ]
         ]
     },
@@ -11001,13 +10405,13 @@
         "method": "POST",
         "ret": "txt",
         "paytoqs": "ignore",
-        "url": "http://localhost:5000/config/save?save_option=restart",
+        "url": "http://localhost:5000/api/config/save?save_option=restart",
         "tls": "",
         "persist": false,
         "proxy": "",
         "insecureHTTPParser": false,
         "authType": "",
-        "senderr": true,
+        "senderr": false,
         "headers": [
             {
                 "keyType": "Content-Type",
@@ -11016,8 +10420,8 @@
                 "valueValue": ""
             }
         ],
-        "x": 620,
-        "y": 1460,
+        "x": 880,
+        "y": 600,
         "wires": [
             [
                 "64467a90df93e582"
@@ -11029,7 +10433,7 @@
         "type": "switch",
         "z": "791e8b1f84050e40",
         "g": "a38a90c36a0abfc3",
-        "name": "check for validation error",
+        "name": "handle validation error",
         "property": "statusCode",
         "propertyType": "msg",
         "rules": [
@@ -11042,31 +10446,13 @@
         "checkall": "true",
         "repair": false,
         "outputs": 1,
-        "x": 710,
-        "y": 1500,
+        "x": 960,
+        "y": 640,
         "wires": [
             [
-                "3c02407020db3c4a"
+                "5b7fe362e2e6b35d"
             ]
         ]
-    },
-    {
-        "id": "3c02407020db3c4a",
-        "type": "debug",
-        "z": "791e8b1f84050e40",
-        "g": "a38a90c36a0abfc3",
-        "name": "validation error",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "payload",
-        "targetType": "msg",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 920,
-        "y": 1500,
-        "wires": []
     },
     {
         "id": "65a881b4715da5ef",
@@ -11077,12 +10463,70 @@
         "links": [
             "e4475a4fd4eb47ea"
         ],
-        "x": 195,
-        "y": 1340,
+        "x": 175,
+        "y": 520,
         "wires": [
             [
                 "9aa93ed98869015b"
             ]
         ]
+    },
+    {
+        "id": "7555653f37b1cd50",
+        "type": "json",
+        "z": "791e8b1f84050e40",
+        "g": "a38a90c36a0abfc3",
+        "name": "",
+        "property": "payload",
+        "action": "",
+        "pretty": false,
+        "x": 630,
+        "y": 560,
+        "wires": [
+            [
+                "0d394a2d73d138d6"
+            ]
+        ]
+    },
+    {
+        "id": "0d394a2d73d138d6",
+        "type": "function",
+        "z": "791e8b1f84050e40",
+        "g": "a38a90c36a0abfc3",
+        "name": "extract frigate config portion for validation",
+        "func": "let newMsg = {};\n\n//put the backed up YAML config into a JSON object to send to validate\nnewMsg.payload = msg.payload.client.backup.frigate;\n\nreturn newMsg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 860,
+        "y": 560,
+        "wires": [
+            [
+                "25515211bb8cecb4"
+            ]
+        ]
+    },
+    {
+        "id": "5b7fe362e2e6b35d",
+        "type": "ui_toast",
+        "z": "791e8b1f84050e40",
+        "g": "a38a90c36a0abfc3",
+        "position": "top right",
+        "displayTime": "3",
+        "highlight": "",
+        "sendall": true,
+        "outputs": 0,
+        "ok": "OK",
+        "cancel": "",
+        "raw": false,
+        "className": "",
+        "topic": "Frigate Config Restore Validation Error",
+        "name": "show frigate validation error",
+        "x": 980,
+        "y": 680,
+        "wires": []
     }
 ]

--- a/node-red-project/flows.json
+++ b/node-red-project/flows.json
@@ -90,9 +90,9 @@
             "477f8523e9784029",
             "5c4e5a6064580e23"
         ],
-        "x": 384,
+        "x": 394,
         "y": 759,
-        "w": 1122,
+        "w": 1112,
         "h": 302
     },
     {
@@ -357,7 +357,7 @@
         ],
         "x": 54,
         "y": 479,
-        "w": 1102,
+        "w": 1092,
         "h": 302
     },
     {
@@ -600,7 +600,7 @@
         ],
         "x": 14,
         "y": 2051.5,
-        "w": 1102,
+        "w": 1092,
         "h": 209.5
     },
     {
@@ -837,7 +837,7 @@
         ],
         "x": 124,
         "y": 131.5,
-        "w": 1078,
+        "w": 1168,
         "h": 475.5
     },
     {
@@ -997,9 +997,9 @@
             "1257b05ec67b5a3e",
             "c12aee3936f24599"
         ],
-        "x": 64,
+        "x": 74,
         "y": 679,
-        "w": 972,
+        "w": 952,
         "h": 342
     },
     {
@@ -1015,11 +1015,12 @@
             "f64e7801aa071234",
             "37bb791e1cfa7ffb",
             "9726f6154932eeed",
-            "02c5bc95c26b6024"
+            "02c5bc95c26b6024",
+            "d1e4b174776b2e77"
         ],
         "x": 744,
         "y": 339,
-        "w": 432,
+        "w": 522,
         "h": 242
     },
     {
@@ -1266,17 +1267,6 @@
         }
     },
     {
-        "id": "8570be913d017562",
-        "type": "ui_group",
-        "name": "IoT Hub (ThingsBoard)",
-        "tab": "b749f5c4a9a4fbf2",
-        "order": 2,
-        "disp": true,
-        "width": "6",
-        "collapse": false,
-        "className": ""
-    },
-    {
         "id": "0fd9a947334c7d0f",
         "type": "ui_tab",
         "name": "System Settings Tab",
@@ -1289,17 +1279,6 @@
         "type": "ui_group",
         "name": "Client-Side Attributes",
         "tab": "0fd9a947334c7d0f",
-        "order": 1,
-        "disp": true,
-        "width": "6",
-        "collapse": false,
-        "className": ""
-    },
-    {
-        "id": "77966ee928726fbf",
-        "type": "ui_group",
-        "name": "Deployment Location",
-        "tab": "b749f5c4a9a4fbf2",
         "order": 1,
         "disp": true,
         "width": "6",
@@ -1336,6 +1315,28 @@
         "order": 4,
         "disabled": false,
         "hidden": false
+    },
+    {
+        "id": "8570be913d017562",
+        "type": "ui_group",
+        "name": "IoT Hub (ThingsBoard)",
+        "tab": "b749f5c4a9a4fbf2",
+        "order": 2,
+        "disp": true,
+        "width": "6",
+        "collapse": false,
+        "className": ""
+    },
+    {
+        "id": "77966ee928726fbf",
+        "type": "ui_group",
+        "name": "Deployment Location",
+        "tab": "b749f5c4a9a4fbf2",
+        "order": 1,
+        "disp": true,
+        "width": "6",
+        "collapse": false,
+        "className": ""
     },
     {
         "id": "e43506628b4a1cdb",
@@ -1473,7 +1474,7 @@
         "type": "debug",
         "z": "94d07e407c25f282",
         "name": "catch - flow-radar",
-        "active": true,
+        "active": false,
         "tosidebar": true,
         "console": false,
         "tostatus": false,
@@ -9563,8 +9564,7 @@
         "name": "link out 2",
         "mode": "link",
         "links": [
-            "e9545b23f4e4cd35",
-            "10d9ada5e1363236"
+            "e9545b23f4e4cd35"
         ],
         "x": 455,
         "y": 1220,
@@ -9632,8 +9632,7 @@
                 "ab9d774782f92e88",
                 "720ee19c705f37d9",
                 "c0078fa5b3946c05",
-                "c497cfedf6aed533",
-                "dbf0b15048a2a4f8"
+                "c497cfedf6aed533"
             ]
         ]
     },
@@ -9732,7 +9731,7 @@
         "useparts": false,
         "accumulate": false,
         "timeout": "",
-        "count": "9",
+        "count": "8",
         "reduceRight": false,
         "reduceExp": "",
         "reduceInit": "",
@@ -10064,120 +10063,6 @@
         "wires": []
     },
     {
-        "id": "90ec4da57d5e81dc",
-        "type": "file in",
-        "z": "f410f6aac9d1a3fc",
-        "name": "read Frigate config file",
-        "filename": "payload",
-        "filenameType": "msg",
-        "format": "utf8",
-        "chunk": false,
-        "sendError": false,
-        "encoding": "none",
-        "allProps": false,
-        "x": 720,
-        "y": 720,
-        "wires": [
-            [
-                "090af8decaa1e8ce"
-            ]
-        ]
-    },
-    {
-        "id": "090af8decaa1e8ce",
-        "type": "change",
-        "z": "f410f6aac9d1a3fc",
-        "name": "FrigateConfig",
-        "rules": [
-            {
-                "t": "set",
-                "p": "topic",
-                "pt": "msg",
-                "to": "metrics_FrigateConfig",
-                "tot": "str"
-            }
-        ],
-        "action": "",
-        "property": "",
-        "from": "",
-        "to": "",
-        "reg": false,
-        "x": 960,
-        "y": 720,
-        "wires": [
-            [
-                "c497cfedf6aed533"
-            ]
-        ]
-    },
-    {
-        "id": "dbf0b15048a2a4f8",
-        "type": "exec",
-        "z": "f410f6aac9d1a3fc",
-        "command": "pwd",
-        "addpay": "",
-        "append": "",
-        "useSpawn": "false",
-        "timer": "",
-        "winHide": false,
-        "oldrc": false,
-        "name": "",
-        "x": 290,
-        "y": 720,
-        "wires": [
-            [
-                "1d24a7b3d5e4ac83"
-            ],
-            [],
-            []
-        ]
-    },
-    {
-        "id": "1d24a7b3d5e4ac83",
-        "type": "change",
-        "z": "f410f6aac9d1a3fc",
-        "name": "set Frigate config file path",
-        "rules": [
-            {
-                "t": "set",
-                "p": "payload",
-                "pt": "msg",
-                "to": "$substring(msg.payload,0, $length(msg.payload)-1) & \"/code/frigate/config/config.yml\"",
-                "tot": "jsonata"
-            }
-        ],
-        "action": "",
-        "property": "",
-        "from": "",
-        "to": "",
-        "reg": false,
-        "x": 470,
-        "y": 720,
-        "wires": [
-            [
-                "90ec4da57d5e81dc",
-                "d98c8fe90fd09d8f"
-            ]
-        ]
-    },
-    {
-        "id": "d98c8fe90fd09d8f",
-        "type": "debug",
-        "z": "f410f6aac9d1a3fc",
-        "name": "Frigate config file path",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "payload",
-        "targetType": "msg",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 720,
-        "y": 780,
-        "wires": []
-    },
-    {
         "id": "371b831295a65179",
         "type": "link in",
         "z": "791e8b1f84050e40",
@@ -10374,7 +10259,8 @@
         "y": 380,
         "wires": [
             [
-                "02c5bc95c26b6024"
+                "02c5bc95c26b6024",
+                "d1e4b174776b2e77"
             ]
         ]
     },
@@ -11111,6 +10997,23 @@
         "statusType": "auto",
         "x": 1150,
         "y": 1320,
+        "wires": []
+    },
+    {
+        "id": "d1e4b174776b2e77",
+        "type": "debug",
+        "z": "791e8b1f84050e40",
+        "g": "c5f739aac1d9e9a3",
+        "name": "debug 1",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "false",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 1160,
+        "y": 380,
         "wires": []
     }
 ]

--- a/node-red-project/flows.json
+++ b/node-red-project/flows.json
@@ -857,6 +857,31 @@
         "h": 162
     },
     {
+        "id": "a38a90c36a0abfc3",
+        "type": "group",
+        "z": "791e8b1f84050e40",
+        "name": "restore TM Frigate config from ThingsBoard",
+        "style": {
+            "label": true
+        },
+        "nodes": [
+            "56cafb11de5348b2",
+            "9aa93ed98869015b",
+            "25515211bb8cecb4",
+            "64467a90df93e582",
+            "65a881b4715da5ef",
+            "7555653f37b1cd50",
+            "0d394a2d73d138d6",
+            "5b7fe362e2e6b35d",
+            "5743aab77af94bd2",
+            "4979b291119bce23"
+        ],
+        "x": 134,
+        "y": 479,
+        "w": 992,
+        "h": 242
+    },
+    {
         "id": "0e1614cf2e5f9942",
         "type": "group",
         "z": "28627559bebdc324",
@@ -974,29 +999,6 @@
         "x": 634,
         "y": 179,
         "w": 432,
-        "h": 242
-    },
-    {
-        "id": "a38a90c36a0abfc3",
-        "type": "group",
-        "z": "791e8b1f84050e40",
-        "name": "restore TM Frigate config from ThingsBoard",
-        "style": {
-            "label": true
-        },
-        "nodes": [
-            "56cafb11de5348b2",
-            "9aa93ed98869015b",
-            "25515211bb8cecb4",
-            "64467a90df93e582",
-            "65a881b4715da5ef",
-            "7555653f37b1cd50",
-            "0d394a2d73d138d6",
-            "5b7fe362e2e6b35d"
-        ],
-        "x": 134,
-        "y": 479,
-        "w": 992,
         "h": 242
     },
     {
@@ -9587,7 +9589,6 @@
         "name": "link out 2",
         "mode": "link",
         "links": [
-            "e9545b23f4e4cd35",
             "65a881b4715da5ef"
         ],
         "x": 455,
@@ -10335,14 +10336,14 @@
         "id": "38fd03504247825b",
         "type": "inject",
         "z": "791e8b1f84050e40",
-        "name": "init-flow-frigate-config-path",
+        "name": "inject after 5 sec",
         "props": [],
         "repeat": "",
         "crontab": "",
         "once": true,
         "onceDelay": "5",
         "topic": "",
-        "x": 260,
+        "x": 230,
         "y": 100,
         "wires": [
             [
@@ -10392,7 +10393,8 @@
         "y": 520,
         "wires": [
             [
-                "56cafb11de5348b2"
+                "56cafb11de5348b2",
+                "4979b291119bce23"
             ]
         ]
     },
@@ -10528,5 +10530,44 @@
         "x": 980,
         "y": 680,
         "wires": []
+    },
+    {
+        "id": "5743aab77af94bd2",
+        "type": "file",
+        "z": "791e8b1f84050e40",
+        "g": "a38a90c36a0abfc3",
+        "name": "write backup config file before restore",
+        "filename": "$flowContext(\"frigateConfigDir\") & \"/config.bak.yml\"",
+        "filenameType": "jsonata",
+        "appendNewline": true,
+        "createDir": false,
+        "overwriteFile": "true",
+        "encoding": "none",
+        "x": 470,
+        "y": 640,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "4979b291119bce23",
+        "type": "file in",
+        "z": "791e8b1f84050e40",
+        "g": "a38a90c36a0abfc3",
+        "name": "read Frigate config file",
+        "filename": "$flowContext(\"frigateConfigDir\") & \"/config.yml\"",
+        "filenameType": "jsonata",
+        "format": "utf8",
+        "chunk": false,
+        "sendError": false,
+        "encoding": "none",
+        "allProps": false,
+        "x": 380,
+        "y": 600,
+        "wires": [
+            [
+                "5743aab77af94bd2"
+            ]
+        ]
     }
 ]

--- a/node-red-project/flows.json
+++ b/node-red-project/flows.json
@@ -64,6 +64,14 @@
         "env": []
     },
     {
+        "id": "791e8b1f84050e40",
+        "type": "tab",
+        "label": "backup-restore",
+        "disabled": false,
+        "info": "Flows that backup/restore the device configuration to/from ThingsBoard. These are triggered by buttons on the Configuration / Setup tab.",
+        "env": []
+    },
+    {
         "id": "04cc3b7b3e019683",
         "type": "group",
         "z": "94d07e407c25f282",
@@ -82,9 +90,9 @@
             "477f8523e9784029",
             "5c4e5a6064580e23"
         ],
-        "x": 394,
+        "x": 384,
         "y": 759,
-        "w": 1112,
+        "w": 1122,
         "h": 302
     },
     {
@@ -213,7 +221,7 @@
         ],
         "x": 14,
         "y": 559,
-        "w": 1052,
+        "w": 1062,
         "h": 222
     },
     {
@@ -234,9 +242,9 @@
             "cbb3b02ca505a55b",
             "7db4b197df9eb075"
         ],
-        "x": 14,
+        "x": 24,
         "y": 839,
-        "w": 1178,
+        "w": 1168,
         "h": 508
     },
     {
@@ -307,9 +315,9 @@
             "9cf49f0891d25df1",
             "6d81c8e3c89b68f6"
         ],
-        "x": 54,
+        "x": 64,
         "y": 2519,
-        "w": 1252,
+        "w": 1242,
         "h": 242
     },
     {
@@ -349,7 +357,7 @@
         ],
         "x": 54,
         "y": 479,
-        "w": 1092,
+        "w": 1102,
         "h": 302
     },
     {
@@ -444,7 +452,7 @@
         ],
         "x": 14,
         "y": 619,
-        "w": 1272,
+        "w": 1282,
         "h": 262
     },
     {
@@ -592,7 +600,7 @@
         ],
         "x": 14,
         "y": 2051.5,
-        "w": 1092,
+        "w": 1102,
         "h": 209.5
     },
     {
@@ -604,9 +612,6 @@
             "label": true
         },
         "nodes": [
-            "0a28f82092611160",
-            "542b3b8720733a01",
-            "ac10d4e38e95fa26",
             "64c998a572e86dce",
             "4d67617dadcb9ede",
             "28063911d2bbf57e",
@@ -654,11 +659,12 @@
             "33dd63cc1dfb53c4",
             "9beaf948294acd98",
             "2b82d4b028657058",
-            "099df29d699f405e"
+            "099df29d699f405e",
+            "8fa3692b8c3f14a5"
         ],
         "x": 14,
         "y": 99,
-        "w": 1352,
+        "w": 1272,
         "h": 1242
     },
     {
@@ -809,6 +815,94 @@
         "h": 82
     },
     {
+        "id": "b781cb3d6df38fed",
+        "type": "group",
+        "z": "791e8b1f84050e40",
+        "name": "backup TM configuration to Thingsboard",
+        "style": {
+            "label": true
+        },
+        "nodes": [
+            "371b831295a65179",
+            "1fdb03a6035a494c",
+            "2b8c15613685457b",
+            "f2256e28de366878",
+            "bd75a8b7203331a0",
+            "0b6c06cde710a592",
+            "f49c1d345cdfef57",
+            "8bc712d2bf7d7608",
+            "c503122374a2fd6b",
+            "bd0b99f0ea3996bf",
+            "c5f739aac1d9e9a3"
+        ],
+        "x": 124,
+        "y": 131.5,
+        "w": 1078,
+        "h": 475.5
+    },
+    {
+        "id": "dff0470b2ba97020",
+        "type": "group",
+        "z": "fa9f914901f79645",
+        "name": "Backup & Restore Buttons",
+        "style": {
+            "label": true
+        },
+        "nodes": [
+            "cad1724850f8df3d",
+            "40ea8ad5c0434e3d",
+            "12a8f585b2824848",
+            "e4475a4fd4eb47ea",
+            "0372cefb5e2ec968"
+        ],
+        "x": 34,
+        "y": 1099,
+        "w": 462,
+        "h": 162
+    },
+    {
+        "id": "906735606a5ebdd5",
+        "type": "group",
+        "z": "791e8b1f84050e40",
+        "name": "restore TM configuration from ThingsBoard",
+        "style": {
+            "label": true
+        },
+        "nodes": [
+            "e9545b23f4e4cd35",
+            "01dff3893eb39da1",
+            "4e8936db02bb178f",
+            "19436a7a52d909d9",
+            "e324cdf01167b6b4",
+            "31bacedd56738550",
+            "d8f03f03f310add8",
+            "29a676d1bd02f536",
+            "cb044bcc7761877e",
+            "bd1fd07675061bc2",
+            "da7f36e9a5928977",
+            "13395b5909a63e3c",
+            "cb52210b00dca61d",
+            "9278adb1ef92bb02",
+            "09658d6c6e8e65cc",
+            "3146435b51b57036",
+            "1cd09de4ae651c87",
+            "f5bdcb22651184a6",
+            "3f95ff9f7d51b28d",
+            "8d1cea31ecc5505f",
+            "3a9976a42e040827",
+            "b0661dcf1869265d",
+            "7d85d4124ac35321",
+            "4cabf52349ebd694",
+            "43092f22b971c203",
+            "0fc0afa3cbbde9da",
+            "b6073793c9d88df9"
+        ],
+        "x": 154,
+        "y": 659,
+        "w": 1152,
+        "h": 702
+    },
+    {
         "id": "0e1614cf2e5f9942",
         "type": "group",
         "z": "28627559bebdc324",
@@ -903,10 +997,30 @@
             "1257b05ec67b5a3e",
             "c12aee3936f24599"
         ],
-        "x": 74,
+        "x": 64,
         "y": 679,
-        "w": 952,
+        "w": 972,
         "h": 342
+    },
+    {
+        "id": "c5f739aac1d9e9a3",
+        "type": "group",
+        "z": "791e8b1f84050e40",
+        "g": "b781cb3d6df38fed",
+        "name": "Send device attribute",
+        "style": {
+            "label": true
+        },
+        "nodes": [
+            "f64e7801aa071234",
+            "37bb791e1cfa7ffb",
+            "9726f6154932eeed",
+            "02c5bc95c26b6024"
+        ],
+        "x": 744,
+        "y": 339,
+        "w": 432,
+        "h": 242
     },
     {
         "id": "a5d65dd0e3566daa",
@@ -6363,77 +6477,6 @@
         "wires": []
     },
     {
-        "id": "0a28f82092611160",
-        "type": "http request",
-        "z": "05fcb02c571dcfee",
-        "g": "dc2934def36c6285",
-        "name": "send client-side attributes",
-        "method": "use",
-        "ret": "txt",
-        "paytoqs": "ignore",
-        "url": "",
-        "tls": "",
-        "persist": false,
-        "proxy": "",
-        "insecureHTTPParser": false,
-        "authType": "",
-        "senderr": false,
-        "headers": [
-            {
-                "keyType": "Content-Type",
-                "keyValue": "",
-                "valueType": "application/json",
-                "valueValue": ""
-            }
-        ],
-        "x": 1170,
-        "y": 300,
-        "wires": [
-            [
-                "542b3b8720733a01"
-            ]
-        ]
-    },
-    {
-        "id": "542b3b8720733a01",
-        "type": "debug",
-        "z": "05fcb02c571dcfee",
-        "g": "dc2934def36c6285",
-        "name": "client-side attributes response",
-        "active": false,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "true",
-        "targetType": "full",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 1190,
-        "y": 340,
-        "wires": []
-    },
-    {
-        "id": "ac10d4e38e95fa26",
-        "type": "function",
-        "z": "05fcb02c571dcfee",
-        "g": "dc2934def36c6285",
-        "name": "set up tb client-side attributes post ",
-        "func": "let serverUrl = global.get(\"serverUrl\", \"config\")\nlet serverPort = global.get(\"serverPort\", \"config\")\nlet accessToken = global.get(\"accessToken\", \"config\")\nmsg.url = `${serverUrl}:${serverPort}/api/v1/${accessToken}/attributes`\n\nmsg.method = \"POST\";\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 1080,
-        "y": 260,
-        "wires": [
-            [
-                "0a28f82092611160"
-            ]
-        ]
-    },
-    {
         "id": "64c998a572e86dce",
         "type": "exec",
         "z": "05fcb02c571dcfee",
@@ -7410,7 +7453,7 @@
         "y": 180,
         "wires": [
             [
-                "ac10d4e38e95fa26"
+                "8fa3692b8c3f14a5"
             ]
         ]
     },
@@ -7818,7 +7861,7 @@
         "y": 1420,
         "wires": [
             [
-                "ac10d4e38e95fa26"
+                "8fa3692b8c3f14a5"
             ]
         ]
     },
@@ -8365,6 +8408,20 @@
                 "b395ee7aa9dc2a44"
             ]
         ]
+    },
+    {
+        "id": "8fa3692b8c3f14a5",
+        "type": "link out",
+        "z": "05fcb02c571dcfee",
+        "g": "dc2934def36c6285",
+        "name": "send device attributes",
+        "mode": "link",
+        "links": [
+            "bd0b99f0ea3996bf"
+        ],
+        "x": 1245,
+        "y": 640,
+        "wires": []
     },
     {
         "id": "e6461a7fdeef48a2",
@@ -9434,6 +9491,115 @@
         ]
     },
     {
+        "id": "cad1724850f8df3d",
+        "type": "ui_button",
+        "z": "fa9f914901f79645",
+        "g": "dff0470b2ba97020",
+        "name": "",
+        "group": "8570be913d017562",
+        "order": 0,
+        "width": 0,
+        "height": 0,
+        "passthru": false,
+        "label": "Backup TM Configuration",
+        "tooltip": "",
+        "color": "",
+        "bgcolor": "gray",
+        "className": "",
+        "icon": "",
+        "payload": "",
+        "payloadType": "str",
+        "topic": "topic",
+        "topicType": "msg",
+        "x": 170,
+        "y": 1180,
+        "wires": [
+            [
+                "40ea8ad5c0434e3d"
+            ]
+        ]
+    },
+    {
+        "id": "40ea8ad5c0434e3d",
+        "type": "link out",
+        "z": "fa9f914901f79645",
+        "g": "dff0470b2ba97020",
+        "name": "link out 1",
+        "mode": "link",
+        "links": [
+            "371b831295a65179"
+        ],
+        "x": 455,
+        "y": 1180,
+        "wires": []
+    },
+    {
+        "id": "12a8f585b2824848",
+        "type": "ui_text",
+        "z": "fa9f914901f79645",
+        "g": "dff0470b2ba97020",
+        "group": "8570be913d017562",
+        "order": 3,
+        "width": 0,
+        "height": 0,
+        "name": "",
+        "label": "",
+        "format": "{{msg.payload}}",
+        "layout": "row-spread",
+        "className": "",
+        "style": false,
+        "font": "",
+        "fontSize": 16,
+        "color": "#000000",
+        "x": 110,
+        "y": 1140,
+        "wires": []
+    },
+    {
+        "id": "e4475a4fd4eb47ea",
+        "type": "link out",
+        "z": "fa9f914901f79645",
+        "g": "dff0470b2ba97020",
+        "name": "link out 2",
+        "mode": "link",
+        "links": [
+            "e9545b23f4e4cd35",
+            "10d9ada5e1363236"
+        ],
+        "x": 455,
+        "y": 1220,
+        "wires": []
+    },
+    {
+        "id": "0372cefb5e2ec968",
+        "type": "ui_button",
+        "z": "fa9f914901f79645",
+        "g": "dff0470b2ba97020",
+        "name": "",
+        "group": "8570be913d017562",
+        "order": 0,
+        "width": 0,
+        "height": 0,
+        "passthru": false,
+        "label": "Restore TM Configuration",
+        "tooltip": "",
+        "color": "",
+        "bgcolor": "gray",
+        "className": "",
+        "icon": "",
+        "payload": "",
+        "payloadType": "str",
+        "topic": "topic",
+        "topicType": "msg",
+        "x": 170,
+        "y": 1220,
+        "wires": [
+            [
+                "e4475a4fd4eb47ea"
+            ]
+        ]
+    },
+    {
         "id": "9f2c4f1852402eb8",
         "type": "inject",
         "z": "f410f6aac9d1a3fc",
@@ -9466,7 +9632,8 @@
                 "ab9d774782f92e88",
                 "720ee19c705f37d9",
                 "c0078fa5b3946c05",
-                "c497cfedf6aed533"
+                "c497cfedf6aed533",
+                "dbf0b15048a2a4f8"
             ]
         ]
     },
@@ -9888,12 +10055,1062 @@
         "tosidebar": true,
         "console": false,
         "tostatus": false,
-        "complete": "payload",
-        "targetType": "msg",
+        "complete": "true",
+        "targetType": "full",
         "statusVal": "",
         "statusType": "auto",
         "x": 350,
         "y": 40,
+        "wires": []
+    },
+    {
+        "id": "90ec4da57d5e81dc",
+        "type": "file in",
+        "z": "f410f6aac9d1a3fc",
+        "name": "read Frigate config file",
+        "filename": "payload",
+        "filenameType": "msg",
+        "format": "utf8",
+        "chunk": false,
+        "sendError": false,
+        "encoding": "none",
+        "allProps": false,
+        "x": 720,
+        "y": 720,
+        "wires": [
+            [
+                "090af8decaa1e8ce"
+            ]
+        ]
+    },
+    {
+        "id": "090af8decaa1e8ce",
+        "type": "change",
+        "z": "f410f6aac9d1a3fc",
+        "name": "FrigateConfig",
+        "rules": [
+            {
+                "t": "set",
+                "p": "topic",
+                "pt": "msg",
+                "to": "metrics_FrigateConfig",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 960,
+        "y": 720,
+        "wires": [
+            [
+                "c497cfedf6aed533"
+            ]
+        ]
+    },
+    {
+        "id": "dbf0b15048a2a4f8",
+        "type": "exec",
+        "z": "f410f6aac9d1a3fc",
+        "command": "pwd",
+        "addpay": "",
+        "append": "",
+        "useSpawn": "false",
+        "timer": "",
+        "winHide": false,
+        "oldrc": false,
+        "name": "",
+        "x": 290,
+        "y": 720,
+        "wires": [
+            [
+                "1d24a7b3d5e4ac83"
+            ],
+            [],
+            []
+        ]
+    },
+    {
+        "id": "1d24a7b3d5e4ac83",
+        "type": "change",
+        "z": "f410f6aac9d1a3fc",
+        "name": "set Frigate config file path",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "$substring(msg.payload,0, $length(msg.payload)-1) & \"/code/frigate/config/config.yml\"",
+                "tot": "jsonata"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 470,
+        "y": 720,
+        "wires": [
+            [
+                "90ec4da57d5e81dc",
+                "d98c8fe90fd09d8f"
+            ]
+        ]
+    },
+    {
+        "id": "d98c8fe90fd09d8f",
+        "type": "debug",
+        "z": "f410f6aac9d1a3fc",
+        "name": "Frigate config file path",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "payload",
+        "targetType": "msg",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 720,
+        "y": 780,
+        "wires": []
+    },
+    {
+        "id": "371b831295a65179",
+        "type": "link in",
+        "z": "791e8b1f84050e40",
+        "g": "b781cb3d6df38fed",
+        "name": "start backup",
+        "links": [
+            "40ea8ad5c0434e3d"
+        ],
+        "x": 165,
+        "y": 180,
+        "wires": [
+            [
+                "1fdb03a6035a494c",
+                "8bc712d2bf7d7608"
+            ]
+        ]
+    },
+    {
+        "id": "1fdb03a6035a494c",
+        "type": "exec",
+        "z": "791e8b1f84050e40",
+        "g": "b781cb3d6df38fed",
+        "command": "pwd",
+        "addpay": "",
+        "append": "",
+        "useSpawn": "false",
+        "timer": "",
+        "winHide": false,
+        "oldrc": false,
+        "name": "",
+        "x": 280,
+        "y": 180,
+        "wires": [
+            [
+                "2b8c15613685457b"
+            ],
+            [],
+            []
+        ]
+    },
+    {
+        "id": "2b8c15613685457b",
+        "type": "change",
+        "z": "791e8b1f84050e40",
+        "g": "b781cb3d6df38fed",
+        "name": "set Frigate config file path",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "$substring(msg.payload,0, $length(msg.payload)-1) & \"/code/frigate/config/config.yml\"",
+                "tot": "jsonata"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 500,
+        "y": 180,
+        "wires": [
+            [
+                "f2256e28de366878"
+            ]
+        ]
+    },
+    {
+        "id": "f2256e28de366878",
+        "type": "file in",
+        "z": "791e8b1f84050e40",
+        "g": "b781cb3d6df38fed",
+        "name": "read Frigate config file",
+        "filename": "payload",
+        "filenameType": "msg",
+        "format": "utf8",
+        "chunk": false,
+        "sendError": false,
+        "encoding": "none",
+        "allProps": false,
+        "x": 810,
+        "y": 180,
+        "wires": [
+            [
+                "bd75a8b7203331a0"
+            ]
+        ]
+    },
+    {
+        "id": "bd75a8b7203331a0",
+        "type": "change",
+        "z": "791e8b1f84050e40",
+        "g": "b781cb3d6df38fed",
+        "name": "set Frigate config payload",
+        "rules": [
+            {
+                "t": "set",
+                "p": "topic",
+                "pt": "msg",
+                "to": "Frigate",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 1060,
+        "y": 180,
+        "wires": [
+            [
+                "0b6c06cde710a592"
+            ]
+        ]
+    },
+    {
+        "id": "d4df0505fc0adfd0",
+        "type": "catch",
+        "z": "791e8b1f84050e40",
+        "name": "",
+        "scope": null,
+        "uncaught": false,
+        "x": 220,
+        "y": 40,
+        "wires": [
+            [
+                "b3dced4dc3de5e25"
+            ]
+        ]
+    },
+    {
+        "id": "b3dced4dc3de5e25",
+        "type": "debug",
+        "z": "791e8b1f84050e40",
+        "name": "backup or restore flow error",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "true",
+        "targetType": "full",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 500,
+        "y": 40,
+        "wires": []
+    },
+    {
+        "id": "0b6c06cde710a592",
+        "type": "join",
+        "z": "791e8b1f84050e40",
+        "g": "b781cb3d6df38fed",
+        "name": "",
+        "mode": "custom",
+        "build": "object",
+        "property": "payload",
+        "propertyType": "msg",
+        "key": "topic",
+        "joiner": "\\n",
+        "joinerType": "str",
+        "useparts": false,
+        "accumulate": false,
+        "timeout": "",
+        "count": "2",
+        "reduceRight": false,
+        "reduceExp": "",
+        "reduceInit": "",
+        "reduceInitType": "",
+        "reduceFixup": "",
+        "x": 340,
+        "y": 340,
+        "wires": [
+            [
+                "f49c1d345cdfef57"
+            ]
+        ]
+    },
+    {
+        "id": "f64e7801aa071234",
+        "type": "function",
+        "z": "791e8b1f84050e40",
+        "g": "c5f739aac1d9e9a3",
+        "name": "set up tb client-side attributes post ",
+        "func": "let serverUrl = global.get(\"serverUrl\", \"config\")\nlet serverPort = global.get(\"serverPort\", \"config\")\nlet accessToken = global.get(\"accessToken\", \"config\")\nmsg.url = `${serverUrl}:${serverPort}/api/v1/${accessToken}/attributes`\n\nmsg.method = \"POST\";\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 910,
+        "y": 380,
+        "wires": [
+            [
+                "02c5bc95c26b6024"
+            ]
+        ]
+    },
+    {
+        "id": "37bb791e1cfa7ffb",
+        "type": "http request",
+        "z": "791e8b1f84050e40",
+        "g": "c5f739aac1d9e9a3",
+        "name": "send client-side attributes",
+        "method": "use",
+        "ret": "txt",
+        "paytoqs": "ignore",
+        "url": "",
+        "tls": "",
+        "persist": false,
+        "proxy": "",
+        "insecureHTTPParser": false,
+        "authType": "",
+        "senderr": false,
+        "headers": [
+            {
+                "keyType": "Content-Type",
+                "keyValue": "",
+                "valueType": "application/json",
+                "valueValue": ""
+            }
+        ],
+        "x": 980,
+        "y": 500,
+        "wires": [
+            [
+                "9726f6154932eeed"
+            ]
+        ]
+    },
+    {
+        "id": "9726f6154932eeed",
+        "type": "debug",
+        "z": "791e8b1f84050e40",
+        "g": "c5f739aac1d9e9a3",
+        "name": "client-side attributes response",
+        "active": false,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "true",
+        "targetType": "full",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 1000,
+        "y": 540,
+        "wires": []
+    },
+    {
+        "id": "02c5bc95c26b6024",
+        "type": "delay",
+        "z": "791e8b1f84050e40",
+        "g": "c5f739aac1d9e9a3",
+        "name": "",
+        "pauseType": "rate",
+        "timeout": "5",
+        "timeoutUnits": "seconds",
+        "rate": "1000",
+        "nbRateUnits": "1",
+        "rateUnits": "minute",
+        "randomFirst": "1",
+        "randomLast": "5",
+        "randomUnits": "seconds",
+        "drop": true,
+        "allowrate": false,
+        "outputs": 2,
+        "x": 920,
+        "y": 440,
+        "wires": [
+            [
+                "37bb791e1cfa7ffb"
+            ],
+            []
+        ]
+    },
+    {
+        "id": "f49c1d345cdfef57",
+        "type": "change",
+        "z": "791e8b1f84050e40",
+        "g": "b781cb3d6df38fed",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "{    \"backup\": payload}",
+                "tot": "jsonata"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 510,
+        "y": 340,
+        "wires": [
+            [
+                "f64e7801aa071234",
+                "c503122374a2fd6b"
+            ]
+        ]
+    },
+    {
+        "id": "8bc712d2bf7d7608",
+        "type": "change",
+        "z": "791e8b1f84050e40",
+        "g": "b781cb3d6df38fed",
+        "name": "set timestamp",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "",
+                "tot": "date"
+            },
+            {
+                "t": "set",
+                "p": "topic",
+                "pt": "msg",
+                "to": "\"date\"",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 310,
+        "y": 260,
+        "wires": [
+            [
+                "0b6c06cde710a592"
+            ]
+        ]
+    },
+    {
+        "id": "c503122374a2fd6b",
+        "type": "debug",
+        "z": "791e8b1f84050e40",
+        "g": "b781cb3d6df38fed",
+        "name": "debug attribute msg",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "payload",
+        "targetType": "msg",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 850,
+        "y": 300,
+        "wires": []
+    },
+    {
+        "id": "bd0b99f0ea3996bf",
+        "type": "link in",
+        "z": "791e8b1f84050e40",
+        "g": "b781cb3d6df38fed",
+        "name": "send device attributes",
+        "links": [
+            "8fa3692b8c3f14a5"
+        ],
+        "x": 555,
+        "y": 420,
+        "wires": [
+            [
+                "f64e7801aa071234",
+                "c503122374a2fd6b"
+            ]
+        ]
+    },
+    {
+        "id": "e9545b23f4e4cd35",
+        "type": "link in",
+        "z": "791e8b1f84050e40",
+        "g": "906735606a5ebdd5",
+        "name": "start restore",
+        "links": [
+            "e4475a4fd4eb47ea"
+        ],
+        "x": 195,
+        "y": 740,
+        "wires": [
+            [
+                "e324cdf01167b6b4"
+            ]
+        ]
+    },
+    {
+        "id": "01dff3893eb39da1",
+        "type": "http request",
+        "z": "791e8b1f84050e40",
+        "g": "906735606a5ebdd5",
+        "name": "read config file from ThingsBoard",
+        "method": "use",
+        "ret": "txt",
+        "paytoqs": "ignore",
+        "url": "",
+        "tls": "",
+        "persist": false,
+        "proxy": "",
+        "insecureHTTPParser": false,
+        "authType": "",
+        "senderr": false,
+        "headers": [],
+        "x": 740,
+        "y": 880,
+        "wires": [
+            [
+                "19436a7a52d909d9"
+            ]
+        ]
+    },
+    {
+        "id": "4e8936db02bb178f",
+        "type": "function",
+        "z": "791e8b1f84050e40",
+        "g": "906735606a5ebdd5",
+        "name": "set up tb client-side attributes for GET ",
+        "func": "let serverUrl = global.get(\"serverUrl\", \"config\")\nlet serverPort = global.get(\"serverPort\", \"config\")\nlet accessToken = global.get(\"accessToken\", \"config\")\nmsg.url = `${serverUrl}:${serverPort}/api/v1/${accessToken}/attributes?clientKeys=backup`\n\nmsg.method = \"GET\";\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 390,
+        "y": 880,
+        "wires": [
+            [
+                "01dff3893eb39da1"
+            ]
+        ]
+    },
+    {
+        "id": "19436a7a52d909d9",
+        "type": "json",
+        "z": "791e8b1f84050e40",
+        "g": "906735606a5ebdd5",
+        "name": "Convert string to JSON object",
+        "property": "payload",
+        "action": "",
+        "pretty": false,
+        "x": 1070,
+        "y": 880,
+        "wires": [
+            [
+                "da7f36e9a5928977"
+            ]
+        ]
+    },
+    {
+        "id": "e324cdf01167b6b4",
+        "type": "exec",
+        "z": "791e8b1f84050e40",
+        "g": "906735606a5ebdd5",
+        "command": "pwd",
+        "addpay": "",
+        "append": "",
+        "useSpawn": "false",
+        "timer": "",
+        "winHide": false,
+        "oldrc": false,
+        "name": "",
+        "x": 290,
+        "y": 740,
+        "wires": [
+            [
+                "31bacedd56738550"
+            ],
+            [],
+            []
+        ]
+    },
+    {
+        "id": "31bacedd56738550",
+        "type": "change",
+        "z": "791e8b1f84050e40",
+        "g": "906735606a5ebdd5",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "pwd",
+                "pt": "flow",
+                "to": "$substring(msg.payload,0, $length(msg.payload)-1)",
+                "tot": "jsonata"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 430,
+        "y": 740,
+        "wires": [
+            [
+                "d8f03f03f310add8"
+            ]
+        ]
+    },
+    {
+        "id": "d8f03f03f310add8",
+        "type": "change",
+        "z": "791e8b1f84050e40",
+        "g": "906735606a5ebdd5",
+        "name": "set up cp arguments",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "$flowContext('pwd') & \"/code/frigate/config/config.yml \" & $flowContext('pwd') & \"/code/frigate/config/config.yml.backup\"",
+                "tot": "jsonata"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 640,
+        "y": 740,
+        "wires": [
+            [
+                "29a676d1bd02f536"
+            ]
+        ]
+    },
+    {
+        "id": "29a676d1bd02f536",
+        "type": "exec",
+        "z": "791e8b1f84050e40",
+        "g": "906735606a5ebdd5",
+        "command": "/bin/cp ",
+        "addpay": "payload",
+        "append": "",
+        "useSpawn": "false",
+        "timer": "",
+        "winHide": false,
+        "oldrc": false,
+        "name": "make local backup of existing config file",
+        "x": 1000,
+        "y": 740,
+        "wires": [
+            [
+                "4e8936db02bb178f"
+            ],
+            [],
+            []
+        ]
+    },
+    {
+        "id": "cb044bcc7761877e",
+        "type": "comment",
+        "z": "791e8b1f84050e40",
+        "g": "906735606a5ebdd5",
+        "name": "backup existing config file",
+        "info": "",
+        "x": 650,
+        "y": 700,
+        "wires": []
+    },
+    {
+        "id": "bd1fd07675061bc2",
+        "type": "comment",
+        "z": "791e8b1f84050e40",
+        "g": "906735606a5ebdd5",
+        "name": "read config text from ThingsBoard",
+        "info": "",
+        "x": 600,
+        "y": 820,
+        "wires": []
+    },
+    {
+        "id": "da7f36e9a5928977",
+        "type": "change",
+        "z": "791e8b1f84050e40",
+        "g": "906735606a5ebdd5",
+        "name": "extract config string",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "payload.client.backup.Frigate",
+                "tot": "msg"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 340,
+        "y": 1000,
+        "wires": [
+            [
+                "13395b5909a63e3c"
+            ]
+        ]
+    },
+    {
+        "id": "13395b5909a63e3c",
+        "type": "change",
+        "z": "791e8b1f84050e40",
+        "g": "906735606a5ebdd5",
+        "name": "set temp filename",
+        "rules": [
+            {
+                "t": "set",
+                "p": "filename",
+                "pt": "msg",
+                "to": "$flowContext('pwd') & \"/code/frigate/config/temp.yml\"",
+                "tot": "jsonata"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 570,
+        "y": 1000,
+        "wires": [
+            [
+                "cb52210b00dca61d"
+            ]
+        ]
+    },
+    {
+        "id": "cb52210b00dca61d",
+        "type": "file",
+        "z": "791e8b1f84050e40",
+        "g": "906735606a5ebdd5",
+        "name": "store temporary file",
+        "filename": "filename",
+        "filenameType": "msg",
+        "appendNewline": false,
+        "createDir": false,
+        "overwriteFile": "true",
+        "encoding": "none",
+        "x": 790,
+        "y": 1000,
+        "wires": [
+            [
+                "1cd09de4ae651c87",
+                "3146435b51b57036"
+            ]
+        ]
+    },
+    {
+        "id": "9278adb1ef92bb02",
+        "type": "comment",
+        "z": "791e8b1f84050e40",
+        "g": "906735606a5ebdd5",
+        "name": "store in temporary file",
+        "info": "",
+        "x": 600,
+        "y": 940,
+        "wires": []
+    },
+    {
+        "id": "09658d6c6e8e65cc",
+        "type": "comment",
+        "z": "791e8b1f84050e40",
+        "g": "906735606a5ebdd5",
+        "name": "validate config in temporary file",
+        "info": "",
+        "x": 610,
+        "y": 1060,
+        "wires": []
+    },
+    {
+        "id": "3146435b51b57036",
+        "type": "template",
+        "z": "791e8b1f84050e40",
+        "g": "906735606a5ebdd5",
+        "name": "Setup arguments for docker run command",
+        "field": "payload",
+        "fieldType": "msg",
+        "format": "handlebars",
+        "syntax": "mustache",
+        "template": "-v {{{flow.pwd}}}/code/frigate/config/temp.yml:/config/config.yml --env-file {{{flow.pwd}}}/code/frigate/frigate.env  --entrypoint python3 ghcr.io/blakeblackshear/frigate:0.14.0 -u -m frigate --validate-config",
+        "output": "str",
+        "x": 390,
+        "y": 1120,
+        "wires": [
+            [
+                "f5bdcb22651184a6"
+            ]
+        ]
+    },
+    {
+        "id": "1cd09de4ae651c87",
+        "type": "debug",
+        "z": "791e8b1f84050e40",
+        "g": "906735606a5ebdd5",
+        "name": "print file contents",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "payload",
+        "targetType": "msg",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 1030,
+        "y": 1000,
+        "wires": []
+    },
+    {
+        "id": "f5bdcb22651184a6",
+        "type": "exec",
+        "z": "791e8b1f84050e40",
+        "g": "906735606a5ebdd5",
+        "command": "docker run",
+        "addpay": "payload",
+        "append": "",
+        "useSpawn": "false",
+        "timer": "",
+        "winHide": false,
+        "oldrc": false,
+        "name": "validate Frigate config file",
+        "x": 750,
+        "y": 1120,
+        "wires": [
+            [
+                "3f95ff9f7d51b28d",
+                "b0661dcf1869265d"
+            ],
+            [
+                "8d1cea31ecc5505f"
+            ],
+            []
+        ]
+    },
+    {
+        "id": "3f95ff9f7d51b28d",
+        "type": "debug",
+        "z": "791e8b1f84050e40",
+        "g": "906735606a5ebdd5",
+        "name": "show iniital rc",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "rc",
+        "targetType": "msg",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 1020,
+        "y": 1080,
+        "wires": []
+    },
+    {
+        "id": "8d1cea31ecc5505f",
+        "type": "debug",
+        "z": "791e8b1f84050e40",
+        "g": "906735606a5ebdd5",
+        "name": "show validation error messages",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "payload",
+        "targetType": "msg",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 1070,
+        "y": 1120,
+        "wires": []
+    },
+    {
+        "id": "3a9976a42e040827",
+        "type": "comment",
+        "z": "791e8b1f84050e40",
+        "g": "906735606a5ebdd5",
+        "name": "check result, replace real config file, and restart Frigate",
+        "info": "",
+        "x": 680,
+        "y": 1200,
+        "wires": []
+    },
+    {
+        "id": "b0661dcf1869265d",
+        "type": "switch",
+        "z": "791e8b1f84050e40",
+        "g": "906735606a5ebdd5",
+        "name": "test rc from validation of Frigate config",
+        "property": "rc.code",
+        "propertyType": "msg",
+        "rules": [
+            {
+                "t": "eq",
+                "v": "0",
+                "vt": "num"
+            },
+            {
+                "t": "neq",
+                "v": "0",
+                "vt": "num"
+            }
+        ],
+        "checkall": "true",
+        "repair": false,
+        "outputs": 2,
+        "x": 350,
+        "y": 1260,
+        "wires": [
+            [
+                "7d85d4124ac35321"
+            ],
+            [
+                "0fc0afa3cbbde9da"
+            ]
+        ]
+    },
+    {
+        "id": "7d85d4124ac35321",
+        "type": "change",
+        "z": "791e8b1f84050e40",
+        "g": "906735606a5ebdd5",
+        "name": "set up cp arguments",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "$flowContext('pwd') & \"/code/frigate/config/temp.yml \" & $flowContext('pwd') &\t \"/code/frigate/config/config.yml\"",
+                "tot": "jsonata"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 660,
+        "y": 1260,
+        "wires": [
+            [
+                "4cabf52349ebd694"
+            ]
+        ]
+    },
+    {
+        "id": "4cabf52349ebd694",
+        "type": "exec",
+        "z": "791e8b1f84050e40",
+        "g": "906735606a5ebdd5",
+        "command": "/bin/cp ",
+        "addpay": "payload",
+        "append": "",
+        "useSpawn": "false",
+        "timer": "",
+        "winHide": false,
+        "oldrc": false,
+        "name": "replace existing config file",
+        "x": 930,
+        "y": 1260,
+        "wires": [
+            [
+                "43092f22b971c203"
+            ],
+            [],
+            []
+        ]
+    },
+    {
+        "id": "43092f22b971c203",
+        "type": "exec",
+        "z": "791e8b1f84050e40",
+        "g": "906735606a5ebdd5",
+        "command": "docker restart frigate",
+        "addpay": "",
+        "append": "",
+        "useSpawn": "false",
+        "timer": "",
+        "winHide": false,
+        "oldrc": false,
+        "name": "",
+        "x": 1180,
+        "y": 1260,
+        "wires": [
+            [
+                "b6073793c9d88df9"
+            ],
+            [],
+            []
+        ]
+    },
+    {
+        "id": "0fc0afa3cbbde9da",
+        "type": "debug",
+        "z": "791e8b1f84050e40",
+        "g": "906735606a5ebdd5",
+        "name": "Print failure msg",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "\"Config file not replaced and Frigate not restarted\"",
+        "targetType": "jsonata",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 640,
+        "y": 1320,
+        "wires": []
+    },
+    {
+        "id": "b6073793c9d88df9",
+        "type": "debug",
+        "z": "791e8b1f84050e40",
+        "g": "906735606a5ebdd5",
+        "name": "Print success msg",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "\"Config file restored and Frigate restarted\"",
+        "targetType": "jsonata",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 1150,
+        "y": 1320,
         "wires": []
     }
 ]


### PR DESCRIPTION
Based off work on https://github.com/glossyio/traffic-monitor/pull/39

Changes:
* Reconfigured backup/restore functionality to reduce the number of shell commands; utilizing:
    * node-RED read node
    * os.homedir() node part of system 
* Utilized Frigate API (`/api/config/save`) for restore functionality including validation, save, and restart
* Removed config telemetry
* Added back on-device config backup before restore
