### PR TITLE
Air Quality telemetry in Node-RED flows

### DIFF
--- a/docs/configuration/node-red-config.md
+++ b/docs/configuration/node-red-config.md
@@ -74,15 +74,16 @@ The config file is loaded whenever the TM flows restart.  It is located in the u
 It is _not necessary_ to copy this full configuration file. Default values are specified below.
 {% endhint %}
 
-<pre class="language-yaml"><code class="lang-yaml"><strong>########
-</strong><strong># This file contains configuration settings executed by node-red
-</strong><strong># Note: Comments will be removed by updates from node-red
-</strong><strong>########
-</strong><strong>
-</strong><strong># Optional: IoT hub backend integration
-</strong><strong>thingsboard:
-</strong><strong>    # Optional: enable connection to backend thingsboard server (default: shown below)
-</strong>    enabled: False
+```yml
+########
+# This file contains configuration settings executed by node-red
+# Note: Comments will be removed by updates from node-red
+########
+
+# Optional: IoT hub backend integration
+thingsboard:
+    # Optional: enable connection to backend thingsboard server (default: shown below)
+    enabled: false
     # Required: host name, without protocol or port number
     host: tb.server.com
     # Required: thingsboard telemetry protocol (default: shown below), 
@@ -114,15 +115,15 @@ deployment:
     bearing:
 
 sensors:
-<strong>    # Optional: if used, must match the Frigate camera name(s)
-</strong>    # if not set, no cameras will be used
+    # Optional: if used, must match the Frigate camera name(s)
+    # if not set, no cameras will be used
     cameras:
         # camera name must match Frigate configuration camera names
         picam_h264:
             # Optional Enable/disable the camera (default: shown below).
             # if disabled, any Frigate events for specified camera will be ignored
             # Note: this will not impact Frigate's system
-            enabled: False
+            enabled: false
             # Optional: define the radar co-located with camera to associate speeds
             # camera and radar direction and field of view (FOV) should match
             # Note: name needs to match one defined in `radars` section
@@ -135,15 +136,18 @@ sensors:
         # Names are used to associate readings with cameras and other sensors
         TM_RADAR_SERIAL_PORT_00:
             # Optional: Enable/disable the radar (default: shown below).
-            enabled: False
+            enabled: false
 
-    # Optional: used to specify air quality monitor sensors
+    # Optional: used to specify air quality monitor sensor name(s)
     # Note: air quality configuration file is separate from the node-red config, based on the aq device
-    aq_monitor:
-        # Optional: Enable/disable the AQ sensor payloads (default: shown below).
-        enabled: False
-        # mqtt topic to subscribe for incoming telemetry from sensors
-        mqtt_topic_incoming: aq/readings
+    airquality_monitors:
+        # Required: aq sensor name must match AQ configuration -defined MQTT topic middle element (second element)
+        sensorname01:
+            # Optional: Enable/disable the AQ sensor payloads (default: shown below).
+            enabled: false
+            # Required: mqtt topic to subscribe for incoming full-payload telemetry from AQ sensor
+            #  must be last element in mqtt topic defined in AQ configuration
+            mqtt_topic_incoming: readings
 
 time:
     # Optional: Set a timezone to use in the UI (default: use browser local time)
@@ -152,7 +156,6 @@ time:
     timezone: America/Los_Angeles
     # Optional: For internet-connected deployments, sync using `timedatectl set-npt` (default: shown below)
     # Note: for offline deployments, time will stop whenever power is disconnected
-    npt_set: True
-
-</code></pre>
+    npt_set: false
+```
 

--- a/docs/configuration/node-red-config.md
+++ b/docs/configuration/node-red-config.md
@@ -89,10 +89,10 @@ thingsboard:
     # Required: thingsboard telemetry protocol (default: shown below), 
     # NOTE: only http(s) currently supported, mqtt coming soon
     #  see https://thingsboard.io/docs/reference/protocols/
-    protocol: https
+    protocol: http
     # Optional: port, common settings: https=443, http=80, mqtt=1883
     # Check with your ThingsBoard admin for settings
-    port: 443
+    port:
     # Optional: API key for device 
     # Note: (Future) if already provisioned, will be assigned based on provisionDeviceKey and secret
     access_token:

--- a/docs/sensor-payloads/air-quality-aq-payload.md
+++ b/docs/sensor-payloads/air-quality-aq-payload.md
@@ -28,10 +28,6 @@ See [Config Readme](https://github.com/greendormer/enviroplus-monitor/blob/main/
 
 ### Recommended config settings
 
-{% hint style="info" %}
-Note: At present, readings will be sent every 5-minutes and _this is hard-coded_. This will be parameterized in a future release.
-{% endhint %}
-
 The following are important keys for the recommended default Traffic Monitor -specific configuration:
 
 * `"enable_send_data_to_homemanager": true` in order to send MQTT payloads to specified broker
@@ -67,30 +63,34 @@ The sensor needs to stabilize (default 5-minutes) after the script initializes b
 ```json
 {
     "gas_calibrated": false,
-    "Bar": [
-        1013.93,
+    "bar": [
+        1009.44,
         "0"
     ],
-    "Hum": [
-        45.9,
-        "1"
+    "hum": [
+        28.7,
+        "2"
     ],
-    "Forecast": {
-        "Valid": false,
-        "3 Hour Change": 0,
-        "Forecast": "Insufficient Data"
-    },
     "p025": 0,
     "p10": 0,
     "p01": 0,
-    "Dew": 7.5,
-    "Temp": 19.5,
-    "Min Temp": 19.5,
-    "Max Temp": 19.5,
-    "Red": 4.43,
-    "Oxi": 0.16,
-    "NH3": 0.66,
-    "Lux": 0
+    "dew": 2.1,
+    "temp": 21,
+    "temp_min": 20.9,
+    "temp_max": 21.1,
+    "gas_red": 4.2,
+    "gas_oxi": 0.15,
+    "gas_nh3": 0.69,
+    "lux": 1.2,
+    "proximity": 255,
+    "lux_raw": 1.16185,
+    "temp_raw": 28.68982029794099,
+    "bar_raw": 1003.7122773175154,
+    "hum_raw": 18.31337919009301,
+    "gas_red_raw": 140805,
+    "gas_oxi_raw": 103585,
+    "gas_nh3_raw": 227871,
+    "current_time": 1738698665.077546
 }
 ```
 
@@ -100,13 +100,13 @@ The sensor needs to stabilize (default 5-minutes) after the script initializes b
 | bar | [REAL, TEXT] | hPa, Comfort-level `{"0": "Stable", "1": "Fair", "3": "Poorer/Windy/", "4": "Rain/Gale/Storm"}` | Air pressure, compensated for altitude and temp as `Bar / comp_factor` where `comp_factor = math.pow(1 - (0.0065 * altitude/(temp + 0.0065 * alt + 273.15)), -5.257)` |
 | hum | [REAL, TEXT] | %, Comfort-level `{"good": "1", "dry": "2", "wet": "3"}`| Adjusted for compensation factor set in `config.json` |
 | Forecast | {OBJECT} | `Valid`: true/false, `3 Hour Change` is millibars difference in barometer readings, `Forecast` is description calculated from barometer change | Calculated forecast based on sensor barometer changes|
-| p01 | REAL | ug/m3 (microgram per meter cubed, µg/m³) | Particulate Matter 1 micrometers / microns (PM1, PM<sub>1</sub>), Read directly using the `pms5003.pm_ug_per_m3()` method from the particulate matter sensor. |
-| p025 | REAL | ug/m3 (microgram per meter cubed, µg/m³) | Particulate Matter 2.5 micrometers / microns (PM2.5, PM<sub>2.5</sub>), read directly using the `pms5003.pm_ug_per_m3()` method from the particulate matter sensor. |
-| p10 | REAL | ug/m3 (microgram per meter cubed, µg/m³) | Particulate Matter 10 micrometers / microns (PM10, PM<sub>10</sub>), Read directly using the `pms5003.pm_ug_per_m3()` method from the particulate matter sensor. |
+| pm01 | REAL | ug/m3 (microgram per meter cubed, µg/m³) | Particulate Matter 1 micrometers / microns (PM1, PM<sub>1</sub>), Read directly using the `pms5003.pm_ug_per_m3()` method from the particulate matter sensor. |
+| pm025 | REAL | ug/m3 (microgram per meter cubed, µg/m³) | Particulate Matter 2.5 micrometers / microns (PM2.5, PM<sub>2.5</sub>), read directly using the `pms5003.pm_ug_per_m3()` method from the particulate matter sensor. |
+| pm10 | REAL | ug/m3 (microgram per meter cubed, µg/m³) | Particulate Matter 10 micrometers / microns (PM10, PM<sub>10</sub>), Read directly using the `pms5003.pm_ug_per_m3()` method from the particulate matter sensor. |
 | dew | REAL | C | Calculated from Temp and Hum as `(237.7 * (math.log(dew_hum/100)+17.271*dew_temp/(237.7+dew_temp))/(17.271 - math.log(dew_hum/100) - 17.271*dew_temp/(237.7 + dew_temp)))` | 
 | temp | REAL |  C | Adjusted for compensation factor set in `config.json` | 
-| Min Temp | REAL | C | Minimum temperature measured while sensor was running (only resets on restart) | 
-| Max Temp | REAL | C | Maximum temperature measured while sensor was running (only resets on restart) | 
+| temp_min | REAL | C | Minimum temperature measured while sensor was running (only resets on restart) | 
+| temp_max | REAL | C | Maximum temperature measured while sensor was running (only resets on restart) | 
 | gas_red | REAL | ppm | Red PPM calculated as `red_in_ppm = math.pow(10, -1.25 * math.log10(red_ratio) + 0.64)`. `red_ratio` is compensated gas value, see Software notes. | 
 | gas_oxi | REAL | ppm | Oxi PPM calculated as `oxi_in_ppm = math.pow(10, math.log10(oxi_ratio) - 0.8129)`. `oxi_ratio` is compensated gas value, see Software notes. | 
 | nh3 | REAL | ppm | NH3 PPM calculated as `nh3_in_ppm = math.pow(10, -1.8 * math.log10(nh3_ratio) - 0.163)`. `nh3_ratio` is compensated gas value, see Software notes. | 

--- a/docs/sensor-payloads/air-quality-aq-payload.md
+++ b/docs/sensor-payloads/air-quality-aq-payload.md
@@ -2,7 +2,7 @@
 description: Enviro + Air Quality sensor from Pimoroni for environmental conditions
 ---
 
-# Air Quality (AQ) Payload
+# Air Quality (AQ) Sensor Specifications
 
 {% hint style="info" %}
 The AQ software is available at [greendormer/enviroplus-monitor](https://github.com/greendormer/enviroplus-monitor). It is based on the wonderful work from the [roscoe81/enviro-monitor](https://github.com/roscoe81/enviro-monitor) and [Pimoroni Enviroplus](https://github.com/pimoroni/enviroplus-python) projects.
@@ -38,11 +38,12 @@ The following are important keys for the recommended default Traffic Monitor -sp
 * `"mqtt_broker_name": "localhost"` to send to Node-RED MQTT broker (assumes port 1883)
 * `"indoor_outdoor_function": "Outdoor"` to utilize `outdoor_mqtt_topic`
 * `"enable_display": false` since the AQ sensor will be in an enclosure
-* `"outdoor_mqtt_topic": "aq-readings"` for monitored message topic
+* `"outdoor_mqtt_topic": "aq/sensorname01/readings"` for sending messages, must start with "aq" and the middle element, "sensorname01" must be defined in your TM config
+* `"long_update_delay": 300` for time between sending MQTT messages (default 300-seconds)
 
 ### Deployment-specific config settings
 
-These need to be configured per-deployment for your location. They are utilized by the [`astral` package](https://astral.readthedocs.io/en/latest/package.html) for calculating the times of various aspects of the sun and phases of the moon.
+The following location-based settings need to be set per-deployment for your location. They are utilized by the [`astral` package](https://astral.readthedocs.io/en/latest/package.html) for calculating the times of various aspects of the sun and phases of the moon (lat/lon, time zone) and calibrating temperature, humidity, barometer, and gas (altitude) readings.
 
 ```json
 {
@@ -55,7 +56,7 @@ These need to be configured per-deployment for your location. They are utilized 
 }
 ```
 
-## Sensor MQTT Incoming Payload
+# Air Quality MQTT Incoming Payload
 
 The TM AQ application sends messages via MQTT integration on the `aq/readings` topic.
 
@@ -65,53 +66,85 @@ The sensor needs to stabilize (default 5-minutes) after the script initializes b
 
 ```json
 {
-    "Gas Calibrated": true,
+    "gas_calibrated": false,
     "Bar": [
-        1014.07,
+        1013.93,
         "0"
     ],
     "Hum": [
-        70.3,
+        45.9,
         "1"
     ],
-    "P2.5": 0,
-    "P10": 0,
-    "P1": 0,
-    "Dew": 10.8,
-    "Temp": 16.2,
-    "Min Temp": 13.7,
-    "Max Temp": 16.8,
-    "Red": 6.7,
-    "Oxi": 0.21,
-    "NH3": 1.51,
+    "Forecast": {
+        "Valid": false,
+        "3 Hour Change": 0,
+        "Forecast": "Insufficient Data"
+    },
+    "p025": 0,
+    "p10": 0,
+    "p01": 0,
+    "Dew": 7.5,
+    "Temp": 19.5,
+    "Min Temp": 19.5,
+    "Max Temp": 19.5,
+    "Red": 4.43,
+    "Oxi": 0.16,
+    "NH3": 0.66,
     "Lux": 0
 }
 ```
 
-### Database&#x20;
+| Key | Valid Values | Units | Notes |
+| -------------- | ------------ | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| gas_calibrated | true/false | | Hard-coded value (10-min) `gas_sensors_warmup_time = 6000` or `startup_stabilisation_time` when `reset_gas_sensor_calibration = true`|
+| bar | [REAL, TEXT] | hPa, Comfort-level `{"0": "Stable", "1": "Fair", "3": "Poorer/Windy/", "4": "Rain/Gale/Storm"}` | Air pressure, compensated for altitude and temp as `Bar / comp_factor` where `comp_factor = math.pow(1 - (0.0065 * altitude/(temp + 0.0065 * alt + 273.15)), -5.257)` |
+| hum | [REAL, TEXT] | %, Comfort-level `{"good": "1", "dry": "2", "wet": "3"}`| Adjusted for compensation factor set in `config.json` |
+| Forecast | {OBJECT} | `Valid`: true/false, `3 Hour Change` is millibars difference in barometer readings, `Forecast` is description calculated from barometer change | Calculated forecast based on sensor barometer changes|
+| p01 | REAL | ug/m3 (microgram per meter cubed, µg/m³) | Particulate Matter 1 micrometers / microns (PM1, PM<sub>1</sub>), Read directly using the `pms5003.pm_ug_per_m3()` method from the particulate matter sensor. |
+| p025 | REAL | ug/m3 (microgram per meter cubed, µg/m³) | Particulate Matter 2.5 micrometers / microns (PM2.5, PM<sub>2.5</sub>), read directly using the `pms5003.pm_ug_per_m3()` method from the particulate matter sensor. |
+| p10 | REAL | ug/m3 (microgram per meter cubed, µg/m³) | Particulate Matter 10 micrometers / microns (PM10, PM<sub>10</sub>), Read directly using the `pms5003.pm_ug_per_m3()` method from the particulate matter sensor. |
+| dew | REAL | C | Calculated from Temp and Hum as `(237.7 * (math.log(dew_hum/100)+17.271*dew_temp/(237.7+dew_temp))/(17.271 - math.log(dew_hum/100) - 17.271*dew_temp/(237.7 + dew_temp)))` | 
+| temp | REAL |  C | Adjusted for compensation factor set in `config.json` | 
+| Min Temp | REAL | C | Minimum temperature measured while sensor was running (only resets on restart) | 
+| Max Temp | REAL | C | Maximum temperature measured while sensor was running (only resets on restart) | 
+| gas_red | REAL | ppm | Red PPM calculated as `red_in_ppm = math.pow(10, -1.25 * math.log10(red_ratio) + 0.64)`. `red_ratio` is compensated gas value, see Software notes. | 
+| gas_oxi | REAL | ppm | Oxi PPM calculated as `oxi_in_ppm = math.pow(10, math.log10(oxi_ratio) - 0.8129)`. `oxi_ratio` is compensated gas value, see Software notes. | 
+| nh3 | REAL | ppm | NH3 PPM calculated as `nh3_in_ppm = math.pow(10, -1.8 * math.log10(nh3_ratio) - 0.163)`. `nh3_ratio` is compensated gas value, see Software notes. | 
+| lux | REAL | lux | Read directly using the `ltr559.get_lux()` method from the light sensor. | 
+| temp_raw | REAL | C | Read directly from sensor absent compensation. |
+| bar_raw | REAL | C | Read directly from sensor absent compensation. |
+| hum_raw | REAL | % | Read directly from sensor absent compensation. |
+| gas_red_raw | REAL | Ohms | Read directly from sensor using `gas_data.reducing` method absent compensation. |
+| gas_oxi_raw | REAL | Ohms | Read directly from sensor using `gas_data.oxidising` method absent compensation. |
+| gas_nh3_raw | REAL | Ohms | Read directly from sensor using `gas_data.nh3` method absent compensation. |
+| current_time | REAL | Unix time in Seconds | Created by script upon reading values. |
+
+# Air Quality TM Database&#x20;
 
 \[insert attributes table here]
 
-## Notes on readings
+# Notes on Air Quality readings
 
-### Gas sensor
+## Gas sensor
 
-MICS6814 analog gas sensor ([datasheet](https://www.sgxsensortech.com/content/uploads/2015/02/1143_Datasheet-MiCS-6814-rev-8.pdf)):  _The MiCS-6814 is a robust MEMS sensor for the detection of pollution from automobile exhausts and for agricultural/industrial odors._ &#x20;
+The [MICS6814](https://www.sgxsensortech.com/content/uploads/2015/02/1143_Datasheet-MiCS-6814-rev-8.pdf) analog gas sensor:  _The MiCS-6814 is a robust MEMS sensor for the detection of pollution from automobile exhausts and for agricultural/industrial odors._ &#x20;
 
-The sensor includes the ability to detect reductive (RED), oxidative (OXI), and ammonia (NH3) gases.
+The sensor includes the ability to detect reductive (RED), oxidative (OXI), and ammonia (NH3) gases. The raw gas readings are measured as Ohms of resistance for their respective gasses, but the software compensates for temperature, humidity, altitude, and drift to provide PPM (parts per million) equivalents.* 
+
+*See Software notes and additional discussions on [pimoroni/enviroplus-python #47](https://github.com/pimoroni/enviroplus-python/issues/47) and [pimoroni/enviroplus-python #67](https://github.com/pimoroni/enviroplus-python/issues/67). 
 
 **Software notes**
 
 * Gas calibrates using Temp, Humidity, and Barometric Pressure readings.
 * Gas Sensors (`Red`, `Oxi`, `NH3`) take 100-minutes to warm-up and readings to become available
-* To compensate for gas sensor drift over time, the software calibrates gas sensors daily at time set by `gas_daily_r0_calibration_hour`, using average of daily readings over a week if not already done in the current day and if warm-up calibration is completed.&#x20;
+* To compensate for gas sensor drift over time, the software calibrates gas sensors daily at time set by `gas_daily_r0_calibration_hour`, using average of daily readings over a week if not already done in the current day and if warm-up calibration is completed. This compensates for gas sensor drift over time&#x20;
 * Raw gas readings will also have compensation factors applied, determined by [regression analysis](https://github.com/roscoe81/enviro-monitor/blob/master/Regression_Analysis/Northcliff_Enviro_Monitor_Regression_Analyser.py).
 
-### Temperature, pressure, and humidity
+## Temperature, pressure, and humidity
 
-BME280 temperature, pressure, humidity sensor ([datasheet](https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bme280-ds002.pdf)) with I2S digital output.
+The [BME280](https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bme280-ds002.pdf) temperature, pressure, humidity sensor with I2S digital output.
 
-#### Software notes
+### Software notes
 
 * `Temp` (temperature) and `Hum` (humidity) have cubic polynomial compensation factors applied to raw readings
 * `Min Temp`and `Max Temp`are calculated over the entire time the script is running
@@ -123,13 +156,17 @@ BME280 temperature, pressure, humidity sensor ([datasheet](https://www.bosch-sen
     dewpoint = (237.7 * (math.log(dew_hum/100)+17.271*dew_temp/(237.7+dew_temp))/(17.271 - math.log(dew_hum/100) - 17.271*dew_temp/(237.7 + dew_temp)))
     ```
 
-### Noise&#x20;
+## Optical (light, proximity)
+
+The [LTR-559](https://optoelectronics.liteon.com/upload/download/DS86-2013-0003/LTR-559ALS-01_DS_V1.pdf) light and proximity sensor
+
+## Noise&#x20;
 
 MEMS microphone ([datasheet](https://media.digikey.com/pdf/Data%20Sheets/Knowles%20Acoustics%20PDFs/SPH0645LM4H-B.pdf)).
 
-### Particulate matter (PM) sensor&#x20;
+## Particulate matter (PM) &#x20;
 
-Plantower PMS5003 Particulate Matter (PM) Sensor ([datasheet](http://www.aqmd.gov/docs/default-source/aq-spec/resources-page/plantower-pms5003-manual_v2-3.pdf)).
+The Plantower [PMS5003](http://www.aqmd.gov/docs/default-source/aq-spec/resources-page/plantower-pms5003-manual_v2-3.pdf) Particulate Matter (PM) Sensor.
 
 \
 

--- a/node-red-project/config.yml
+++ b/node-red-project/config.yml
@@ -1,79 +1,30 @@
-########
-# This file contains configuration settings executed by node-red
-# Note: Comments will be removed by updates from node-red
-########
-
-# Optional: IoT hub backend integration
 thingsboard:
-    # Optional: enable connection to backend thingsboard server (default: shown below)
-    enabled: False
-    # Required: host name, without protocol or port number
+    enabled: false
     host: tb.server.com
-    # Required: thingsboard telemetry protocol (default: shown below), 
-    # NOTE: only http(s) currently supported, mqtt coming soon
-    #  see https://thingsboard.io/docs/reference/protocols/
-    protocol: https
-    # Optional: port, common settings: https=443, http=80, mqtt=1883
-    # Check with your ThingsBoard admin for settings
-    port: 443
-    # Optional: API key for device 
-    # Note: (Future) if already provisioned, will be assigned based on provisionDeviceKey and secret
-    api_key:
-    # Optional: future use for auto-provisioning (RPiSN)
-    # provisionDeviceKey: 
-    # Optional: future use for auto-provisioning (manual)
-    # provisionDeviceSecret: 
+    protocol: http
+    port:
+    access_token:
 
-# Optional: deployment location details
-# Note: May be used to determine device placement on maps
-# NOTE: Can be overridden at the sensors level, top-level values will cascade down
 deployment:
-    # NOTE: for address-level accuracy, recommend at least 4 digits after the decimal
-    # Optional: Latitude in decimal degrees format; e.g. 45.5225
     lat:
-    # Optional: Longitude in decimal degrees format; e.g. -122.6919
     lon:
-    # Optional: cardinal (N, S, E, W) or ordinal (NE, NW, SE, etc.) direction the camera/radar is facing 
-    # Note: For bearing, match the roadway traffic direction
     bearing:
 
 sensors:
-    # Optional: if used, must match the Frigate camera name(s)
-    # if not set, no cameras will be used
     cameras:
-        # camera name must match Frigate configuration camera names
-        picam_264:
-            # Optional Enable/disable the camera (default: shown below).
-            # if disabled, any Frigate events for specified camera will be ignored
-            # Note: this will not impact Frigate's system
-            enabled: False
-            # Optional: define the radar co-located with camera to associate speeds
-            # camera and radar direction and field of view (FOV) should match
-            # Note: name needs to match one defined in `radars` section
-            # Note: A single radar may be attached to multiple cameras
+        picam_h264:
+            enabled: false
             camera_radar: TM_RADAR_SERIAL_PORT_00
 
-    # Optional: used to specify what radars are enabled for speed/direction and detection
     radars:
-        # Note: Names must match those defined in the node-red environment file
-        # Names are used to associate readings with cameras and other sensors
         TM_RADAR_SERIAL_PORT_00:
-            # Optional: Enable/disable the radar (default: shown below).
-            enabled: False
+            enabled: false
 
-    # Optional: used to specify air quality monitor sensors
-    # Note: air quality configuration file is separate from the node-red config, based on the aq device
-    aq_monitor:
-        # Optional: Enable/disable the AQ sensor payloads (default: shown below).
-        enabled: False
-        # mqtt topic to subscribe for incoming telemetry from sensors
-        mqtt_topic_incoming: aq/readings
+    airquality_monitors:
+        sensorname01:
+            enabled: false
+            mqtt_topic_incoming: readings
 
 time:
-    # Optional: Set a timezone to use in the UI (default: use browser local time)
-    # NOTE: shall be in unix tz format: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-    #  this will also set the timezone for the entire system
     timezone: America/Los_Angeles
-    # Optional: For internet-connected deployments, sync using `timedatectl set-npt` (default: shown below)
-    # Note: for offline deployments, time will stop whenever power is disconnected
-    npt_set: True
+    npt_set: false

--- a/node-red-project/flows.json
+++ b/node-red-project/flows.json
@@ -2499,8 +2499,8 @@
         ],
         "repeat": "3600",
         "crontab": "",
-        "once": false,
-        "onceDelay": "1.2",
+        "once": true,
+        "onceDelay": "20",
         "topic": "",
         "payload": "\"C=\" & $ceil($millis()/1000) & \"\\n\"",
         "payloadType": "jsonata",
@@ -4358,7 +4358,7 @@
         "type": "function",
         "z": "1c71c8f26f5b7b19",
         "name": "init: set initial settings, takes ~6.9-sec",
-        "func": "//send parameters to query, start with PI (idle) and end with PA (active)\n// required as a long string of these commands will sometimes not report back\n// clear buffer between each command with ctr+c (hex \\x03)\n\nmsg.complete = false;\n\n// construct time zone elements\nconst date = new Date()\nconst offsetInMinutes = date.getTimezoneOffset()\nconst hours = Math.abs(Math.floor(offsetInMinutes / 60))\nconst minutes = Math.abs(offsetInMinutes % 60)\nconst offsetString = (offsetInMinutes >= 0 ? \"-\" : \"+\") +\n    hours.toString().padStart(2, '0') +\n    minutes.toString().padStart(2, '0')\n\nconst attribute_array = [\"PI\", \"OJ\", \"US\", \"F2\", \"S2\", \"K+\", \"IG\", \"ON\",\n    \"OU\", \"OT\", \"Oh\", \"Oc\",\n    \"@O\", \"@|300\\n\",\n    \"C=\" + date.getTime() + \"\\n\",\n    \"CZ\" + \"GMT\" + offsetString + \"\\n\",\n    \"OM\", \"M>20\\n\", \"OS\", \"R>5\\n\", \"O3\",\n    \"PA\", \"A!\"\n]\n\n// send each, clear it with ctr+c which is hex code 0x03\nconst hexCode = '\\x03'; // 0x03 hex code\nconst delay = 200; // ms delay\nconst delay_short = 100;  //300 ms per attribute\n\nnode.send({ payload: hexCode });\nawait new Promise(resolve => setTimeout(resolve, delay_short));\n\nfor (let i = 0; i < attribute_array.length; i++) {\n    node.send({ payload: attribute_array[i] });\n    await new Promise(resolve => setTimeout(resolve, delay));\n    node.send({ payload: hexCode });\n    await new Promise(resolve => setTimeout(resolve, delay_short));\n}\n\nmsg.complete = true;\nnode.done();\nreturn msg;",
+        "func": "//send parameters to query, start with PI (idle) and end with PA (active)\n// required as a long string of these commands will sometimes not report back\n// clear buffer between each command with ctr+c (hex \\x03)\n\nmsg.complete = false;\n\n// construct time zone elements\nconst date = new Date()\nconst offsetInMinutes = date.getTimezoneOffset()\nconst hours = Math.abs(Math.floor(offsetInMinutes / 60))\nconst minutes = Math.abs(offsetInMinutes % 60)\nconst offsetString = (offsetInMinutes >= 0 ? \"-\" : \"+\") +\n    hours.toString().padStart(2, '0') +\n    minutes.toString().padStart(2, '0')\n\nconst attribute_array = [\"PI\", \"OJ\", \"US\", \"F2\", \"S2\", \"K+\", \"IG\", \"ON\",\n    \"OU\", \"OT\", \"Oh\", \"Oc\",\n    \"@O\", \"@|300\\n\",\n    \"C=\" + Math.ceil(date.getTime()/1000) + \"\\n\",\n    \"CZ\" + \"GMT\" + offsetString + \"\\n\",\n    \"OM\", \"M>20\\n\", \"OS\", \"R>5\\n\", \"O3\",\n    \"PA\", \"A!\"\n]\n\n// send each, clear it with ctr+c which is hex code 0x03\nconst hexCode = '\\x03'; // 0x03 hex code\nconst delay = 200; // ms delay\nconst delay_short = 100;  //300 ms per attribute\n\nnode.send({ payload: hexCode });\nawait new Promise(resolve => setTimeout(resolve, delay_short));\n\nfor (let i = 0; i < attribute_array.length; i++) {\n    node.send({ payload: attribute_array[i] });\n    await new Promise(resolve => setTimeout(resolve, delay));\n    node.send({ payload: hexCode });\n    await new Promise(resolve => setTimeout(resolve, delay_short));\n}\n\nmsg.complete = true;\nnode.done();\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
         "noerr": 0,
@@ -4370,72 +4370,8 @@
         "wires": [
             [
                 "05a58d9ee463c696",
-                "09952039b0ab86aa"
-            ]
-        ]
-    },
-    {
-        "id": "355a9ce4be9a632c",
-        "type": "function",
-        "z": "1c71c8f26f5b7b19",
-        "name": "function 1",
-        "func": "  const date = new Date()\n  const offsetInMinutes = date.getTimezoneOffset()\n  const hours = Math.abs(Math.floor(offsetInMinutes / 60))\n  const minutes = Math.abs(offsetInMinutes % 60)\n  const offsetString = (offsetInMinutes >= 0 ? \"-\" : \"+\") + \n                       hours.toString().padStart(2, '0') + \n                       minutes.toString().padStart(2, '0')\n  msg.payload = offsetString\n  return msg",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 920,
-        "y": 660,
-        "wires": [
-            [
-                "2fbcb816a744905e"
-            ]
-        ]
-    },
-    {
-        "id": "2fbcb816a744905e",
-        "type": "debug",
-        "z": "1c71c8f26f5b7b19",
-        "name": "debug 1",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "false",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 1110,
-        "y": 660,
-        "wires": []
-    },
-    {
-        "id": "c501a6a048b77b17",
-        "type": "inject",
-        "z": "1c71c8f26f5b7b19",
-        "name": "",
-        "props": [
-            {
-                "p": "payload"
-            },
-            {
-                "p": "topic",
-                "vt": "str"
-            }
-        ],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "",
-        "payload": "",
-        "payloadType": "date",
-        "x": 750,
-        "y": 660,
-        "wires": [
-            [
-                "355a9ce4be9a632c"
+                "09952039b0ab86aa",
+                "5e7c4009964478fc"
             ]
         ]
     },
@@ -4509,6 +4445,22 @@
                 "3e9d121913d7feae"
             ]
         ]
+    },
+    {
+        "id": "5e7c4009964478fc",
+        "type": "debug",
+        "z": "1c71c8f26f5b7b19",
+        "name": "debug 1",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "false",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 810,
+        "y": 660,
+        "wires": []
     },
     {
         "id": "f20c74c0ccfd256c",
@@ -4796,7 +4748,7 @@
         "g": "b7398c4e0bc743e5",
         "mydb": "2f60c1ab30a6fc8f",
         "sqlquery": "prepared",
-        "sql": "INSERT INTO events (id, camera, label, sub_label, top_score, frame_time, start_time, end_time, entered_zones, score, area, ratio, motionless_count, position_changes, attributes, direction_calc, speed_calc, provenance, deployment_id, radarName) \nVALUES ($id, $camera, $label, $sub_label, $top_score, $frame_time, $start_time, $end_time, json($entered_zones), $score, $area, $ratio, $motionless_count, $position_changes, json($attributes), $direction_calc, $speed_calc, $provenance, $deployment_id, radarName);",
+        "sql": "INSERT INTO events (id, camera, label, sub_label, top_score, frame_time, start_time, end_time, entered_zones, score, area, ratio, motionless_count, position_changes, attributes, direction_calc, speed_calc, provenance, deployment_id, radarName) \nVALUES ($id, $camera, $label, $sub_label, $top_score, $frame_time, $start_time, $end_time, json($entered_zones), $score, $area, $ratio, $motionless_count, $position_changes, json($attributes), $direction_calc, $speed_calc, $provenance, $deployment_id, $radarName);",
         "name": "tmdb.events, Prepared Statement",
         "x": 680,
         "y": 840,
@@ -4990,7 +4942,7 @@
         "z": "9269520ddb532b00",
         "g": "0a5faeac9fbd6d55",
         "name": "append config, deployment properties",
-        "func": "// attach radarName, deployment_id, if applicable\n\nconst sensor = global.get(`config.sensors.cameras.${msg.frigate_event.camera}`);\n\nmsg.radarEnabled = false;\n\nif (sensor.hasOwnProperty('camera_radar')) {\n    //get radar settings\n    const radar = global.get(`config.sensors.radars.${msg.frigate_event.camera}`);\n    if (radar.hasOwnProperty('enabled')) {\n        if (radar.enabled === true) {\n            msg.frigate_event.radarName = sensor.camera_radar;\n            msg.radarEnabled = true;\n        }\n    }\n}\n\nif (sensor.hasOwnProperty('deployment')) {\n    msg.frigate_event.deployment_id = sensor.deployment.id;\n}\n//indicate if camera is enabled in TM for capture (may still be on in Frigate)\nif (sensor.hasOwnProperty('enabled')) {\n    msg.enabled = sensor.enabled;\n}\n\nreturn msg;",
+        "func": "// attach radarName, deployment_id, if applicable\n\nconst camera = global.get(`config.sensors.cameras.${msg.frigate_event.camera}`);\n\nmsg.radarEnabled = false;\n\nif (camera.hasOwnProperty('camera_radar')) {\n    //get radar settings\n    const radar = global.get(`config.sensors.radars.${camera.camera_radar}`);\n    if (radar.hasOwnProperty('enabled')) {\n        if (radar.enabled === true) {\n            msg.frigate_event.radarName = camera.camera_radar;\n            msg.radarEnabled = true;\n        }\n    }\n}\n\nif (camera.hasOwnProperty('deployment')) {\n    msg.frigate_event.deployment_id = camera.deployment.id;\n}\n//indicate if camera is enabled in TM for capture (may still be on in Frigate)\nif (camera.hasOwnProperty('enabled')) {\n    msg.enabled = camera.enabled;\n}\n\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
         "noerr": 0,
@@ -5069,7 +5021,7 @@
         "fieldType": "msg",
         "format": "sql",
         "syntax": "mustache",
-        "template": "CREATE TABLE IF NOT EXISTS events (\n    id TEXT PRIMARY KEY,\n    camera TEXT,\n    label TEXT,\n    sub_label TEXT,\n    top_score REAL,\n    frame_time REAL,\n    start_time REAL,\n    end_time REAL,\n    entered_zones TEXT,\n    score REAL,\n    area REAL,\n    ratio REAL,\n    motionless_count REAL,\n    position_changes REAL,\n    attributes TEXT,\n    direction_calc TEXT,\n    speed_calc REAL,\n    source TEXT,\n    deployment_id TEXT DEFAULT NULL,\n    FOREIGN KEY (deployment_id) REFERENCES deployment(id)\n    );",
+        "template": "CREATE TABLE IF NOT EXISTS events (\n    id TEXT PRIMARY KEY,\n    camera TEXT,\n    label TEXT,\n    sub_label TEXT,\n    top_score REAL,\n    frame_time REAL,\n    start_time REAL,\n    end_time REAL,\n    entered_zones TEXT,\n    score REAL,\n    area REAL,\n    ratio REAL,\n    motionless_count REAL,\n    position_changes REAL,\n    attributes TEXT,\n    direction_calc TEXT,\n    speed_calc REAL,\n    provenance TEXT, \n    deployment_id TEXT DEFAULT NULL,\n    radarName TEXT DEFAULT NULL\n    );",
         "output": "str",
         "x": 510,
         "y": 1080,

--- a/node-red-project/flows.json
+++ b/node-red-project/flows.json
@@ -604,15 +604,13 @@
             "22234193104332f6",
             "4094c101f6b59d95",
             "de7bc8103f7ca3c6",
-            "ef75320f6a5f0382",
             "f9a458c786e4bb84",
-            "8ccadc734d8ab769",
-            "463b64006f270db3"
+            "8ccadc734d8ab769"
         ],
         "x": 354,
-        "y": 1039,
+        "y": 959,
         "w": 1222,
-        "h": 282
+        "h": 242
     },
     {
         "id": "1eebfe6a2eca8ad4",
@@ -632,15 +630,13 @@
             "1acba66197b7b0fa",
             "01307f2f13f465f2",
             "3faf0dcbc24ef11c",
-            "2479e1e747a9c6ec",
             "1ef2418fe536aad5",
-            "1db11b98d771c791",
-            "dd88a80a3a79aa0b"
+            "1db11b98d771c791"
         ],
         "x": 354,
-        "y": 739,
+        "y": 699,
         "w": 1122,
-        "h": 282
+        "h": 242
     },
     {
         "id": "047f05d7650ba3cc",
@@ -660,15 +656,13 @@
             "7e4a607265a272c2",
             "080fd00489701aa1",
             "a489601d43802b82",
-            "fe45aef575ccab71",
             "8d4953609399d75e",
-            "d18b637f01871f23",
             "2aac5b4f344a86e8"
         ],
         "x": 354,
-        "y": 1339,
+        "y": 1219,
         "w": 1242,
-        "h": 282
+        "h": 242
     },
     {
         "id": "fcbf8999ca05a371",
@@ -687,15 +681,13 @@
             "83065a55697cc160",
             "95186b0fee06a3f5",
             "07cdbeafa34a565e",
-            "c61ef5ee09cb5c93",
-            "4f072d31286f7667",
             "303ea9d25d718231",
             "a18940845d6c5a2e"
         ],
         "x": 414,
-        "y": 1639,
+        "y": 1499,
         "w": 1242,
-        "h": 302
+        "h": 262
     },
     {
         "id": "23636f4163fa6e3b",
@@ -823,18 +815,17 @@
             "6e30f911242c5595",
             "edcc237df962c31a",
             "59a9c9a7ba535641",
-            "fb89305143faab57",
-            "45cdb2f02dfb2009",
             "07d558da50af5ae4",
             "1bdec3d0b912f792",
             "14ec91d93285b0fb",
             "9b57af73505cbb61",
-            "8e8edd5176fc9a71"
+            "8e8edd5176fc9a71",
+            "46e349af1bed1834"
         ],
         "x": 414,
-        "y": 1959,
+        "y": 1779,
         "w": 1132,
-        "h": 362
+        "h": 282
     },
     {
         "id": "805c5feafbb3610b",
@@ -854,11 +845,12 @@
             "9e95f569494a21dc",
             "50c56047654010ea",
             "8c434de19f88fefc",
-            "7eb7b4b61d38b789"
+            "7eb7b4b61d38b789",
+            "3e9d121913d7feae"
         ],
-        "x": 34,
+        "x": 54,
         "y": 439,
-        "w": 2292,
+        "w": 2272,
         "h": 162
     },
     {
@@ -1275,7 +1267,7 @@
         "z": "1c71c8f26f5b7b19",
         "g": "dea1b8828f8e501f",
         "x": 380,
-        "y": 1080,
+        "y": 1040,
         "wires": [
             [
                 "4094c101f6b59d95",
@@ -1290,7 +1282,7 @@
         "z": "1c71c8f26f5b7b19",
         "g": "047f05d7650ba3cc",
         "x": 380,
-        "y": 1380,
+        "y": 1300,
         "wires": [
             [
                 "080fd00489701aa1",
@@ -1347,12 +1339,26 @@
         "z": "1c71c8f26f5b7b19",
         "g": "da1c8c74261a93a4",
         "x": 620,
-        "y": 2000,
+        "y": 1820,
         "wires": [
             [
                 "edcc237df962c31a",
                 "ca4ed8761a4ded27",
                 "59a9c9a7ba535641"
+            ]
+        ]
+    },
+    {
+        "id": "3e9d121913d7feae",
+        "type": "junction",
+        "z": "1c71c8f26f5b7b19",
+        "g": "805c5feafbb3610b",
+        "x": 120,
+        "y": 540,
+        "wires": [
+            [
+                "c4a024def66c8499",
+                "8c434de19f88fefc"
             ]
         ]
     },
@@ -2380,7 +2386,7 @@
         "statusVal": "",
         "statusType": "auto",
         "x": 640,
-        "y": 1080,
+        "y": 1040,
         "wires": []
     },
     {
@@ -2462,19 +2468,18 @@
         "type": "inject",
         "z": "1c71c8f26f5b7b19",
         "g": "805c5feafbb3610b",
-        "name": "query all settings, after 4; then active",
+        "name": "query all settings, manually",
         "props": [],
         "repeat": "",
         "crontab": "",
-        "once": true,
+        "once": false,
         "onceDelay": "4",
         "topic": "",
-        "x": 230,
+        "x": 210,
         "y": 480,
         "wires": [
             [
-                "c4a024def66c8499",
-                "8c434de19f88fefc"
+                "3e9d121913d7feae"
             ]
         ]
     },
@@ -2482,7 +2487,7 @@
         "id": "0cdaafdd0b8921be",
         "type": "inject",
         "z": "1c71c8f26f5b7b19",
-        "name": "init: set radar time (in seconds), after 1.2",
+        "name": "init: set radar time (in seconds), repeat 60-min",
         "props": [
             {
                 "p": "payload"
@@ -2494,71 +2499,13 @@
         ],
         "repeat": "3600",
         "crontab": "",
-        "once": true,
+        "once": false,
         "onceDelay": "1.2",
         "topic": "",
         "payload": "\"C=\" & $ceil($millis()/1000) & \"\\n\"",
         "payloadType": "jsonata",
         "x": 240,
-        "y": 200,
-        "wires": [
-            [
-                "05a58d9ee463c696"
-            ]
-        ]
-    },
-    {
-        "id": "b6a08c3a8951d79f",
-        "type": "inject",
-        "z": "1c71c8f26f5b7b19",
-        "name": "init: set radar timezone, after 1.3",
-        "props": [
-            {
-                "p": "payload"
-            },
-            {
-                "p": "topic",
-                "vt": "str"
-            }
-        ],
-        "repeat": "",
-        "crontab": "",
-        "once": true,
-        "onceDelay": "1.3",
-        "topic": "",
-        "payload": "\"CZ\" & \"PST-7\" & \"\\n\"",
-        "payloadType": "jsonata",
-        "x": 210,
-        "y": 240,
-        "wires": [
-            [
-                "05a58d9ee463c696"
-            ]
-        ]
-    },
-    {
-        "id": "6b8d8a5677b9c558",
-        "type": "inject",
-        "z": "1c71c8f26f5b7b19",
-        "name": "init: base settings and filters, after 1.1",
-        "props": [
-            {
-                "p": "payload"
-            },
-            {
-                "p": "topic",
-                "vt": "str"
-            }
-        ],
-        "repeat": "",
-        "crontab": "",
-        "once": true,
-        "onceDelay": "1.1",
-        "topic": "",
-        "payload": "\"OJUSF2S2K+IGONO3OUOTOhOc\" & \"OMM>20\\n\" & \"OSR>5\\n\" & \"@O@|300\\n\" & \"A!\" ",
-        "payloadType": "jsonata",
-        "x": 230,
-        "y": 160,
+        "y": 320,
         "wires": [
             [
                 "05a58d9ee463c696"
@@ -2569,7 +2516,7 @@
         "id": "561dcf614bf5d56a",
         "type": "inject",
         "z": "1c71c8f26f5b7b19",
-        "name": "init: PI, idle power mode for settings",
+        "name": "init: PI, idle power mode, manual",
         "props": [
             {
                 "p": "payload"
@@ -2586,66 +2533,8 @@
         "topic": "",
         "payload": "\"PI\"",
         "payloadType": "jsonata",
-        "x": 220,
+        "x": 190,
         "y": 120,
-        "wires": [
-            [
-                "05a58d9ee463c696"
-            ]
-        ]
-    },
-    {
-        "id": "7c8d64d25c65f351",
-        "type": "inject",
-        "z": "1c71c8f26f5b7b19",
-        "name": "init: PA, active power mode, manual",
-        "props": [
-            {
-                "p": "payload"
-            },
-            {
-                "p": "topic",
-                "vt": "str"
-            }
-        ],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": "20",
-        "topic": "",
-        "payload": "\"PA\"",
-        "payloadType": "jsonata",
-        "x": 220,
-        "y": 400,
-        "wires": [
-            [
-                "05a58d9ee463c696"
-            ]
-        ]
-    },
-    {
-        "id": "a3a84b97fafede04",
-        "type": "inject",
-        "z": "1c71c8f26f5b7b19",
-        "name": "init: save settings, after 1.6",
-        "props": [
-            {
-                "p": "payload"
-            },
-            {
-                "p": "topic",
-                "vt": "str"
-            }
-        ],
-        "repeat": "",
-        "crontab": "",
-        "once": true,
-        "onceDelay": "1.6",
-        "topic": "",
-        "payload": "\"A!\"",
-        "payloadType": "jsonata",
-        "x": 200,
-        "y": 360,
         "wires": [
             [
                 "05a58d9ee463c696"
@@ -2724,66 +2613,8 @@
         "statusVal": "",
         "statusType": "auto",
         "x": 590,
-        "y": 1380,
+        "y": 1300,
         "wires": []
-    },
-    {
-        "id": "d764d1165570c18b",
-        "type": "inject",
-        "z": "1c71c8f26f5b7b19",
-        "name": "init: turn on OS, after 1.4",
-        "props": [
-            {
-                "p": "payload"
-            },
-            {
-                "p": "topic",
-                "vt": "str"
-            }
-        ],
-        "repeat": "7200",
-        "crontab": "",
-        "once": true,
-        "onceDelay": "1.4",
-        "topic": "",
-        "payload": "\"OS\"",
-        "payloadType": "jsonata",
-        "x": 190,
-        "y": 280,
-        "wires": [
-            [
-                "05a58d9ee463c696"
-            ]
-        ]
-    },
-    {
-        "id": "06c0cf29349aefe0",
-        "type": "inject",
-        "z": "1c71c8f26f5b7b19",
-        "name": "init: turn on OM, after 1.5",
-        "props": [
-            {
-                "p": "payload"
-            },
-            {
-                "p": "topic",
-                "vt": "str"
-            }
-        ],
-        "repeat": "7200",
-        "crontab": "",
-        "once": true,
-        "onceDelay": "1.5",
-        "topic": "",
-        "payload": "\"OM\"",
-        "payloadType": "jsonata",
-        "x": 190,
-        "y": 320,
-        "wires": [
-            [
-                "05a58d9ee463c696"
-            ]
-        ]
     },
     {
         "id": "ca182659939320ce",
@@ -2870,7 +2701,7 @@
         "sql": "INSERT INTO radar_dov (time, unit, direction, velocity, radarName, deployment_id) \nVALUES ($time, $unit, $direction, $velocity, $radarName, $deployment_id);\n",
         "name": "",
         "x": 1280,
-        "y": 980,
+        "y": 740,
         "wires": [
             []
         ]
@@ -2888,8 +2719,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 610,
-        "y": 980,
+        "x": 600,
+        "y": 740,
         "wires": [
             [
                 "c6fcbfb9341f189b"
@@ -2906,7 +2737,7 @@
         "sql": "",
         "name": "",
         "x": 1280,
-        "y": 1160,
+        "y": 1120,
         "wires": [
             [
                 "866e0c814ea2b4da"
@@ -2926,7 +2757,7 @@
         "onceDelay": 0.1,
         "topic": "",
         "x": 550,
-        "y": 1160,
+        "y": 1120,
         "wires": [
             [
                 "f9a458c786e4bb84"
@@ -2946,7 +2777,7 @@
         "onceDelay": 0.1,
         "topic": "",
         "x": 540,
-        "y": 1200,
+        "y": 1160,
         "wires": [
             [
                 "8ccadc734d8ab769"
@@ -2968,7 +2799,7 @@
         "statusVal": "",
         "statusType": "auto",
         "x": 1360,
-        "y": 1200,
+        "y": 1160,
         "wires": []
     },
     {
@@ -2985,7 +2816,7 @@
         "finalize": "",
         "libs": [],
         "x": 640,
-        "y": 1280,
+        "y": 1000,
         "wires": [
             [
                 "22234193104332f6"
@@ -3002,7 +2833,7 @@
         "sql": "INSERT INTO radar_timed_speed_counts (time, direction, units, count, average, radarName, deployment_id)\nVALUES ($time, $direction, $units, $count, $average, $radarName, $deployment_id);\n",
         "name": "",
         "x": 1280,
-        "y": 1280,
+        "y": 1000,
         "wires": [
             []
         ]
@@ -3017,7 +2848,7 @@
         "sql": "",
         "name": "",
         "x": 1280,
-        "y": 1460,
+        "y": 1380,
         "wires": [
             [
                 "9de4885ad8ef8485"
@@ -3037,7 +2868,7 @@
         "onceDelay": 0.1,
         "topic": "",
         "x": 550,
-        "y": 1460,
+        "y": 1380,
         "wires": [
             [
                 "8d4953609399d75e"
@@ -3057,7 +2888,7 @@
         "onceDelay": 0.1,
         "topic": "",
         "x": 540,
-        "y": 1500,
+        "y": 1420,
         "wires": [
             [
                 "2aac5b4f344a86e8"
@@ -3079,7 +2910,7 @@
         "statusVal": "",
         "statusType": "auto",
         "x": 1370,
-        "y": 1500,
+        "y": 1420,
         "wires": []
     },
     {
@@ -3092,7 +2923,7 @@
         "sql": "INSERT INTO radar_raw_speed_magnitude (time, unit, magnitude, speed, radarName, deployment_id) \nVALUES ($time, $unit, $magnitude, $speed, $radarName, $deployment_id);",
         "name": "",
         "x": 1280,
-        "y": 1580,
+        "y": 1260,
         "wires": [
             []
         ]
@@ -3111,7 +2942,7 @@
         "finalize": "",
         "libs": [],
         "x": 660,
-        "y": 1580,
+        "y": 1260,
         "wires": [
             [
                 "81522ee190374834"
@@ -3203,7 +3034,7 @@
         "sql": "INSERT INTO radar_raw_speed_magnitude_single (time, unit, magnitude, speed, radarName, deployment_id) \nVALUES ($time, $unit, $magnitude, $speed, $radarName, $deployment_id);",
         "name": "",
         "x": 1280,
-        "y": 1860,
+        "y": 1580,
         "wires": [
             []
         ]
@@ -3222,7 +3053,7 @@
         "finalize": "",
         "libs": [],
         "x": 740,
-        "y": 1860,
+        "y": 1580,
         "wires": [
             [
                 "252e2f5b95aeb8da"
@@ -3267,8 +3098,8 @@
         "links": [
             "0124afc74d86b533"
         ],
-        "x": 485,
-        "y": 1900,
+        "x": 535,
+        "y": 1640,
         "wires": []
     },
     {
@@ -3282,7 +3113,7 @@
             "fc5e2cd719fa680a"
         ],
         "x": 475,
-        "y": 1420,
+        "y": 1340,
         "wires": []
     },
     {
@@ -3296,7 +3127,7 @@
             "087588593911f398"
         ],
         "x": 475,
-        "y": 1120,
+        "y": 1080,
         "wires": []
     },
     {
@@ -3313,7 +3144,7 @@
         "finalize": "",
         "libs": [],
         "x": 640,
-        "y": 1800,
+        "y": 1540,
         "wires": [
             [
                 "83065a55697cc160",
@@ -3786,86 +3617,6 @@
         ]
     },
     {
-        "id": "2479e1e747a9c6ec",
-        "type": "inject",
-        "z": "1c71c8f26f5b7b19",
-        "g": "1eebfe6a2eca8ad4",
-        "name": "inject manually",
-        "props": [],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "",
-        "x": 540,
-        "y": 940,
-        "wires": [
-            [
-                "dd88a80a3a79aa0b"
-            ]
-        ]
-    },
-    {
-        "id": "ef75320f6a5f0382",
-        "type": "inject",
-        "z": "1c71c8f26f5b7b19",
-        "g": "dea1b8828f8e501f",
-        "name": "inject manually",
-        "props": [],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "",
-        "x": 540,
-        "y": 1240,
-        "wires": [
-            [
-                "463b64006f270db3"
-            ]
-        ]
-    },
-    {
-        "id": "fe45aef575ccab71",
-        "type": "inject",
-        "z": "1c71c8f26f5b7b19",
-        "g": "047f05d7650ba3cc",
-        "name": "inject manually",
-        "props": [],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "",
-        "x": 540,
-        "y": 1540,
-        "wires": [
-            [
-                "d18b637f01871f23"
-            ]
-        ]
-    },
-    {
-        "id": "c61ef5ee09cb5c93",
-        "type": "inject",
-        "z": "1c71c8f26f5b7b19",
-        "g": "fcbf8999ca05a371",
-        "name": "inject manually",
-        "props": [],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "",
-        "x": 540,
-        "y": 1760,
-        "wires": [
-            [
-                "4f072d31286f7667"
-            ]
-        ]
-    },
-    {
         "id": "17f2bd782fa7cc56",
         "type": "change",
         "z": "1c71c8f26f5b7b19",
@@ -4014,26 +3765,6 @@
         ]
     },
     {
-        "id": "dd88a80a3a79aa0b",
-        "type": "template",
-        "z": "1c71c8f26f5b7b19",
-        "g": "1eebfe6a2eca8ad4",
-        "name": "alter table radar_dov",
-        "field": "topic",
-        "fieldType": "msg",
-        "format": "sql",
-        "syntax": "mustache",
-        "template": "",
-        "output": "str",
-        "x": 940,
-        "y": 940,
-        "wires": [
-            [
-                "ca182659939320ce"
-            ]
-        ]
-    },
-    {
         "id": "f9a458c786e4bb84",
         "type": "template",
         "z": "1c71c8f26f5b7b19",
@@ -4046,7 +3777,7 @@
         "template": "CREATE TABLE IF NOT EXISTS radar_timed_speed_counts (\n    time REAL, \n    direction TEXT, \n    units TEXT, \n    count INTEGER, \n    average REAL, \n    radarName TEXT, \n    deployment_id TEXT\n);",
         "output": "str",
         "x": 890,
-        "y": 1160,
+        "y": 1120,
         "wires": [
             [
                 "50dcead7cf35b74f"
@@ -4066,27 +3797,7 @@
         "template": "SELECT * \nFROM radar_timed_speed_counts \nORDER BY time DESC \nLIMIT 5;",
         "output": "str",
         "x": 850,
-        "y": 1200,
-        "wires": [
-            [
-                "50dcead7cf35b74f"
-            ]
-        ]
-    },
-    {
-        "id": "463b64006f270db3",
-        "type": "template",
-        "z": "1c71c8f26f5b7b19",
-        "g": "dea1b8828f8e501f",
-        "name": "alter table radar_timedspeedcounts",
-        "field": "topic",
-        "fieldType": "msg",
-        "format": "sql",
-        "syntax": "mustache",
-        "template": "",
-        "output": "str",
-        "x": 900,
-        "y": 1240,
+        "y": 1160,
         "wires": [
             [
                 "50dcead7cf35b74f"
@@ -4106,27 +3817,7 @@
         "template": "CREATE TABLE IF NOT EXISTS radar_raw_speed_magnitude (\n    time REAL, \n    unit TEXT, \n    magnitude TEXT, \n    speed TEXT, \n    radarName TEXT, \n    deployment_id TEXT\n    );",
         "output": "str",
         "x": 880,
-        "y": 1460,
-        "wires": [
-            [
-                "a3dddf65b65ca371"
-            ]
-        ]
-    },
-    {
-        "id": "d18b637f01871f23",
-        "type": "template",
-        "z": "1c71c8f26f5b7b19",
-        "g": "047f05d7650ba3cc",
-        "name": "alter table radar_raw_speed_magnitude",
-        "field": "topic",
-        "fieldType": "msg",
-        "format": "sql",
-        "syntax": "mustache",
-        "template": "",
-        "output": "str",
-        "x": 880,
-        "y": 1540,
+        "y": 1380,
         "wires": [
             [
                 "a3dddf65b65ca371"
@@ -4146,30 +3837,10 @@
         "template": "SELECT * \nFROM radar_raw_speed_magnitude \nORDER BY time DESC \nLIMIT 5;",
         "output": "str",
         "x": 840,
-        "y": 1500,
+        "y": 1420,
         "wires": [
             [
                 "a3dddf65b65ca371"
-            ]
-        ]
-    },
-    {
-        "id": "4f072d31286f7667",
-        "type": "template",
-        "z": "1c71c8f26f5b7b19",
-        "g": "fcbf8999ca05a371",
-        "name": "alter table radar_raw_speed_magnitude_single",
-        "field": "topic",
-        "fieldType": "msg",
-        "format": "sql",
-        "syntax": "mustache",
-        "template": "",
-        "output": "str",
-        "x": 900,
-        "y": 1760,
-        "wires": [
-            [
-                "a3924864154eaefb"
             ]
         ]
     },
@@ -4227,8 +3898,8 @@
         "targetType": "msg",
         "statusVal": "",
         "statusType": "auto",
-        "x": 1230,
-        "y": 2100,
+        "x": 810,
+        "y": 1860,
         "wires": []
     },
     {
@@ -4244,7 +3915,7 @@
         "onceDelay": 0.1,
         "topic": "",
         "x": 550,
-        "y": 2200,
+        "y": 1980,
         "wires": [
             [
                 "1bdec3d0b912f792"
@@ -4261,7 +3932,7 @@
         "sql": "INSERT INTO radar_oc_payload (end_time, start_time, delta_time_msec, dir, frames, max_mph, min_mph, max_mag, avg_mag, frames_per_mph, length_ft)\nVALUES ($end_time, $start_time, $delta_time_msec, $dir, $frames, $max_mph, $min_mph, $max_mag, $avg_mag, $frames_per_mph, $length_ft);",
         "name": "",
         "x": 1280,
-        "y": 2200,
+        "y": 1980,
         "wires": [
             [
                 "45801cdcc5094abc"
@@ -4281,7 +3952,7 @@
         "onceDelay": 0.1,
         "topic": "",
         "x": 540,
-        "y": 2240,
+        "y": 2020,
         "wires": [
             [
                 "07d558da50af5ae4"
@@ -4303,7 +3974,7 @@
         "statusVal": "",
         "statusType": "auto",
         "x": 1350,
-        "y": 2240,
+        "y": 2020,
         "wires": []
     },
     {
@@ -4313,10 +3984,10 @@
         "g": "da1c8c74261a93a4",
         "mydb": "2f60c1ab30a6fc8f",
         "sqlquery": "prepared",
-        "sql": "INSERT INTO radar_oc_payload (end_time, start_time, delta_time_msec, dir, frames, max_mph, min_mph, max_mag, avg_mag, frames_per_mph, length_ft, radarName, deployment_id)\nVALUES ($end_time, $start_time, $delta_time_msec, $dir, $frames, $max_mph, $min_mph, $max_mag, $avg_mag, $frames_per_mph, $length_ft, $radarName, $deployment_id);",
+        "sql": "INSERT INTO radar_oc_payload (start_time, end_time, delta_time_msec, direction, frames_count, velocity_max, velocity_min, magnitude_max, magnitude_mean, velocity_change, frames_per_velocity, object_length, units, object_label, radarName, deployment_id)\nVALUES ($start_time, $end_time, $delta_time_msec, $direction, $frames_count, $velocity_max, $velocity_min, $magnitude_max, $magnitude_mean, $velocity_change, $frames_per_velocity, $object_length, $units, $object_label, $radarName, $deployment_id);",
         "name": "",
         "x": 1280,
-        "y": 2040,
+        "y": 1820,
         "wires": [
             []
         ]
@@ -4334,8 +4005,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 1220,
-        "y": 2000,
+        "x": 880,
+        "y": 1820,
         "wires": [
             [
                 "6e30f911242c5595"
@@ -4352,49 +4023,9 @@
         "links": [
             "e05e91362c933e94"
         ],
-        "x": 1155,
-        "y": 2140,
+        "x": 735,
+        "y": 1900,
         "wires": []
-    },
-    {
-        "id": "fb89305143faab57",
-        "type": "inject",
-        "z": "1c71c8f26f5b7b19",
-        "g": "da1c8c74261a93a4",
-        "name": "inject manually",
-        "props": [],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "",
-        "x": 540,
-        "y": 2280,
-        "wires": [
-            [
-                "45cdb2f02dfb2009"
-            ]
-        ]
-    },
-    {
-        "id": "45cdb2f02dfb2009",
-        "type": "template",
-        "z": "1c71c8f26f5b7b19",
-        "g": "da1c8c74261a93a4",
-        "name": "alter table radar_oc_payload",
-        "field": "payload",
-        "fieldType": "msg",
-        "format": "sql",
-        "syntax": "mustache",
-        "template": "",
-        "output": "str",
-        "x": 920,
-        "y": 2280,
-        "wires": [
-            [
-                "09369d5e4816364f"
-            ]
-        ]
     },
     {
         "id": "07d558da50af5ae4",
@@ -4409,7 +4040,7 @@
         "template": "SELECT * \nFROM radar_oc_payload \nORDER BY end_time DESC \nLIMIT 5;",
         "output": "str",
         "x": 870,
-        "y": 2240,
+        "y": 2020,
         "wires": [
             [
                 "09369d5e4816364f"
@@ -4426,10 +4057,10 @@
         "fieldType": "msg",
         "format": "sql",
         "syntax": "mustache",
-        "template": "CREATE TABLE IF NOT EXISTS radar_oc_payload (\n    end_time REAL,\n    start_time REAL,\n    delta_time_msec INTEGER,\n    dir TEXT,\n    frames INTEGER,\n    max_mph REAL,\n    min_mph REAL,\n    max_mag REAL,\n    avg_mag REAL,\n    frames_per_mph REAL,\n    length_ft REAL,\n    radarName TEXT,\n    deployment_id TEXT\n    );",
+        "template": "CREATE TABLE IF NOT EXISTS radar_oc_payload (\n    start_time REAL,\n    end_time REAL,\n    delta_time_msec REAL,\n    direction TEXT,\n    frames_count REAL,\n    velocity_max REAL,\n    velocity_min REAL,\n    magnitude_max REAL,\n    magnitude_mean REAL,\n    velocity_change REAL,\n    frames_per_velocity REAL,\n    object_length REAL,\n    units TEXT,\n    object_label TEXT,\n    radarName TEXT,\n    deployment_id TEXT\n);",
         "output": "str",
         "x": 910,
-        "y": 2200,
+        "y": 1980,
         "wires": [
             [
                 "09369d5e4816364f"
@@ -4442,7 +4073,7 @@
         "z": "1c71c8f26f5b7b19",
         "g": "da1c8c74261a93a4",
         "name": "dir",
-        "func": "\n// end_time\n// start_time\n// delta_time_msec\n// __dirnameframes\n// max_mph\n// min_mph\n// max_mag\n// avg_mag\n// frames_per_mph\n// length_ft\n\n// radarName\n// deployment_id\n\nreturn msg;",
+        "func": "const newPayload = {\n    start_time: msg.payload.start_time,\n    end_time: msg.payload.end_time,\n    delta_time_msec: msg.payload.delta_time_msec,\n    direction: msg.payload.dir == \"OUT\" ? \"outbound\" : msg.payload.dir == \"IN\" ? \"inbound\" : null,\n    frames_count: msg.payload.frames,\n    velocity_max: msg.payload.max_mps !== undefined ? msg.payload.max_mps : msg.payload.max_mph !== undefined ? msg.payload.max_mph : null,\n    velocity_min: msg.payload.min_mps !== undefined ? msg.payload.min_mps : msg.payload.min_mph !== undefined ? msg.payload.min_mph : null,\n    magnitude_max: msg.payload.max_mag,\n    magnitude_mean: msg.payload.avg_mag,\n    velocity_change: null,\n    frames_per_velocity: msg.payload.frames_per_mps !== undefined ? msg.payload.frames_per_mps : msg.payload.frames_per_mph !== undefined ? msg.payload.frames_per_mph : null,\n    object_length: msg.payload.length_m !== undefined ? msg.payload.length_m : msg.payload.length_ft !== undefined ? msg.payload.length_ft : null,\n    units: msg.payload.max_mps !== undefined ? \"metric\" : msg.payload.max_mph !== undefined ? \"imperial\" : null,\n    object_label: null,\n    radarName: msg.payload.radarName,\n    deployment_id: msg.payload.deployment_id\n};\n\nmsg.payload = newPayload;\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
         "noerr": 0,
@@ -4450,7 +4081,7 @@
         "finalize": "",
         "libs": [],
         "x": 490,
-        "y": 2000,
+        "y": 1820,
         "wires": [
             [
                 "14ec91d93285b0fb"
@@ -4463,7 +4094,7 @@
         "z": "1c71c8f26f5b7b19",
         "g": "da1c8c74261a93a4",
         "name": "classifier",
-        "func": "\n\n// classifier\n// start_time\n// max_speed_mph\n// min_speed_mph\n// max_magnitude\n// avg_magnitude\n// total_frames\n// frames_per_mph\n// length_ft\n// delta_time_msec\n\n// radarName\n// deployment_id\n\nreturn msg;",
+        "func": "const newPayload = {\n    start_time: msg.payload.start_time,\n    end_time: msg.payload.end_time,\n    delta_time_msec: msg.payload.delta_time_msec,\n    direction: msg.payload.classifier == \"object_outbound\" ? \"outbound\" : msg.payload.classifier == \"object_inbound\" ? \"inbound\" : null,\n    frames_count: msg.payload.total_frames,\n    velocity_max: msg.payload.max_speed_mps !== undefined ? msg.payload.max_speed_mps : msg.payload.max_speed_mph !== undefined ? msg.payload.max_speed_mph : null,\n    velocity_min: msg.payload.min_speed_mps !== undefined ? msg.payload.min_speed_mps : msg.payload.min_speed_mph !== undefined ? msg.payload.min_speed_mph : null,\n    magnitude_max: msg.payload.max_magnitude,\n    magnitude_mean: msg.payload.avg_magnitude,\n    velocity_change: msg.payload.speed_change,\n    frames_per_velocity: msg.payload.frames_per_mps !== undefined ? msg.payload.frames_per_mps : msg.payload.frames_per_mph !== undefined ? msg.payload.frames_per_mph : null,\n    object_length: msg.payload.length_m !== undefined ? msg.payload.length_m : msg.payload.length_ft !== undefined ? msg.payload.length_ft : null,\n    units: msg.payload.max_speed_mps !== undefined ? \"metric\" : msg.payload.max_speed_mph !== undefined ? \"imperial\" : null,\n    object_label: null,\n    radarName: msg.payload.radarName,\n    deployment_id: msg.payload.deployment_id\n};\n\nmsg.payload = newPayload;\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
         "noerr": 0,
@@ -4471,7 +4102,7 @@
         "finalize": "",
         "libs": [],
         "x": 500,
-        "y": 2040,
+        "y": 1860,
         "wires": [
             [
                 "14ec91d93285b0fb"
@@ -4535,7 +4166,7 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 960,
+        "x": 920,
         "y": 520,
         "wires": [
             [
@@ -4670,15 +4301,15 @@
         "type": "function",
         "z": "1c71c8f26f5b7b19",
         "g": "805c5feafbb3610b",
-        "name": "query each setting, and clear buffer, takes ~9.0-sec",
-        "func": "//send parameters to query, start with PI (idle) and end with PA (active)\n// required as a long string of these commands will sometimes not report back\nconst attribute_array = [\"PI\", \"?P\", \"?N\", \"?D\", \"?V\", \"?B\", \"??\", \"U?\", \"u?\", \"F?\", \"O?\", \"?F\", \"t?\", \"s?\", \"PA\"]\n\n// send each, clear it with ctr+c which is hex code 0x03\nconst hexCode = '\\x03'; // 0x03 hex code\nconst delay = 500; // 500 ms delay\nconst delay_short = 100;\n//500+100 = 600 ms per attribute\n\nnode.send({payload:hexCode});\nawait new Promise(resolve => setTimeout(resolve, delay_short));\n\nfor (let i = 0; i < attribute_array.length; i++) {\n    node.send({payload:attribute_array[i]});\n    await new Promise(resolve => setTimeout(resolve, delay));\n    node.send({payload:hexCode});\n    await new Promise(resolve => setTimeout(resolve, delay_short));\n}\n\nmsg.complete = true;\nnode.done();\nreturn msg;",
+        "name": "init: query each setting, and clear buffer, takes ~9.0-sec",
+        "func": "//send parameters to query, start with PI (idle) and end with PA (active)\n// required as a long string of these commands will sometimes not report back\n// clear buffer between each command with ctr+c (hex \\x03)\n\nmsg.complete = false;\n\nconst attribute_array = [\"PI\", \"?P\", \"?N\", \"?D\", \"?V\", \"?B\", \"??\", \"U?\", \"u?\", \"F?\", \"O?\", \"?F\", \"t?\", \"s?\", \"PA\"]\n\n// send each, clear it with ctr+c which is hex code 0x03\nconst hexCode = '\\x03'; // 0x03 hex code\nconst delay = 500; // 500 ms delay\nconst delay_short = 100;\n//500+100 = 600 ms per attribute\n\nnode.send({payload:hexCode});\nawait new Promise(resolve => setTimeout(resolve, delay_short));\n\nfor (let i = 0; i < attribute_array.length; i++) {\n    node.send({payload:attribute_array[i]});\n    await new Promise(resolve => setTimeout(resolve, delay));\n    node.send({payload:hexCode});\n    await new Promise(resolve => setTimeout(resolve, delay_short));\n}\n\nmsg.complete = true;\nnode.done();\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
         "noerr": 0,
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 330,
+        "x": 340,
         "y": 560,
         "wires": [
             [
@@ -4703,11 +4334,179 @@
         "checkall": "true",
         "repair": false,
         "outputs": 1,
-        "x": 690,
-        "y": 520,
+        "x": 650,
+        "y": 560,
         "wires": [
             [
                 "ae11d5c9948bf4e1"
+            ]
+        ]
+    },
+    {
+        "id": "46e349af1bed1834",
+        "type": "comment",
+        "z": "1c71c8f26f5b7b19",
+        "g": "da1c8c74261a93a4",
+        "name": "payload varies by firmware version/build",
+        "info": "",
+        "x": 590,
+        "y": 1940,
+        "wires": []
+    },
+    {
+        "id": "a0b880e68f9b7198",
+        "type": "function",
+        "z": "1c71c8f26f5b7b19",
+        "name": "init: set initial settings, takes ~6.9-sec",
+        "func": "//send parameters to query, start with PI (idle) and end with PA (active)\n// required as a long string of these commands will sometimes not report back\n// clear buffer between each command with ctr+c (hex \\x03)\n\nmsg.complete = false;\n\n// construct time zone elements\nconst date = new Date()\nconst offsetInMinutes = date.getTimezoneOffset()\nconst hours = Math.abs(Math.floor(offsetInMinutes / 60))\nconst minutes = Math.abs(offsetInMinutes % 60)\nconst offsetString = (offsetInMinutes >= 0 ? \"-\" : \"+\") +\n    hours.toString().padStart(2, '0') +\n    minutes.toString().padStart(2, '0')\n\nconst attribute_array = [\"PI\", \"OJ\", \"US\", \"F2\", \"S2\", \"K+\", \"IG\", \"ON\",\n    \"OU\", \"OT\", \"Oh\", \"Oc\",\n    \"@O\", \"@|300\\n\",\n    \"C=\" + date.getTime() + \"\\n\",\n    \"CZ\" + \"GMT\" + offsetString + \"\\n\",\n    \"OM\", \"M>20\\n\", \"OS\", \"R>5\\n\", \"O3\",\n    \"PA\", \"A!\"\n]\n\n// send each, clear it with ctr+c which is hex code 0x03\nconst hexCode = '\\x03'; // 0x03 hex code\nconst delay = 200; // ms delay\nconst delay_short = 100;  //300 ms per attribute\n\nnode.send({ payload: hexCode });\nawait new Promise(resolve => setTimeout(resolve, delay_short));\n\nfor (let i = 0; i < attribute_array.length; i++) {\n    node.send({ payload: attribute_array[i] });\n    await new Promise(resolve => setTimeout(resolve, delay));\n    node.send({ payload: hexCode });\n    await new Promise(resolve => setTimeout(resolve, delay_short));\n}\n\nmsg.complete = true;\nnode.done();\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 230,
+        "y": 240,
+        "wires": [
+            [
+                "05a58d9ee463c696",
+                "09952039b0ab86aa"
+            ]
+        ]
+    },
+    {
+        "id": "355a9ce4be9a632c",
+        "type": "function",
+        "z": "1c71c8f26f5b7b19",
+        "name": "function 1",
+        "func": "  const date = new Date()\n  const offsetInMinutes = date.getTimezoneOffset()\n  const hours = Math.abs(Math.floor(offsetInMinutes / 60))\n  const minutes = Math.abs(offsetInMinutes % 60)\n  const offsetString = (offsetInMinutes >= 0 ? \"-\" : \"+\") + \n                       hours.toString().padStart(2, '0') + \n                       minutes.toString().padStart(2, '0')\n  msg.payload = offsetString\n  return msg",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 920,
+        "y": 660,
+        "wires": [
+            [
+                "2fbcb816a744905e"
+            ]
+        ]
+    },
+    {
+        "id": "2fbcb816a744905e",
+        "type": "debug",
+        "z": "1c71c8f26f5b7b19",
+        "name": "debug 1",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "false",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 1110,
+        "y": 660,
+        "wires": []
+    },
+    {
+        "id": "c501a6a048b77b17",
+        "type": "inject",
+        "z": "1c71c8f26f5b7b19",
+        "name": "",
+        "props": [
+            {
+                "p": "payload"
+            },
+            {
+                "p": "topic",
+                "vt": "str"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "payload": "",
+        "payloadType": "date",
+        "x": 750,
+        "y": 660,
+        "wires": [
+            [
+                "355a9ce4be9a632c"
+            ]
+        ]
+    },
+    {
+        "id": "7c8d64d25c65f351",
+        "type": "inject",
+        "z": "1c71c8f26f5b7b19",
+        "name": "init: PA, active power mode, manual",
+        "props": [
+            {
+                "p": "payload"
+            },
+            {
+                "p": "topic",
+                "vt": "str"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": "20",
+        "topic": "",
+        "payload": "\"PA\"",
+        "payloadType": "jsonata",
+        "x": 200,
+        "y": 160,
+        "wires": [
+            [
+                "05a58d9ee463c696"
+            ]
+        ]
+    },
+    {
+        "id": "cca525a755c918da",
+        "type": "inject",
+        "z": "1c71c8f26f5b7b19",
+        "name": "init: set initial radar settings",
+        "props": [],
+        "repeat": "",
+        "crontab": "",
+        "once": true,
+        "onceDelay": 0.1,
+        "topic": "",
+        "x": 180,
+        "y": 200,
+        "wires": [
+            [
+                "a0b880e68f9b7198"
+            ]
+        ]
+    },
+    {
+        "id": "09952039b0ab86aa",
+        "type": "switch",
+        "z": "1c71c8f26f5b7b19",
+        "name": "complete?",
+        "property": "complete",
+        "propertyType": "msg",
+        "rules": [
+            {
+                "t": "true"
+            }
+        ],
+        "checkall": "true",
+        "repair": false,
+        "outputs": 1,
+        "x": 350,
+        "y": 280,
+        "wires": [
+            [
+                "3e9d121913d7feae"
             ]
         ]
     },
@@ -5731,7 +5530,7 @@
         "z": "f7932be9acc7391c",
         "g": "43087a735f896849",
         "name": "tb telemetry response",
-        "active": true,
+        "active": false,
         "tosidebar": true,
         "console": false,
         "tostatus": false,
@@ -5905,7 +5704,7 @@
         "z": "f7932be9acc7391c",
         "g": "1819134eccdf2660",
         "name": "format radar_oc_payload telemetry",
-        "func": "const newPayload = {\n    ts: msg.payload.start_time * 1000,\n    values: {\n        radar: {\n            radar_oc_payload: {\n                start_time: msg.payload.start_time,\n                end_time: msg.payload.end_time,\n                delta_time_msec: msg.payload.delta_time_msec,\n                dir: msg.payload.dir,\n                frames: msg.payload.frames,\n                max_mph: msg.payload.max_mph,\n                min_mph: msg.payload.min_mph,\n                max_mag: msg.payload.max_mag,\n                avg_mag: msg.payload.avg_mag,\n                frames_per_mph: msg.payload.frames_per_mph,\n                length_ft: msg.payload.length_ft,\n                radarName: msg.payload.radarName,\n                deployment_id: msg.payload.deployment_id\n            }\n        }\n    }\n}\n\nmsg.payload = newPayload;\n\nreturn msg;",
+        "func": "const newPayload = {\n    ts: msg.payload.start_time * 1000,\n    values: {\n        radar: {\n            radar_oc_payload: {\n                start_time: msg.payload.start_time,\n                end_time: msg.payload.end_time,\n                delta_time_msec: msg.payload.delta_time_msec,\n                direction: msg.payload.direction,\n                frames_count: msg.payload.frames_count,\n                velocity_max: msg.payload.velocity_max,\n                velocity_min: msg.payload.velocity_min,\n                magnitude_max: msg.payload.magnitude_max,\n                magnitude_mean: msg.payload.magnitude_mean,\n                velocity_change: msg.payload.velocity_change,\n                frames_per_velocity: msg.payload.frames_per_velocity,\n                object_length: msg.payload.object_length,\n                units: msg.payload.units,\n                object_label: msg.payload.object_label,\n                radarName: msg.payload.radarName,\n                deployment_id: msg.payload.deployment_id\n            }\n        }\n    }\n}\n\nmsg.payload = newPayload;\n\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
         "noerr": 0,

--- a/node-red-project/flows.json
+++ b/node-red-project/flows.json
@@ -24,6 +24,14 @@
         "env": []
     },
     {
+        "id": "b1fde507a4b80c79",
+        "type": "tab",
+        "label": "capture-aq",
+        "disabled": false,
+        "info": "",
+        "env": []
+    },
+    {
         "id": "f7932be9acc7391c",
         "type": "tab",
         "label": "thingsboard",
@@ -59,14 +67,6 @@
         "id": "f410f6aac9d1a3fc",
         "type": "tab",
         "label": "system-metrics",
-        "disabled": false,
-        "info": "",
-        "env": []
-    },
-    {
-        "id": "b1fde507a4b80c79",
-        "type": "tab",
-        "label": "capture-aq",
         "disabled": false,
         "info": "",
         "env": []
@@ -264,38 +264,34 @@
             "c123fc5ed5e14e8a",
             "673e45159a2dfccf",
             "2c7c7df250289562",
-            "627ba0f672680054"
+            "627ba0f672680054",
+            "b7398c4e0bc743e5"
         ],
         "x": 54,
         "y": 359,
-        "w": 1272,
-        "h": 342
+        "w": 1278,
+        "h": 548
     },
     {
         "id": "53e4faf6d3ece28c",
         "type": "group",
         "z": "9269520ddb532b00",
-        "name": "record event to database and pass to dashboard",
+        "name": "create event table",
         "style": {
             "label": true
         },
         "nodes": [
             "510b389597efaf1b",
             "b77bb1c374a198e4",
-            "61d6a19c99c60e0b",
-            "a96d834e3571c549",
             "e256d5e89eb39332",
             "d8786159d48401b9",
-            "7f0ef976c7b79245",
-            "59a579e6a1fa9a08",
-            "274f87c31437c2d7",
             "6b08c9332096b857",
             "3731dfc3716b1167"
         ],
         "x": 54,
-        "y": 839,
+        "y": 1039,
         "w": 912,
-        "h": 322
+        "h": 122
     },
     {
         "id": "541d31d14bcd8b00",
@@ -543,12 +539,13 @@
             "1819134eccdf2660",
             "55a1af374cc8ecb9",
             "99dfff63ac837bc8",
-            "f35d3f484c2f6107"
+            "f35d3f484c2f6107",
+            "694f0242d0985c69"
         ],
         "x": 108,
         "y": 93,
-        "w": 924,
-        "h": 934
+        "w": 1824,
+        "h": 894
     },
     {
         "id": "fe1b9f6f9d89d353",
@@ -559,19 +556,20 @@
             "label": true
         },
         "nodes": [
-            "f453ff6136f95abe",
-            "8768b75dbfee3973",
-            "d367cb76b239682f"
+            "fac72767826a76d9",
+            "f034ca2ecdf9a2f6",
+            "8d3fe796e032166c"
         ],
-        "x": 114,
-        "y": 1119,
-        "w": 492,
-        "h": 142
+        "x": 108,
+        "y": 1053,
+        "w": 1864,
+        "h": 234
     },
     {
         "id": "8d3fe796e032166c",
         "type": "group",
         "z": "f7932be9acc7391c",
+        "g": "fe1b9f6f9d89d353",
         "name": "send tb client-side attributes",
         "style": {
             "label": true
@@ -583,8 +581,8 @@
             "9c111c8d0f212bf8",
             "8ad71425a71a860e"
         ],
-        "x": 1114,
-        "y": 1119,
+        "x": 1134,
+        "y": 1079,
         "w": 812,
         "h": 162
     },
@@ -610,6 +608,7 @@
         "id": "694f0242d0985c69",
         "type": "group",
         "z": "f7932be9acc7391c",
+        "g": "2f27e270200485b9",
         "name": "send tb telemetry",
         "style": {
             "label": true
@@ -621,8 +620,8 @@
             "93aa421659d2c20b",
             "9b8c2bcc16a637fd"
         ],
-        "x": 1114,
-        "y": 99,
+        "x": 1134,
+        "y": 119,
         "w": 772,
         "h": 162
     },
@@ -919,13 +918,12 @@
         },
         "nodes": [
             "8a83d59ee0db1198",
-            "8606059dd2f94a75",
             "c6ff73faf6fa9e98"
         ],
         "x": 134,
         "y": 679,
-        "w": 872,
-        "h": 122
+        "w": 372,
+        "h": 82
     },
     {
         "id": "99dfff63ac837bc8",
@@ -942,7 +940,7 @@
             "24c1b5f3bff3834c"
         ],
         "x": 134,
-        "y": 819,
+        "y": 779,
         "w": 392,
         "h": 82
     },
@@ -1131,9 +1129,67 @@
             "08da197b902c939e"
         ],
         "x": 134,
-        "y": 919,
-        "w": 252,
+        "y": 879,
+        "w": 352,
         "h": 82
+    },
+    {
+        "id": "fac72767826a76d9",
+        "type": "group",
+        "z": "f7932be9acc7391c",
+        "g": "fe1b9f6f9d89d353",
+        "name": "deployment",
+        "style": {
+            "label": true,
+            "fill": "#ffffbf"
+        },
+        "nodes": [
+            "f453ff6136f95abe",
+            "8768b75dbfee3973"
+        ],
+        "x": 134,
+        "y": 1179,
+        "w": 492,
+        "h": 82
+    },
+    {
+        "id": "f034ca2ecdf9a2f6",
+        "type": "group",
+        "z": "f7932be9acc7391c",
+        "g": "fe1b9f6f9d89d353",
+        "name": "system-attributes",
+        "style": {
+            "label": true,
+            "fill": "#bfc7d7"
+        },
+        "nodes": [
+            "d367cb76b239682f"
+        ],
+        "x": 134,
+        "y": 1079,
+        "w": 115,
+        "h": 82
+    },
+    {
+        "id": "b7398c4e0bc743e5",
+        "type": "group",
+        "z": "9269520ddb532b00",
+        "g": "71c085648c20e329",
+        "name": "save and forward event",
+        "style": {
+            "label": true
+        },
+        "nodes": [
+            "274f87c31437c2d7",
+            "61d6a19c99c60e0b",
+            "a96d834e3571c549",
+            "7f0ef976c7b79245",
+            "59a579e6a1fa9a08"
+        ],
+        "x": 494,
+        "y": 759,
+        "w": 812,
+        "h": 122
     },
     {
         "id": "05a58d9ee463c696",
@@ -4419,15 +4475,15 @@
         "id": "274f87c31437c2d7",
         "type": "link out",
         "z": "9269520ddb532b00",
-        "g": "53e4faf6d3ece28c",
+        "g": "b7398c4e0bc743e5",
         "name": "event payload",
         "mode": "link",
         "links": [
             "c249329109ac17d5",
             "ed447e5f8becbfad"
         ],
-        "x": 655,
-        "y": 940,
+        "x": 1265,
+        "y": 800,
         "wires": []
     },
     {
@@ -4599,13 +4655,13 @@
         "id": "61d6a19c99c60e0b",
         "type": "sqlite",
         "z": "9269520ddb532b00",
-        "g": "53e4faf6d3ece28c",
+        "g": "b7398c4e0bc743e5",
         "mydb": "2f60c1ab30a6fc8f",
         "sqlquery": "prepared",
         "sql": "INSERT INTO events (id, camera, label, sub_label, top_score, frame_time, start_time, end_time, entered_zones, score, area, ratio, motionless_count, position_changes, attributes, direction_calc, speed_calc, provenance, deployment_id, radarName) \nVALUES ($id, $camera, $label, $sub_label, $top_score, $frame_time, $start_time, $end_time, json($entered_zones), $score, $area, $ratio, $motionless_count, $position_changes, json($attributes), $direction_calc, $speed_calc, $provenance, $deployment_id, radarName);",
         "name": "tmdb.events, Prepared Statement",
-        "x": 780,
-        "y": 880,
+        "x": 680,
+        "y": 840,
         "wires": [
             []
         ]
@@ -4614,7 +4670,7 @@
         "id": "a96d834e3571c549",
         "type": "function",
         "z": "9269520ddb532b00",
-        "g": "53e4faf6d3ece28c",
+        "g": "b7398c4e0bc743e5",
         "name": "write params for events insert",
         "func": "const newMsg = {};\nnewMsg.payload = {}; // contain everything going into a DB record, single record\n\n// Frigate Event info\nnewMsg.payload.id = msg.frigate_event.id;\nnewMsg.payload.camera = msg.frigate_event.camera;\nnewMsg.payload.label = msg.frigate_event.label;\nnewMsg.payload.sub_label = msg.frigate_event.sub_label;\nnewMsg.payload.top_score = msg.frigate_event.top_score;\n//for Timestamp, frigate event and radar use seconds\nnewMsg.payload.frame_time = msg.frigate_event.frame_time;\nnewMsg.payload.start_time = msg.frigate_event.start_time;\nnewMsg.payload.end_time = msg.frigate_event.end_time;\nnewMsg.payload.entered_zones = `${JSON.stringify(msg.frigate_event.entered_zones)}`; //array, wrap in single quote for sqlite insert as text\n\nnewMsg.payload.score = msg.frigate_event.score;\nnewMsg.payload.area = msg.frigate_event.area;\nnewMsg.payload.ratio = msg.frigate_event.ratio;\nnewMsg.payload.motionless_count = msg.frigate_event.motionless_count;\nnewMsg.payload.position_changes = msg.frigate_event.position_changes;\nnewMsg.payload.attributes = `${JSON.stringify(msg.frigate_event.attributes)}`; //array, wrap in single quote for sqlite insert as text\n\n\nnewMsg.payload.direction_calc = (msg.event_direction_speed.calc_event_direction || undefined);\nnewMsg.payload.speed_calc = (msg.event_direction_speed.calc_event_speed || undefined);\n\n//provenance, frigate first, then radar, if it matched\nnewMsg.payload.provenance = [];\nnewMsg.payload.provenance.push(\"frigate\");\nif (msg.status_radarMatch === true) {\n    newMsg.payload.provenance.push(\"radar\");\n}\n\nnewMsg.payload.deployment_id = msg.frigate_event.deployment_id;\nnewMsg.payload.radarName = msg.frigate_event.radarName;\n\nconst obj = newMsg.payload;\n\nmsg.payload = newMsg.payload;\n\nconst keyedObj = Object.keys(obj).reduce((acc, key) => {\n    acc[`$${key}`] = obj[key];\n    return acc;\n}, {});\n\nmsg.params = keyedObj;\n\nreturn msg;",
         "outputs": 1,
@@ -4623,8 +4679,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 210,
-        "y": 880,
+        "x": 650,
+        "y": 800,
         "wires": [
             [
                 "61d6a19c99c60e0b",
@@ -4674,7 +4730,7 @@
         "id": "7f0ef976c7b79245",
         "type": "debug",
         "z": "9269520ddb532b00",
-        "g": "53e4faf6d3ece28c",
+        "g": "b7398c4e0bc743e5",
         "name": "composed tmdb.events message",
         "active": false,
         "tosidebar": true,
@@ -4684,15 +4740,15 @@
         "targetType": "full",
         "statusVal": "",
         "statusType": "auto",
-        "x": 300,
-        "y": 980,
+        "x": 1040,
+        "y": 840,
         "wires": []
     },
     {
         "id": "59a579e6a1fa9a08",
         "type": "function",
         "z": "9269520ddb532b00",
-        "g": "53e4faf6d3ece28c",
+        "g": "b7398c4e0bc743e5",
         "name": "cleanse final msg.payload to forward along",
         "func": "let newMsg = {};\n\nnewMsg.topic = \"tm/event\"\nnewMsg.payload = msg.payload;\n\nreturn newMsg;",
         "outputs": 1,
@@ -4701,8 +4757,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 290,
-        "y": 940,
+        "x": 1030,
+        "y": 800,
         "wires": [
             [
                 "7f0ef976c7b79245",
@@ -4906,6 +4962,402 @@
         ]
     },
     {
+        "id": "e968e39eb0de5bc1",
+        "type": "mqtt in",
+        "z": "b1fde507a4b80c79",
+        "name": "",
+        "topic": "aq/#",
+        "qos": "2",
+        "datatype": "auto-detect",
+        "broker": "a5d65dd0e3566daa",
+        "nl": false,
+        "rap": true,
+        "rh": 0,
+        "inputs": 0,
+        "x": 110,
+        "y": 100,
+        "wires": [
+            [
+                "3da49a479e99f3b5",
+                "4ef1e892a6b1c695"
+            ]
+        ]
+    },
+    {
+        "id": "3da49a479e99f3b5",
+        "type": "debug",
+        "z": "b1fde507a4b80c79",
+        "name": "debug: published airquality messages",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "true",
+        "targetType": "full",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 450,
+        "y": 100,
+        "wires": []
+    },
+    {
+        "id": "35d0362b1f8a5e1a",
+        "type": "sqlite",
+        "z": "b1fde507a4b80c79",
+        "g": "672f3b07194c5dd5",
+        "mydb": "2f60c1ab30a6fc8f",
+        "sqlquery": "msg.topic",
+        "sql": "",
+        "name": "",
+        "x": 920,
+        "y": 580,
+        "wires": [
+            [
+                "9ec2c67401c5aebc"
+            ]
+        ]
+    },
+    {
+        "id": "ad3b1bd4bcdd6731",
+        "type": "inject",
+        "z": "b1fde507a4b80c79",
+        "g": "672f3b07194c5dd5",
+        "name": "inject after 0.1 sec",
+        "props": [],
+        "repeat": "",
+        "crontab": "",
+        "once": true,
+        "onceDelay": 0.1,
+        "topic": "",
+        "x": 210,
+        "y": 580,
+        "wires": [
+            [
+                "d61da5053d3a100e"
+            ]
+        ]
+    },
+    {
+        "id": "e063e562cca50f31",
+        "type": "inject",
+        "z": "b1fde507a4b80c79",
+        "g": "672f3b07194c5dd5",
+        "name": "inject manually",
+        "props": [],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "x": 200,
+        "y": 620,
+        "wires": [
+            [
+                "e13414feb4f512b8"
+            ]
+        ]
+    },
+    {
+        "id": "9ec2c67401c5aebc",
+        "type": "debug",
+        "z": "b1fde507a4b80c79",
+        "g": "672f3b07194c5dd5",
+        "name": "debug: airquality query",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "payload",
+        "targetType": "msg",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 960,
+        "y": 620,
+        "wires": []
+    },
+    {
+        "id": "8cae4cba37aecc0d",
+        "type": "sqlite",
+        "z": "b1fde507a4b80c79",
+        "g": "efdb589a1b6e0c2f",
+        "mydb": "2f60c1ab30a6fc8f",
+        "sqlquery": "prepared",
+        "sql": "INSERT INTO airquality (entryDateTime, gas_calibrated, temp, bar, hum, dew, temp_raw, bar_raw, hum_raw, pm01, pm025, pm10, gas_red, gas_oxi, gas_nh3, gas_red_raw, gas_oxi_raw, gas_nh3_raw, lux, lux_raw, proximity, sensorName, deployment_id)\nVALUES ($entryDateTime, $gas_calibrated, $temp, $bar, $hum, $dew, $temp_raw, $bar_raw, $hum_raw, $pm01, $pm025, $pm10, $gas_red, $gas_oxi, $gas_nh3, $gas_red_raw, $gas_oxi_raw, $gas_nh3_raw, $lux, $lux_raw, $proximity, $sensorName, $deployment_id);\n",
+        "name": "",
+        "x": 1080,
+        "y": 280,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "99bfb6c2ced810ec",
+        "type": "function",
+        "z": "b1fde507a4b80c79",
+        "g": "efdb589a1b6e0c2f",
+        "name": "write params for airquality insert",
+        "func": "//format for SQLITE Insert Prepared Statement\n\nconst obj = msg.payload;\n\nconst keyedObj = Object.keys(obj).reduce((acc, key) => {\n    acc[`$${key}`] = obj[key];\n    return acc;\n}, {});\n\nmsg.params = keyedObj;\n\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 1030,
+        "y": 240,
+        "wires": [
+            [
+                "8cae4cba37aecc0d"
+            ]
+        ]
+    },
+    {
+        "id": "d61da5053d3a100e",
+        "type": "template",
+        "z": "b1fde507a4b80c79",
+        "g": "672f3b07194c5dd5",
+        "name": "create airquality table",
+        "field": "topic",
+        "fieldType": "msg",
+        "format": "sql",
+        "syntax": "mustache",
+        "template": "CREATE TABLE IF NOT EXISTS airquality (\n    entryDateTime REAL,\n    gas_calibrated INTEGER,\n    temp REAL,\n    bar REAL,\n    hum REAL,\n    dew REAL,\n    temp_raw REAL,\n    bar_raw REAL,\n    hum_raw REAL,\n    pm01 REAL,\n    pm025 REAL,\n    pm10 REAL,\n    gas_red REAL,\n    gas_oxi REAL,\n    gas_nh3 REAL,\n    gas_red_raw REAL,\n    gas_oxi_raw REAL,\n    gas_nh3_raw REAL,\n    lux REAL,\n    lux_raw REAL,\n    proximity REAL,\n    sensorName TEXT,\n    deployment_id TEXT\n);",
+        "output": "str",
+        "x": 600,
+        "y": 580,
+        "wires": [
+            [
+                "35d0362b1f8a5e1a"
+            ]
+        ]
+    },
+    {
+        "id": "e13414feb4f512b8",
+        "type": "template",
+        "z": "b1fde507a4b80c79",
+        "g": "672f3b07194c5dd5",
+        "name": "select latest 5 rows from airquality",
+        "field": "topic",
+        "fieldType": "msg",
+        "format": "sql",
+        "syntax": "mustache",
+        "template": "SELECT * \nFROM airquality \nORDER BY entryDateTime DESC \nLIMIT 5;",
+        "output": "str",
+        "x": 560,
+        "y": 620,
+        "wires": [
+            [
+                "35d0362b1f8a5e1a"
+            ]
+        ]
+    },
+    {
+        "id": "014464d29b72fa53",
+        "type": "switch",
+        "z": "b1fde507a4b80c79",
+        "g": "efdb589a1b6e0c2f",
+        "name": "enabled?",
+        "property": "sensor.enabled",
+        "propertyType": "msg",
+        "rules": [
+            {
+                "t": "true"
+            }
+        ],
+        "checkall": "true",
+        "repair": false,
+        "outputs": 1,
+        "x": 520,
+        "y": 240,
+        "wires": [
+            [
+                "24ae834ea737eac6"
+            ]
+        ]
+    },
+    {
+        "id": "24ae834ea737eac6",
+        "type": "template",
+        "z": "b1fde507a4b80c79",
+        "g": "efdb589a1b6e0c2f",
+        "name": "format mqtt for sqlite",
+        "field": "payload",
+        "fieldType": "msg",
+        "format": "handlebars",
+        "syntax": "mustache",
+        "template": "{\n    \"entryDateTime\": {{payload.current_time}},\n    \"gas_calibrated\": {{#payload.gas_calibrated}}1{{/payload.gas_calibrated}}{{^payload.gas_calibrated}}0{{/payload.gas_calibrated}},\n    \"temp\": {{payload.temp}},\n    \"bar\": {{payload.bar.0}},\n    \"hum\": {{payload.hum.0}},\n    \"dew\": {{payload.dew}},\n    \"temp_raw\": {{payload.temp_raw}},\n    \"bar_raw\": {{payload.bar_raw}},\n    \"hum_raw\": {{payload.hum_raw}},\n    \"pm01\": {{payload.pm01}},\n    \"pm025\": {{payload.pm025}},\n    \"pm10\": {{payload.pm10}},\n    \"gas_red\": {{payload.gas_red}},\n    \"gas_oxi\": {{payload.gas_oxi}},\n    \"gas_nh3\": {{payload.gas_nh3}},\n    \"gas_red_raw\": {{payload.gas_red_raw}},\n    \"gas_oxi_raw\": {{payload.gas_oxi_raw}},\n    \"gas_nh3_raw\": {{payload.gas_nh3_raw}},\n    \"lux\": {{payload.lux}},\n    \"lux_raw\": {{payload.lux_raw}},\n    \"proximity\": {{payload.proximity}},\n    \"sensorName\": \"{{sensor.name}}\",\n    \"deployment_id\": \"{{sensor.deployment_id}}\"\n}",
+        "output": "json",
+        "x": 740,
+        "y": 240,
+        "wires": [
+            [
+                "99bfb6c2ced810ec",
+                "ef6ffe823574c1d1"
+            ]
+        ]
+    },
+    {
+        "id": "ef6ffe823574c1d1",
+        "type": "link out",
+        "z": "b1fde507a4b80c79",
+        "g": "efdb589a1b6e0c2f",
+        "name": "airquality link out",
+        "mode": "link",
+        "links": [
+            "2be1c8d04ce69a48"
+        ],
+        "x": 915,
+        "y": 340,
+        "wires": []
+    },
+    {
+        "id": "78fe0447b9a69129",
+        "type": "catch",
+        "z": "b1fde507a4b80c79",
+        "name": "catch - airquality flow",
+        "scope": null,
+        "uncaught": false,
+        "x": 160,
+        "y": 40,
+        "wires": [
+            [
+                "86c57166ac231b3c"
+            ]
+        ]
+    },
+    {
+        "id": "86c57166ac231b3c",
+        "type": "debug",
+        "z": "b1fde507a4b80c79",
+        "name": "catch - airquality flow",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "true",
+        "targetType": "full",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 400,
+        "y": 40,
+        "wires": []
+    },
+    {
+        "id": "4ef1e892a6b1c695",
+        "type": "change",
+        "z": "b1fde507a4b80c79",
+        "g": "efdb589a1b6e0c2f",
+        "name": "set sensor config properties",
+        "rules": [
+            {
+                "t": "set",
+                "p": "sensor",
+                "pt": "msg",
+                "to": "$globalContext(\"config.sensors.airquality_monitors.\" & $split(topic, '/', limit)[1])\t ",
+                "tot": "jsonata"
+            },
+            {
+                "t": "set",
+                "p": "sensor.name",
+                "pt": "msg",
+                "to": "$split(topic, '/', limit)[1]",
+                "tot": "jsonata"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 440,
+        "y": 200,
+        "wires": [
+            [
+                "014464d29b72fa53"
+            ]
+        ]
+    },
+    {
+        "id": "f1530cb4468b517b",
+        "type": "inject",
+        "z": "b1fde507a4b80c79",
+        "g": "672f3b07194c5dd5",
+        "name": "inject manually",
+        "props": [],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "x": 200,
+        "y": 680,
+        "wires": [
+            [
+                "f11bc2c9463f8c85"
+            ]
+        ]
+    },
+    {
+        "id": "f11bc2c9463f8c85",
+        "type": "template",
+        "z": "b1fde507a4b80c79",
+        "g": "672f3b07194c5dd5",
+        "name": "drop",
+        "field": "topic",
+        "fieldType": "msg",
+        "format": "sql",
+        "syntax": "mustache",
+        "template": "DROP TABLE airquality;",
+        "output": "str",
+        "x": 470,
+        "y": 680,
+        "wires": [
+            [
+                "35d0362b1f8a5e1a"
+            ]
+        ]
+    },
+    {
+        "id": "3ac16ca7857d43a0",
+        "type": "inject",
+        "z": "b1fde507a4b80c79",
+        "g": "672f3b07194c5dd5",
+        "name": "inject manually",
+        "props": [],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "x": 200,
+        "y": 720,
+        "wires": [
+            [
+                "88e51d22037ef437"
+            ]
+        ]
+    },
+    {
+        "id": "88e51d22037ef437",
+        "type": "template",
+        "z": "b1fde507a4b80c79",
+        "g": "672f3b07194c5dd5",
+        "name": "pragma",
+        "field": "topic",
+        "fieldType": "msg",
+        "format": "sql",
+        "syntax": "mustache",
+        "template": "PRAGMA table_info(airquality);",
+        "output": "str",
+        "x": 480,
+        "y": 720,
+        "wires": [
+            [
+                "35d0362b1f8a5e1a"
+            ]
+        ]
+    },
+    {
         "id": "677a57bbf3619854",
         "type": "http request",
         "z": "f7932be9acc7391c",
@@ -4922,8 +5374,8 @@
         "authType": "",
         "senderr": true,
         "headers": [],
-        "x": 1530,
-        "y": 200,
+        "x": 1550,
+        "y": 220,
         "wires": [
             [
                 "df6ac2f42ac6d8c7"
@@ -4944,8 +5396,8 @@
         "targetType": "full",
         "statusVal": "",
         "statusType": "auto",
-        "x": 1740,
-        "y": 200,
+        "x": 1760,
+        "y": 220,
         "wires": []
     },
     {
@@ -5025,7 +5477,7 @@
         "type": "debug",
         "z": "f7932be9acc7391c",
         "name": "catch - thingsboard error",
-        "active": false,
+        "active": true,
         "tosidebar": true,
         "console": false,
         "tostatus": false,
@@ -5204,8 +5656,8 @@
         "drop": false,
         "allowrate": false,
         "outputs": 1,
-        "x": 1270,
-        "y": 180,
+        "x": 1290,
+        "y": 200,
         "wires": [
             [
                 "9b8c2bcc16a637fd"
@@ -5343,23 +5795,12 @@
             "1ba33a74f2d3a680"
         ],
         "x": 175,
-        "y": 760,
+        "y": 720,
         "wires": [
             [
                 "c6ff73faf6fa9e98"
             ]
         ]
-    },
-    {
-        "id": "8606059dd2f94a75",
-        "type": "comment",
-        "z": "f7932be9acc7391c",
-        "g": "55a1af374cc8ecb9",
-        "name": "upload to TB as telemetry 'deployment'",
-        "info": "",
-        "x": 830,
-        "y": 720,
-        "wires": []
     },
     {
         "id": "c6ff73faf6fa9e98",
@@ -5375,7 +5816,7 @@
         "finalize": "",
         "libs": [],
         "x": 360,
-        "y": 760,
+        "y": 720,
         "wires": [
             [
                 "93aa421659d2c20b"
@@ -5396,7 +5837,7 @@
         "finalize": "",
         "libs": [],
         "x": 370,
-        "y": 860,
+        "y": 820,
         "wires": [
             [
                 "93aa421659d2c20b"
@@ -5413,7 +5854,7 @@
             "6dca925fad91c100"
         ],
         "x": 175,
-        "y": 860,
+        "y": 820,
         "wires": [
             [
                 "521115ddd5741eea"
@@ -5434,8 +5875,8 @@
         "targetType": "full",
         "statusVal": "",
         "statusType": "auto",
-        "x": 1780,
-        "y": 1220,
+        "x": 1800,
+        "y": 1180,
         "wires": []
     },
     {
@@ -5462,8 +5903,8 @@
                 "valueValue": ""
             }
         ],
-        "x": 1550,
-        "y": 1220,
+        "x": 1570,
+        "y": 1180,
         "wires": [
             [
                 "542b3b8720733a01"
@@ -5474,7 +5915,7 @@
         "id": "f453ff6136f95abe",
         "type": "function",
         "z": "f7932be9acc7391c",
-        "g": "fe1b9f6f9d89d353",
+        "g": "fac72767826a76d9",
         "name": "set deployment client side attribute payload",
         "func": "var newMsg = {};\n\n// format the payload with a timestamp\nlet values = {\n    ...msg.payload.currentDeployment,\n}\n//ts in milliseconds\nnewMsg.payload = {\n    ts: new Date().getTime(),\n    values: {\n        deploymentSensors: values,\n        deploymentTopLat: global.get(\"config.deployment.lat\",'config'),\n        deploymentTopLon: global.get(\"config.deployment.lon\",'config'),\n        deploymentTopBearing: global.get(\"config.deployment.bearing\",'config')\n    }\n}\n\nreturn newMsg;\n\n//global.set(`config.sensors.${sensorType}.${sensorName}.deployment.id`, newPayload.id, 'config');\n",
         "outputs": 1,
@@ -5483,7 +5924,7 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 410,
+        "x": 430,
         "y": 1220,
         "wires": [
             [
@@ -5495,12 +5936,12 @@
         "id": "8768b75dbfee3973",
         "type": "link in",
         "z": "f7932be9acc7391c",
-        "g": "fe1b9f6f9d89d353",
+        "g": "fac72767826a76d9",
         "name": "deployment attributes send, link in",
         "links": [
             "1ba33a74f2d3a680"
         ],
-        "x": 155,
+        "x": 175,
         "y": 1220,
         "wires": [
             [
@@ -5512,14 +5953,14 @@
         "id": "d367cb76b239682f",
         "type": "link in",
         "z": "f7932be9acc7391c",
-        "g": "fe1b9f6f9d89d353",
+        "g": "f034ca2ecdf9a2f6",
         "name": "tb attributes link in",
         "links": [
             "486556a1e7fce8cf",
             "7c96d66a8330a4fc"
         ],
-        "x": 155,
-        "y": 1160,
+        "x": 175,
+        "y": 1120,
         "wires": [
             [
                 "058c390e87e3c283"
@@ -5542,8 +5983,8 @@
         "checkall": "true",
         "repair": false,
         "outputs": 1,
-        "x": 1240,
-        "y": 140,
+        "x": 1260,
+        "y": 160,
         "wires": [
             [
                 "21944450ecc08385"
@@ -5573,8 +6014,8 @@
         "checkall": "true",
         "repair": false,
         "outputs": 2,
-        "x": 1330,
-        "y": 220,
+        "x": 1350,
+        "y": 240,
         "wires": [
             [
                 "677a57bbf3619854"
@@ -5599,8 +6040,8 @@
         "checkall": "true",
         "repair": false,
         "outputs": 1,
-        "x": 1240,
-        "y": 1160,
+        "x": 1260,
+        "y": 1120,
         "wires": [
             [
                 "9c111c8d0f212bf8"
@@ -5625,8 +6066,8 @@
         "drop": false,
         "allowrate": false,
         "outputs": 1,
-        "x": 1270,
-        "y": 1200,
+        "x": 1290,
+        "y": 1160,
         "wires": [
             [
                 "8ad71425a71a860e"
@@ -5656,8 +6097,8 @@
         "checkall": "true",
         "repair": false,
         "outputs": 2,
-        "x": 1330,
-        "y": 1240,
+        "x": 1350,
+        "y": 1200,
         "wires": [
             [
                 "0a28f82092611160"
@@ -5694,7 +6135,7 @@
             "ef6ffe823574c1d1"
         ],
         "x": 175,
-        "y": 960,
+        "y": 920,
         "wires": [
             [
                 "08da197b902c939e"
@@ -5706,17 +6147,19 @@
         "type": "template",
         "z": "f7932be9acc7391c",
         "g": "f35d3f484c2f6107",
-        "name": "",
+        "name": "format airquality telemetry",
         "field": "payload",
         "fieldType": "msg",
         "format": "handlebars",
         "syntax": "mustache",
-        "template": "This is the payload: {{payload}} !",
-        "output": "str",
-        "x": 300,
-        "y": 960,
+        "template": "{\n    \"ts\":{{payload.entryDateTime}},\n    \"values\": {\n        \"airquality\": {\n            \"entryDateTime\": {{payload.entryDateTime}},\n            \"gas_calibrated\": {{payload.gas_calibrated}},\n            \"temp\": {{payload.temp}},\n            \"bar\": {{payload.bar}},\n            \"hum\": {{payload.hum}},\n            \"dew\": {{payload.dew}},\n            \"temp_raw\": {{payload.temp_raw}},\n            \"bar_raw\": {{payload.bar_raw}},\n            \"hum_raw\": {{payload.hum_raw}},\n            \"pm01\": {{payload.pm01}},\n            \"pm025\": {{payload.pm025}},\n            \"pm10\": {{payload.pm10}},\n            \"gas_red\": {{payload.gas_red}},\n            \"gas_oxi\": {{payload.gas_oxi}},\n            \"gas_nh3\": {{payload.gas_nh3}},\n            \"gas_red_raw\": {{payload.gas_red_raw}},\n            \"gas_oxi_raw\": {{payload.gas_oxi_raw}},\n            \"gas_nh3_raw\": {{payload.gas_nh3_raw}},\n            \"lux\": {{payload.lux}},\n            \"lux_raw\": {{payload.lux_raw}},\n            \"proximity\": {{payload.proximity}},\n            \"sensorName\": \"{{payload.sensorName}}\",\n            \"deployment_id\": \"{{payload.deployment_id}}\"\n        }\n    }\n}",
+        "output": "json",
+        "x": 350,
+        "y": 920,
         "wires": [
-            []
+            [
+                "93aa421659d2c20b"
+            ]
         ]
     },
     {
@@ -11300,401 +11743,5 @@
         "x": 1160,
         "y": 400,
         "wires": []
-    },
-    {
-        "id": "e968e39eb0de5bc1",
-        "type": "mqtt in",
-        "z": "b1fde507a4b80c79",
-        "name": "",
-        "topic": "aq/#",
-        "qos": "2",
-        "datatype": "auto-detect",
-        "broker": "a5d65dd0e3566daa",
-        "nl": false,
-        "rap": true,
-        "rh": 0,
-        "inputs": 0,
-        "x": 110,
-        "y": 100,
-        "wires": [
-            [
-                "3da49a479e99f3b5",
-                "4ef1e892a6b1c695"
-            ]
-        ]
-    },
-    {
-        "id": "3da49a479e99f3b5",
-        "type": "debug",
-        "z": "b1fde507a4b80c79",
-        "name": "debug: published airquality messages",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "true",
-        "targetType": "full",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 450,
-        "y": 100,
-        "wires": []
-    },
-    {
-        "id": "35d0362b1f8a5e1a",
-        "type": "sqlite",
-        "z": "b1fde507a4b80c79",
-        "g": "672f3b07194c5dd5",
-        "mydb": "2f60c1ab30a6fc8f",
-        "sqlquery": "msg.topic",
-        "sql": "",
-        "name": "",
-        "x": 920,
-        "y": 580,
-        "wires": [
-            [
-                "9ec2c67401c5aebc"
-            ]
-        ]
-    },
-    {
-        "id": "ad3b1bd4bcdd6731",
-        "type": "inject",
-        "z": "b1fde507a4b80c79",
-        "g": "672f3b07194c5dd5",
-        "name": "inject after 0.1 sec",
-        "props": [],
-        "repeat": "",
-        "crontab": "",
-        "once": true,
-        "onceDelay": 0.1,
-        "topic": "",
-        "x": 210,
-        "y": 580,
-        "wires": [
-            [
-                "d61da5053d3a100e"
-            ]
-        ]
-    },
-    {
-        "id": "e063e562cca50f31",
-        "type": "inject",
-        "z": "b1fde507a4b80c79",
-        "g": "672f3b07194c5dd5",
-        "name": "inject manually",
-        "props": [],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "",
-        "x": 200,
-        "y": 620,
-        "wires": [
-            [
-                "e13414feb4f512b8"
-            ]
-        ]
-    },
-    {
-        "id": "9ec2c67401c5aebc",
-        "type": "debug",
-        "z": "b1fde507a4b80c79",
-        "g": "672f3b07194c5dd5",
-        "name": "debug: airquality query",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "payload",
-        "targetType": "msg",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 960,
-        "y": 620,
-        "wires": []
-    },
-    {
-        "id": "8cae4cba37aecc0d",
-        "type": "sqlite",
-        "z": "b1fde507a4b80c79",
-        "g": "efdb589a1b6e0c2f",
-        "mydb": "2f60c1ab30a6fc8f",
-        "sqlquery": "prepared",
-        "sql": "INSERT INTO airquality (entryDateTime, gas_calibrated, temp, bar, hum, dew, temp_raw, bar_raw, hum_raw, pm01, pm025, pm10, gas_red, gas_oxi, gas_nh3, gas_red_raw, gas_oxi_raw, gas_nh3_raw, lux, lux_raw, proximity, noise_level, sensorName, deployment_id)\nVALUES ($entryDateTime, $gas_calibrated, $temp, $bar, $hum, $dew, $temp_raw, $bar_raw, $hum_raw, $pm01, $pm025, $pm10, $gas_red, $gas_oxi, $gas_nh3, $gas_red_raw, $gas_oxi_raw, $gas_nh3_raw, $lux, $lux_raw, $proximity, $noise_level, $sensorName, $deployment_id);\n",
-        "name": "",
-        "x": 1080,
-        "y": 280,
-        "wires": [
-            []
-        ]
-    },
-    {
-        "id": "99bfb6c2ced810ec",
-        "type": "function",
-        "z": "b1fde507a4b80c79",
-        "g": "efdb589a1b6e0c2f",
-        "name": "write params for airquality insert",
-        "func": "//format for SQLITE Insert Prepared Statement\n\nconst obj = msg.payload;\n\nconst keyedObj = Object.keys(obj).reduce((acc, key) => {\n    acc[`$${key}`] = obj[key];\n    return acc;\n}, {});\n\nmsg.params = keyedObj;\n\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 1030,
-        "y": 240,
-        "wires": [
-            [
-                "8cae4cba37aecc0d"
-            ]
-        ]
-    },
-    {
-        "id": "d61da5053d3a100e",
-        "type": "template",
-        "z": "b1fde507a4b80c79",
-        "g": "672f3b07194c5dd5",
-        "name": "create airquality table",
-        "field": "topic",
-        "fieldType": "msg",
-        "format": "sql",
-        "syntax": "mustache",
-        "template": "CREATE TABLE IF NOT EXISTS airquality (\n    entryDateTime REAL,\n    gas_calibrated INTEGER,\n    temp REAL,\n    bar REAL,\n    hum REAL,\n    dew REAL,\n    temp_raw REAL,\n    bar_raw REAL,\n    hum_raw REAL,\n    pm01 REAL,\n    pm025 REAL,\n    pm10 REAL,\n    gas_red REAL,\n    gas_oxi REAL,\n    gas_nh3 REAL,\n    gas_red_raw REAL,\n    gas_oxi_raw REAL,\n    gas_nh3_raw REAL,\n    lux REAL,\n    lux_raw REAL,\n    proximity REAL,\n    noise_level REAL,\n    sensorName TEXT,\n    deployment_id TEXT\n);",
-        "output": "str",
-        "x": 600,
-        "y": 580,
-        "wires": [
-            [
-                "35d0362b1f8a5e1a"
-            ]
-        ]
-    },
-    {
-        "id": "e13414feb4f512b8",
-        "type": "template",
-        "z": "b1fde507a4b80c79",
-        "g": "672f3b07194c5dd5",
-        "name": "select latest 5 rows from airquality",
-        "field": "topic",
-        "fieldType": "msg",
-        "format": "sql",
-        "syntax": "mustache",
-        "template": "SELECT * \nFROM airquality \nORDER BY entryDateTime DESC \nLIMIT 5;",
-        "output": "str",
-        "x": 560,
-        "y": 620,
-        "wires": [
-            [
-                "35d0362b1f8a5e1a"
-            ]
-        ]
-    },
-    {
-        "id": "014464d29b72fa53",
-        "type": "switch",
-        "z": "b1fde507a4b80c79",
-        "g": "efdb589a1b6e0c2f",
-        "name": "enabled?",
-        "property": "sensor.enabled",
-        "propertyType": "msg",
-        "rules": [
-            {
-                "t": "true"
-            }
-        ],
-        "checkall": "true",
-        "repair": false,
-        "outputs": 1,
-        "x": 520,
-        "y": 240,
-        "wires": [
-            [
-                "24ae834ea737eac6"
-            ]
-        ]
-    },
-    {
-        "id": "24ae834ea737eac6",
-        "type": "template",
-        "z": "b1fde507a4b80c79",
-        "g": "efdb589a1b6e0c2f",
-        "name": "format mqtt for sqlite",
-        "field": "payload",
-        "fieldType": "msg",
-        "format": "handlebars",
-        "syntax": "mustache",
-        "template": "{\n    \"entryDateTime\": {{payload.current_time}},\n    \"gas_calibrated\": {{#payload.gas_calibrated}}1{{/payload.gas_calibrated}}{{^payload.gas_calibrated}}0{{/payload.gas_calibrated}},\n    \"temp\": {{payload.temp}},\n    \"bar\": {{payload.bar.0}},\n    \"hum\": {{payload.hum.0}},\n    \"dew\": {{payload.dew}},\n    \"temp_raw\": {{payload.temp_raw}},\n    \"bar_raw\": {{payload.bar_raw}},\n    \"hum_raw\": {{payload.hum_raw}},\n    \"pm01\": {{payload.p01}},\n    \"pm025\": {{payload.p025}},\n    \"pm10\": {{payload.p10}},\n    \"gas_red\": {{payload.gas_red}},\n    \"gas_oxi\": {{payload.gas_oxi}},\n    \"gas_nh3\": {{payload.gas_nh3}},\n    \"gas_red_raw\": {{payload.gas_red_raw}},\n    \"gas_oxi_raw\": {{payload.gas_oxi_raw}},\n    \"gas_nh3_raw\": {{payload.gas_nh3_raw}},\n    \"lux\": {{payload.lux}},\n    \"lux_raw\": {{payload.lux_raw}},\n    \"proximity\": {{payload.proximity}},\n    \"noise_level\": \"\",\n    \"sensorName\": \"{{sensor.name}}\",\n    \"deployment_id\": \"{{sensor.deployment_id}}\"\n}",
-        "output": "json",
-        "x": 740,
-        "y": 240,
-        "wires": [
-            [
-                "99bfb6c2ced810ec",
-                "ef6ffe823574c1d1"
-            ]
-        ]
-    },
-    {
-        "id": "ef6ffe823574c1d1",
-        "type": "link out",
-        "z": "b1fde507a4b80c79",
-        "g": "efdb589a1b6e0c2f",
-        "name": "airquality link out",
-        "mode": "link",
-        "links": [
-            "2be1c8d04ce69a48"
-        ],
-        "x": 915,
-        "y": 340,
-        "wires": []
-    },
-    {
-        "id": "78fe0447b9a69129",
-        "type": "catch",
-        "z": "b1fde507a4b80c79",
-        "name": "catch - airquality flow",
-        "scope": null,
-        "uncaught": false,
-        "x": 160,
-        "y": 40,
-        "wires": [
-            [
-                "86c57166ac231b3c"
-            ]
-        ]
-    },
-    {
-        "id": "86c57166ac231b3c",
-        "type": "debug",
-        "z": "b1fde507a4b80c79",
-        "name": "catch - airquality flow",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "true",
-        "targetType": "full",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 400,
-        "y": 40,
-        "wires": []
-    },
-    {
-        "id": "4ef1e892a6b1c695",
-        "type": "change",
-        "z": "b1fde507a4b80c79",
-        "g": "efdb589a1b6e0c2f",
-        "name": "set sensor config properties",
-        "rules": [
-            {
-                "t": "set",
-                "p": "sensor",
-                "pt": "msg",
-                "to": "$globalContext(\"config.sensors.airquality_monitors.\" & $split(topic, '/', limit)[1])\t ",
-                "tot": "jsonata"
-            },
-            {
-                "t": "set",
-                "p": "sensor.name",
-                "pt": "msg",
-                "to": "$split(topic, '/', limit)[1]",
-                "tot": "jsonata"
-            }
-        ],
-        "action": "",
-        "property": "",
-        "from": "",
-        "to": "",
-        "reg": false,
-        "x": 440,
-        "y": 200,
-        "wires": [
-            [
-                "014464d29b72fa53"
-            ]
-        ]
-    },
-    {
-        "id": "f1530cb4468b517b",
-        "type": "inject",
-        "z": "b1fde507a4b80c79",
-        "g": "672f3b07194c5dd5",
-        "name": "inject manually",
-        "props": [],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "",
-        "x": 200,
-        "y": 680,
-        "wires": [
-            [
-                "f11bc2c9463f8c85"
-            ]
-        ]
-    },
-    {
-        "id": "f11bc2c9463f8c85",
-        "type": "template",
-        "z": "b1fde507a4b80c79",
-        "g": "672f3b07194c5dd5",
-        "name": "drop",
-        "field": "topic",
-        "fieldType": "msg",
-        "format": "sql",
-        "syntax": "mustache",
-        "template": "DROP TABLE airquality;",
-        "output": "str",
-        "x": 470,
-        "y": 680,
-        "wires": [
-            [
-                "35d0362b1f8a5e1a"
-            ]
-        ]
-    },
-    {
-        "id": "3ac16ca7857d43a0",
-        "type": "inject",
-        "z": "b1fde507a4b80c79",
-        "g": "672f3b07194c5dd5",
-        "name": "inject manually",
-        "props": [],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "",
-        "x": 200,
-        "y": 720,
-        "wires": [
-            [
-                "88e51d22037ef437"
-            ]
-        ]
-    },
-    {
-        "id": "88e51d22037ef437",
-        "type": "template",
-        "z": "b1fde507a4b80c79",
-        "g": "672f3b07194c5dd5",
-        "name": "pragma",
-        "field": "topic",
-        "fieldType": "msg",
-        "format": "sql",
-        "syntax": "mustache",
-        "template": "PRAGMA table_info(airquality);",
-        "output": "str",
-        "x": 480,
-        "y": 720,
-        "wires": [
-            [
-                "35d0362b1f8a5e1a"
-            ]
-        ]
     }
 ]

--- a/node-red-project/flows.json
+++ b/node-red-project/flows.json
@@ -64,6 +64,14 @@
         "env": []
     },
     {
+        "id": "b1fde507a4b80c79",
+        "type": "tab",
+        "label": "capture-aq",
+        "disabled": false,
+        "info": "",
+        "env": []
+    },
+    {
         "id": "0a6e123f5e53c029",
         "type": "group",
         "z": "28627559bebdc324",
@@ -11166,6 +11174,74 @@
         "statusType": "auto",
         "x": 1160,
         "y": 400,
+        "wires": []
+    },
+    {
+        "id": "e968e39eb0de5bc1",
+        "type": "mqtt in",
+        "z": "b1fde507a4b80c79",
+        "name": "",
+        "topic": "aq/#",
+        "qos": "2",
+        "datatype": "auto-detect",
+        "broker": "a5d65dd0e3566daa",
+        "nl": false,
+        "rap": true,
+        "rh": 0,
+        "inputs": 0,
+        "x": 110,
+        "y": 60,
+        "wires": [
+            [
+                "3da49a479e99f3b5"
+            ]
+        ]
+    },
+    {
+        "id": "3da49a479e99f3b5",
+        "type": "debug",
+        "z": "b1fde507a4b80c79",
+        "name": "debug 1",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "true",
+        "targetType": "full",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 330,
+        "y": 60,
+        "wires": []
+    },
+    {
+        "id": "5afaf6995a6bb8cf",
+        "type": "comment",
+        "z": "b1fde507a4b80c79",
+        "name": "attach timestamp, entryDateTime",
+        "info": "",
+        "x": 390,
+        "y": 200,
+        "wires": []
+    },
+    {
+        "id": "3d42c2ee8cdbb69e",
+        "type": "comment",
+        "z": "b1fde507a4b80c79",
+        "name": "check if enabled",
+        "info": "",
+        "x": 180,
+        "y": 140,
+        "wires": []
+    },
+    {
+        "id": "d00238beae2aadd7",
+        "type": "comment",
+        "z": "b1fde507a4b80c79",
+        "name": "create table airquality",
+        "info": "",
+        "x": 420,
+        "y": 460,
         "wires": []
     }
 ]

--- a/node-red-project/flows.json
+++ b/node-red-project/flows.json
@@ -541,8 +541,8 @@
             "55a1af374cc8ecb9",
             "99dfff63ac837bc8",
             "f35d3f484c2f6107",
-            "aa8d606460d6e410",
-            "221ddfedf40c108f"
+            "221ddfedf40c108f",
+            "8c521232f464d27a"
         ],
         "x": 108,
         "y": 93,
@@ -561,12 +561,12 @@
             "fac72767826a76d9",
             "f034ca2ecdf9a2f6",
             "75f7976086cc9838",
-            "232db2c330aebd95"
+            "fdb3962b458f90c2"
         ],
         "x": 108,
-        "y": 1053,
+        "y": 999,
         "w": 1198,
-        "h": 234
+        "h": 368
     },
     {
         "id": "9e0b1edd49eb4244",
@@ -816,6 +816,25 @@
         "h": 222
     },
     {
+        "id": "694f0242d0985c69",
+        "type": "group",
+        "z": "f7932be9acc7391c",
+        "name": "send to tb",
+        "style": {
+            "label": true
+        },
+        "nodes": [
+            "21944450ecc08385",
+            "93aa421659d2c20b",
+            "9b8c2bcc16a637fd",
+            "43087a735f896849"
+        ],
+        "x": 1374,
+        "y": 93,
+        "w": 1118,
+        "h": 188
+    },
+    {
         "id": "b334a2375eb8cb42",
         "type": "group",
         "z": "f7932be9acc7391c",
@@ -852,13 +871,15 @@
             "e05e91362c933e94",
             "9f5540b6beae8e73",
             "3fb645608f34cc0c",
-            "2a979d76853ee0ab",
             "cc21b9e657cba081",
             "ff1719e60656a2e6",
             "d3f14c01ec3c7250",
-            "5d3596375bd695c0",
             "4796b517d7d045a7",
-            "9a894f4bd304f5a9"
+            "9a894f4bd304f5a9",
+            "5d3596375bd695c0",
+            "f29975eb207b5b8d",
+            "1711871384d75e10",
+            "6c582e93dfb3d6fa"
         ],
         "x": 134,
         "y": 219,
@@ -1094,11 +1115,11 @@
             "fill": "#ffffbf"
         },
         "nodes": [
-            "f453ff6136f95abe",
-            "8768b75dbfee3973"
+            "8768b75dbfee3973",
+            "9b0f7197fe82bbfa"
         ],
         "x": 134,
-        "y": 1179,
+        "y": 1259,
         "w": 492,
         "h": 82
     },
@@ -1113,12 +1134,15 @@
             "fill": "#bfc7d7"
         },
         "nodes": [
-            "d367cb76b239682f"
+            "d367cb76b239682f",
+            "e507fdc9cbf67095",
+            "0b62cae60d488c85",
+            "4af0d78e8bc39647"
         ],
         "x": 134,
         "y": 1079,
-        "w": 115,
-        "h": 82
+        "w": 472,
+        "h": 142
     },
     {
         "id": "b7398c4e0bc743e5",
@@ -1139,6 +1163,27 @@
         "x": 494,
         "y": 759,
         "w": 812,
+        "h": 122
+    },
+    {
+        "id": "43087a735f896849",
+        "type": "group",
+        "z": "f7932be9acc7391c",
+        "g": "694f0242d0985c69",
+        "name": "tb http api",
+        "style": {
+            "label": true
+        },
+        "nodes": [
+            "677a57bbf3619854",
+            "df6ac2f42ac6d8c7",
+            "9c944328e288b2dc",
+            "dd3f9ef16332021c",
+            "d739b10ce5fa8f40"
+        ],
+        "x": 1714,
+        "y": 119,
+        "w": 752,
         "h": 122
     },
     {
@@ -1166,46 +1211,6 @@
         "y": 859,
         "w": 932,
         "h": 242
-    },
-    {
-        "id": "694f0242d0985c69",
-        "type": "group",
-        "z": "f7932be9acc7391c",
-        "name": "send to tb",
-        "style": {
-            "label": true
-        },
-        "nodes": [
-            "21944450ecc08385",
-            "93aa421659d2c20b",
-            "9b8c2bcc16a637fd",
-            "43087a735f896849"
-        ],
-        "x": 1374,
-        "y": 93,
-        "w": 1118,
-        "h": 194
-    },
-    {
-        "id": "43087a735f896849",
-        "type": "group",
-        "z": "f7932be9acc7391c",
-        "g": "694f0242d0985c69",
-        "name": "tb http api",
-        "style": {
-            "label": true
-        },
-        "nodes": [
-            "677a57bbf3619854",
-            "df6ac2f42ac6d8c7",
-            "9c944328e288b2dc",
-            "dd3f9ef16332021c",
-            "d739b10ce5fa8f40"
-        ],
-        "x": 1714,
-        "y": 119,
-        "w": 752,
-        "h": 142
     },
     {
         "id": "05a58d9ee463c696",
@@ -1311,25 +1316,12 @@
         ]
     },
     {
-        "id": "232db2c330aebd95",
-        "type": "junction",
-        "z": "f7932be9acc7391c",
-        "g": "fe1b9f6f9d89d353",
-        "x": 740,
-        "y": 1120,
-        "wires": [
-            [
-                "75f7976086cc9838"
-            ]
-        ]
-    },
-    {
-        "id": "aa8d606460d6e410",
+        "id": "8c521232f464d27a",
         "type": "junction",
         "z": "f7932be9acc7391c",
         "g": "2f27e270200485b9",
-        "x": 1060,
-        "y": 160,
+        "x": 1000,
+        "y": 620,
         "wires": [
             [
                 "221ddfedf40c108f"
@@ -2073,7 +2065,7 @@
         "z": "3dae026ab340962a",
         "g": "8004ba7ad5a9bd83",
         "name": "capture deployment info, send diff sql queries",
-        "func": "// msg.sqlActiveDeployments (sql query results, array of objects)\n// msg.sensors (sensorType.sensorName.properties)\n\nlet newArr = {};\nnewArr.updatedDeployment = [];\nnewArr.currentDeployment = [];\n\nconst sqlresults = msg.sqlActiveDeployments;\n\n//go through each sensor, see if new deployment configs (lat, lon, bearing) are different from previous deployment\nfor (const [sensorType, sensors] of Object.entries(msg.sensors)) {\n    for (const [sensorName, sensor] of Object.entries(sensors)) {\n        if (sensor.hasOwnProperty('enabled') && sensor.enabled === true) {\n            if (sensor.hasOwnProperty('deployment')) {\n                const sensorDeployment = sensor.deployment;\n\n                let newMsg = {};\n                newMsg.payload = {};\n                let updateMsg = {};\n                updateMsg.payload = {};\n                let mergedMsg = {};\n\n                let hasDifference = false;\n                newMsg.sqlSend = false;\n\n                //find matching sqlresult(s)\n                const sqlMatchObj = sqlresults.find(o => o.sensorName === sensorName);\n\n                if (sqlMatchObj) {\n                    //fields to check for differences\n                    [\"lat\", \"lon\", \"bearing\"].forEach(property => {\n                        if (sqlMatchObj[property] !== sensorDeployment[property]) {\n                            hasDifference = true;\n                        }\n                    });\n                }\n\n                //if new deployment, UPDATE old record's entryEndDateTime \n                if (hasDifference) {\n                    updateMsg.payload.id = sqlMatchObj.id;\n                    updateMsg.payload.entryEndDateTime = (new Date()).getTime();\n\n                    //send update query, updateMsg\n                    updateMsg.topic = `UPDATE deployment SET entryEndDateTime = ${updateMsg.payload.entryEndDateTime} WHERE id = '${updateMsg.payload.id}'`;\n                    updateMsg.sqlSend = true;\n                    node.send(updateMsg);\n                    mergedMsg = {...updateMsg.payload, ...sqlMatchObj};\n                    newArr.updatedDeployment.push(mergedMsg);\n                }\n\n                //if new deployment from difference or non-existing, and add new record\n                if (hasDifference || !sqlMatchObj) {\n                    const newDateTime = new Date();\n                    newMsg.payload.id = newDateTime.getTime() + '-' + Math.floor(Math.random() * 0xFFFFFFFF).toString(16).padStart(8, '0') + '-d';\n                    newMsg.payload.entryStartDateTime = newDateTime.getTime();\n                    newMsg.payload.entryEndDateTime = '';\n                    newMsg.payload.lat = sensorDeployment[\"lat\"];\n                    newMsg.payload.lon = sensorDeployment[\"lon\"];\n                    newMsg.payload.bearing = sensorDeployment[\"bearing\"];\n                    newMsg.payload.sensorType = sensorType;\n                    newMsg.payload.sensorName = sensorName;\n                    newMsg.payload.deviceName = global.get(\"deviceAttributes.deviceName\");\n                    //send add record query, newPayload\n                    newMsg.topic = `INSERT INTO deployment (id, entryStartDateTime, lat, lon, bearing, sensorType, sensorName, deviceName) VALUES ('${newMsg.payload.id}', ${newMsg.payload.entryStartDateTime}, ${newMsg.payload.lat}, ${newMsg.payload.lon}, '${newMsg.payload.bearing}', '${newMsg.payload.sensorType}', '${newMsg.payload.sensorName}', '${newMsg.payload.deviceName}')`;\n                    newMsg.sqlSend = true;\n                    node.send(newMsg);\n\n                    //update config with id\n                    global.set(`config.sensors.${sensorType}.${sensorName}.deployment.id`, newMsg.payload.id);\n                }\n                else {\n                    newMsg.payload = sqlMatchObj;\n                }\n                //collect all sensor info for output\n                newArr.currentDeployment.push(newMsg.payload);\n            }\n        }\n    }\n}\n\nmsg = {};\nmsg.payload = newArr;\n\nnode.done();\nreturn msg;",
+        "func": "// msg.sqlActiveDeployments (sql query results, array of objects)\n// msg.sensors (sensorType.sensorName.properties)\n\nlet newArr = {};\nnewArr.updatedDeployment = [];\nnewArr.currentDeployment = [];\n\nconst sqlresults = msg.sqlActiveDeployments;\n\n//go through each sensor, see if new deployment configs (lat, lon, bearing) are different from previous deployment\nfor (const [sensorType, sensors] of Object.entries(msg.sensors)) {\n    for (const [sensorName, sensor] of Object.entries(sensors)) {\n        if (sensor.hasOwnProperty('enabled') && sensor.enabled === true) {\n            if (sensor.hasOwnProperty('deployment')) {\n                const sensorDeployment = sensor.deployment;\n\n                let newMsg = {};\n                newMsg.payload = {};\n                let updateMsg = {};\n                updateMsg.payload = {};\n                let mergedMsg = {};\n\n                let hasDifference = false;\n                newMsg.sqlSend = false;\n\n                //find matching sqlresult(s)\n                const sqlMatchObj = sqlresults.find(o => o.sensorName === sensorName);\n\n                if (sqlMatchObj) {\n                    //fields to check for differences\n                    [\"lat\", \"lon\", \"bearing\"].forEach(property => {\n                        if (sqlMatchObj[property] !== sensorDeployment[property]) {\n                            hasDifference = true;\n                        }\n                    });\n                }\n\n                //if new deployment, UPDATE old record's entryEndDateTime \n                if (hasDifference) {\n                    updateMsg.payload.id = sqlMatchObj.id;\n                    updateMsg.payload.entryEndDateTime = (new Date()).getTime();\n\n                    //send update query, updateMsg\n                    updateMsg.topic = `UPDATE deployment SET entryEndDateTime = ${updateMsg.payload.entryEndDateTime} WHERE id = '${updateMsg.payload.id}'`;\n                    updateMsg.sqlSend = true;\n                    node.send(updateMsg);\n                    mergedMsg = {...updateMsg.payload, ...sqlMatchObj};\n                    newArr.updatedDeployment.push(mergedMsg);\n                }\n\n                //if new deployment from difference or non-existing, and add new record\n                if (hasDifference || !sqlMatchObj) {\n                    const newDateTime = new Date();\n                    newMsg.payload.id = newDateTime.getTime() + '-' + Math.floor(Math.random() * 0xFFFFFFFF).toString(16).padStart(8, '0') + '-d';\n                    newMsg.payload.entryStartDateTime = newDateTime.getTime();\n                    newMsg.payload.entryEndDateTime = '';\n                    newMsg.payload.lat = sensorDeployment[\"lat\"];\n                    newMsg.payload.lon = sensorDeployment[\"lon\"];\n                    newMsg.payload.bearing = sensorDeployment[\"bearing\"];\n                    newMsg.payload.sensorType = sensorType;\n                    newMsg.payload.sensorName = sensorName;\n                    newMsg.payload.deviceName = global.get(\"deviceAttributes.deviceName\");\n                    //send add record query, newPayload\n                    newMsg.topic = `INSERT INTO deployment (id, entryStartDateTime, lat, lon, bearing, sensorType, sensorName, deviceName) VALUES ('${newMsg.payload.id}', ${newMsg.payload.entryStartDateTime}, ${newMsg.payload.lat}, ${newMsg.payload.lon}, '${newMsg.payload.bearing}', '${newMsg.payload.sensorType}', '${newMsg.payload.sensorName}', '${newMsg.payload.deviceName}')`;\n                    newMsg.sqlSend = true;\n                    node.send(newMsg);\n\n                    //update config with id\n                    global.set(`config.sensors.${sensorType}.${sensorName}.deployment.id`, newMsg.payload.id);\n                }\n                //deployment already exists, no change\n                else {\n                    newMsg.payload = sqlMatchObj;\n                    global.set(`config.sensors.${sensorType}.${sensorName}.deployment.id`, sqlMatchObj.id);\n                }\n                //collect all sensor info for output\n                newArr.currentDeployment.push(newMsg.payload);\n            }\n        }\n    }\n}\n\nmsg = {};\nmsg.payload = newArr;\n\nnode.done();\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
         "noerr": 0,
@@ -2182,7 +2174,7 @@
         "z": "3dae026ab340962a",
         "g": "8004ba7ad5a9bd83",
         "name": "latest deployment info",
-        "active": false,
+        "active": true,
         "tosidebar": true,
         "console": false,
         "tostatus": false,
@@ -2232,7 +2224,7 @@
         "fieldType": "msg",
         "format": "sql",
         "syntax": "mustache",
-        "template": "SELECT id, entryStartDateTime, lat, lon, bearing, sensorName, deviceName\nFROM deployment\nWHERE entryStartDateTime IN(\n  SELECT MAX(entryStartDateTime)\n  FROM deployment\n  WHERE entryEndDateTime IS NULL\n  GROUP BY sensorName, deviceName\n)\nORDER BY sensorName, deviceName;\n",
+        "template": "SELECT id, entryStartDateTime, lat, lon, bearing, sensorType, sensorName, deviceName\nFROM deployment\nWHERE entryStartDateTime IN(\n  SELECT MAX(entryStartDateTime)\n  FROM deployment\n  WHERE entryEndDateTime IS NULL\n  GROUP BY sensorName, deviceName\n)\nORDER BY sensorName, deviceName;\n",
         "output": "str",
         "x": 290,
         "y": 520,
@@ -2292,7 +2284,7 @@
         "fieldType": "msg",
         "format": "sql",
         "syntax": "mustache",
-        "template": "SELECT id, entryStartDateTime, sensorType, sensorName, deviceName \nFROM deployment \nWHERE entryStartDateTime IN (   \n    SELECT MAX(entryStartDateTime)   \n    FROM deployment   \n    WHERE entryEndDateTime IS NULL   \n    GROUP BY sensorName, deviceName \n    ) \nORDER BY sensorName, deviceName;",
+        "template": "SELECT id, entryStartDateTime, lat, lon, bearing, sensorType, sensorName, deviceName\nFROM deployment\nWHERE entryStartDateTime IN(\n  SELECT MAX(entryStartDateTime)\n  FROM deployment\n  WHERE entryEndDateTime IS NULL\n  GROUP BY sensorName, deviceName\n)\nORDER BY sensorName, deviceName;\n",
         "output": "str",
         "x": 510,
         "y": 980,
@@ -2393,7 +2385,7 @@
         "z": "1c71c8f26f5b7b19",
         "g": "1eebfe6a2eca8ad4",
         "name": "debug-radar-write-DetectObjectVelocity",
-        "active": false,
+        "active": true,
         "tosidebar": true,
         "console": false,
         "tostatus": false,
@@ -2695,7 +2687,7 @@
         "z": "1c71c8f26f5b7b19",
         "g": "047f05d7650ba3cc",
         "name": "debug-radar-raws-speeds-write",
-        "active": false,
+        "active": true,
         "tosidebar": true,
         "console": false,
         "tostatus": false,
@@ -2713,7 +2705,7 @@
         "z": "1c71c8f26f5b7b19",
         "g": "da1c8c74261a93a4",
         "name": "radar_oc_payload",
-        "active": false,
+        "active": true,
         "tosidebar": true,
         "console": false,
         "tostatus": false,
@@ -5436,7 +5428,7 @@
         "z": "f7932be9acc7391c",
         "g": "43087a735f896849",
         "name": "tb telemetry response",
-        "active": false,
+        "active": true,
         "tosidebar": true,
         "console": false,
         "tostatus": false,
@@ -5445,7 +5437,7 @@
         "statusVal": "",
         "statusType": "auto",
         "x": 2320,
-        "y": 220,
+        "y": 200,
         "wires": []
     },
     {
@@ -5527,7 +5519,7 @@
         "y": 260,
         "wires": [
             [
-                "2a979d76853ee0ab"
+                "f29975eb207b5b8d"
             ]
         ]
     },
@@ -5605,33 +5597,12 @@
         "wires": []
     },
     {
-        "id": "2a979d76853ee0ab",
-        "type": "function",
-        "z": "f7932be9acc7391c",
-        "g": "1819134eccdf2660",
-        "name": "format radar_timedspeedcounts telemetry",
-        "func": "// format the payload with a timestamp\nlet values = {\n    ...msg.payload,\n}\n//ts in milliseconds\nmsg.payload = {\n    ts: values.TimedSpeedCounts.time * 1000,\n    values: {\n        radar_timedspeedcounts: values.TimedSpeedCounts\n    }\n}\n\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 380,
-        "y": 260,
-        "wires": [
-            [
-                "aa8d606460d6e410"
-            ]
-        ]
-    },
-    {
         "id": "cc21b9e657cba081",
         "type": "function",
         "z": "f7932be9acc7391c",
         "g": "1819134eccdf2660",
         "name": "format radar_oc_payload telemetry",
-        "func": "// format the payload with a timestamp\nlet values = {\n    ...msg.payload,\n}\n//ts in milliseconds\nmsg.payload = {\n    ts: values.start_time * 1000,\n    values: {\n        radar_oc_payload: values\n    }\n}\n\nreturn msg;",
+        "func": "const newPayload = {\n    ts: msg.payload.start_time * 1000,\n    values: {\n        radar: {\n            radar_oc_payload: {\n                start_time: msg.payload.start_time,\n                end_time: msg.payload.end_time,\n                delta_time_msec: msg.payload.delta_time_msec,\n                dir: msg.payload.dir,\n                frames: msg.payload.frames,\n                max_mph: msg.payload.max_mph,\n                min_mph: msg.payload.min_mph,\n                max_mag: msg.payload.max_mag,\n                avg_mag: msg.payload.avg_mag,\n                frames_per_mph: msg.payload.frames_per_mph,\n                length_ft: msg.payload.length_ft,\n                radarName: msg.payload.radarName,\n                deployment_id: msg.payload.deployment_id\n            }\n        }\n    }\n}\n\nmsg.payload = newPayload;\n\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
         "noerr": 0,
@@ -5698,7 +5669,8 @@
         "y": 360,
         "wires": [
             [
-                "aa8d606460d6e410"
+                "1711871384d75e10",
+                "221ddfedf40c108f"
             ]
         ]
     },
@@ -5731,33 +5703,12 @@
         ]
     },
     {
-        "id": "5d3596375bd695c0",
-        "type": "function",
-        "z": "f7932be9acc7391c",
-        "g": "1819134eccdf2660",
-        "name": "format radar_dov telemetry",
-        "func": "// format the payload with a timestamp\nlet values = {\n    ...msg.payload,\n}\n//ts in milliseconds\nmsg.payload = {\n    ts: values.time * 1000,\n    values: {\n        radar_dov: values\n    }\n}\n\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 340,
-        "y": 360,
-        "wires": [
-            [
-                "ff1719e60656a2e6"
-            ]
-        ]
-    },
-    {
         "id": "4796b517d7d045a7",
         "type": "function",
         "z": "f7932be9acc7391c",
         "g": "1819134eccdf2660",
         "name": "format radar_raw_speed_magnitude telemetry",
-        "func": "// format the payload with a timestamp\nlet values = {\n    ...msg.payload,\n}\n//ts in milliseconds\nmsg.payload = {\n    ts: values.time * 1000,\n    values: {\n        radar_raw_speed_magnitude: values\n    }\n}\n\nreturn msg;",
+        "func": "const newPayload = {\n    ts: msg.payload.time * 1000,\n    values: {\n        radar: {\n            radar_raw_speed_magnitude: {\n                time: msg.payload.time,\n                unit: msg.payload.time,\n                magnitude: msg.payload.magnitude,\n                speed: msg.payload.speed,\n                radarName: msg.payload.radarName,\n                deployment_id: msg.payload.deployment_id\n            }\n        }\n    }\n}\n\nmsg.payload = newPayload;\n\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
         "noerr": 0,
@@ -5778,7 +5729,7 @@
         "z": "f7932be9acc7391c",
         "g": "1819134eccdf2660",
         "name": "format radar_raw_speed_magnitude_single telemetry",
-        "func": "// format the payload with a timestamp\nlet values = {\n    ...msg.payload,\n}\n//ts in milliseconds\nmsg.payload = {\n    ts: values.time * 1000,\n    values: {\n        radar_raw_speed_magnitude_single: values\n    }\n}\n\nreturn msg;",
+        "func": "const newPayload = {\n    ts: msg.payload.time * 1000,\n    values: {\n        radar: {\n            radar_raw_speed_magnitude_single: {\n                time: msg.payload.time,\n                unit: msg.payload.unit,\n                magnitude: msg.payload.magnitude,\n                speed: msg.payload.speed,\n                radarName: msg.payload.radarName,\n                deployment_id: msg.payload.deployment_id\n            }\n        }\n    }\n}\n\nmsg.payload = newPayload;\n\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
         "noerr": 0,
@@ -5816,7 +5767,7 @@
         "z": "f7932be9acc7391c",
         "g": "55a1af374cc8ecb9",
         "name": "format deployment telemetry",
-        "func": "var newMsg = {};\n\n// format the payload with a timestamp\nlet values = {\n    ...msg.payload,\n}\n//ts in milliseconds\nnewMsg.payload = {\n    ts: new Date().getTime(),\n    values: {\n        deployment: values\n    }\n}\n\nreturn newMsg;\n\n/* Sample payload:\n{\n    \"updatedDeployment\": [\n        {\n            \"id\": \"1737518994047-c5a4e582-d\",\n            \"entryStartDateTime\": 1737518994047,\n            \"lat\": 45.52252,\n            \"lon\": -122.6912,\n            \"bearing\": \"e\",\n            \"sensorName\": \"picam_264\",\n            \"deviceName\": \"a06979cfbfcc59da\"\n        }\n    ],\n    \"currentDeployment\": [\n        {\n            \"id\": \"1737519005736-e1c914cc-d\",\n            \"entryStartDateTime\": 1737519005736,\n            \"entryEndDateTime\": \"\",\n            \"lat\": 45.52252,\n            \"lon\": -122.6912,\n            \"bearing\": \"w\",\n            \"sensorName\": \"picam_264\",\n            \"deviceName\": \"a06979cfbfcc59da\"\n        },\n        {\n            \"id\": \"1737518994047-42d3a02b-d\",\n            \"entryStartDateTime\": 1737518994047,\n            \"lat\": 45.52252,\n            \"lon\": -122.6912,\n            \"bearing\": \"s\",\n            \"sensorName\": \"TM_RADAR_SERIAL_PORT_00\",\n            \"deviceName\": \"a06979cfbfcc59da\"\n        }\n    ]\n}\n*/",
+        "func": "var newMsg = {};\n\n// format the payload with a timestamp\nlet values = {\n    ...msg.payload,\n}\n//ts in milliseconds\nnewMsg.payload = {\n    ts: new Date().getTime(),\n    values: {\n        deployments: values\n    }\n}\n\nreturn newMsg;\n\n/* Sample payload:\n{\n    \"updatedDeployment\": [\n        {\n            \"id\": \"1737518994047-c5a4e582-d\",\n            \"entryStartDateTime\": 1737518994047,\n            \"lat\": 45.52252,\n            \"lon\": -122.6912,\n            \"bearing\": \"e\",\n            \"sensorName\": \"picam_264\",\n            \"deviceName\": \"a06979cfbfcc59da\"\n        }\n    ],\n    \"currentDeployment\": [\n        {\n            \"id\": \"1737519005736-e1c914cc-d\",\n            \"entryStartDateTime\": 1737519005736,\n            \"entryEndDateTime\": \"\",\n            \"lat\": 45.52252,\n            \"lon\": -122.6912,\n            \"bearing\": \"w\",\n            \"sensorName\": \"picam_264\",\n            \"deviceName\": \"a06979cfbfcc59da\"\n        },\n        {\n            \"id\": \"1737518994047-42d3a02b-d\",\n            \"entryStartDateTime\": 1737518994047,\n            \"lat\": 45.52252,\n            \"lon\": -122.6912,\n            \"bearing\": \"s\",\n            \"sensorName\": \"TM_RADAR_SERIAL_PORT_00\",\n            \"deviceName\": \"a06979cfbfcc59da\"\n        }\n    ]\n}\n*/",
         "outputs": 1,
         "timeout": 0,
         "noerr": 0,
@@ -5827,7 +5778,7 @@
         "y": 620,
         "wires": [
             [
-                "aa8d606460d6e410"
+                "8c521232f464d27a"
             ]
         ]
     },
@@ -5848,7 +5799,7 @@
         "y": 720,
         "wires": [
             [
-                "aa8d606460d6e410"
+                "8c521232f464d27a"
             ]
         ]
     },
@@ -5870,27 +5821,6 @@
         ]
     },
     {
-        "id": "f453ff6136f95abe",
-        "type": "function",
-        "z": "f7932be9acc7391c",
-        "g": "fac72767826a76d9",
-        "name": "set deployment client side attribute payload",
-        "func": "var newMsg = {};\n\n// format the payload with a timestamp\nlet values = {\n    ...msg.payload.currentDeployment,\n}\n//ts in milliseconds\nnewMsg.payload = {\n    ts: new Date().getTime(),\n    values: {\n        deploymentSensors: values,\n        deploymentTopLat: global.get(\"config.deployment.lat\"),\n        deploymentTopLon: global.get(\"config.deployment.lon\"),\n        deploymentTopBearing: global.get(\"config.deployment.bearing\")\n    }\n}\n\nreturn newMsg;\n\n",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 430,
-        "y": 1220,
-        "wires": [
-            [
-                "232db2c330aebd95"
-            ]
-        ]
-    },
-    {
         "id": "8768b75dbfee3973",
         "type": "link in",
         "z": "f7932be9acc7391c",
@@ -5900,10 +5830,10 @@
             "1ba33a74f2d3a680"
         ],
         "x": 175,
-        "y": 1220,
+        "y": 1300,
         "wires": [
             [
-                "f453ff6136f95abe"
+                "9b0f7197fe82bbfa"
             ]
         ]
     },
@@ -5914,14 +5844,13 @@
         "g": "f034ca2ecdf9a2f6",
         "name": "tb attributes link in",
         "links": [
-            "486556a1e7fce8cf",
-            "7c96d66a8330a4fc"
+            "486556a1e7fce8cf"
         ],
         "x": 175,
         "y": 1120,
         "wires": [
             [
-                "232db2c330aebd95"
+                "e507fdc9cbf67095"
             ]
         ]
     },
@@ -6015,7 +5944,7 @@
         "y": 820,
         "wires": [
             [
-                "aa8d606460d6e410"
+                "8c521232f464d27a"
             ]
         ]
     },
@@ -6166,9 +6095,176 @@
         "y": 160,
         "wires": [
             [
-                "aa8d606460d6e410"
+                "221ddfedf40c108f"
             ]
         ]
+    },
+    {
+        "id": "9b0f7197fe82bbfa",
+        "type": "template",
+        "z": "f7932be9acc7391c",
+        "g": "fac72767826a76d9",
+        "name": "set deployment client side attribute payload",
+        "field": "payload",
+        "fieldType": "msg",
+        "format": "handlebars",
+        "syntax": "mustache",
+        "template": "{\n    \"deployments\": {\n        {{#payload.currentDeployment}}\n        \"{{sensorName}}\": {\n            \"sensorType\": \"{{sensorType}}\",\n            \"lat\": {{lat}},\n            \"lon\": {{lon}},\n            \"bearing\": \"{{bearing}}\",\n            \"id\": \"{{id}}\"\n        },\n        {{/payload.currentDeployment}}\n        \"deploymentTopLevel\": {\n            \"lat\": {{global.config.deployment.lat}},\n            \"lon\": {{global.config.deployment.lon}},\n            \"bearing\": \"{{global.config.deployment.bearing}}\"\n        }\n    }\n}",
+        "output": "json",
+        "x": 430,
+        "y": 1300,
+        "wires": [
+            [
+                "75f7976086cc9838"
+            ]
+        ]
+    },
+    {
+        "id": "5d3596375bd695c0",
+        "type": "function",
+        "z": "f7932be9acc7391c",
+        "g": "1819134eccdf2660",
+        "name": "format radar_dov telemetry",
+        "func": "const newPayload = {\n    ts: msg.payload.time * 1000,\n    values: {\n        radar: {\n            radar_dov: {\n                time: msg.payload.time,\n                unit: msg.payload.unit,\n                direction: msg.payload.direction,\n                velocity: msg.payload.DetectedObjectVelocity,\n                radarName: msg.payload.radarName,\n                deployment_id: msg.payload.deployment_id\n            }\n        }\n    }\n}\n\nmsg.payload = newPayload;\n\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 340,
+        "y": 360,
+        "wires": [
+            [
+                "ff1719e60656a2e6"
+            ]
+        ]
+    },
+    {
+        "id": "f29975eb207b5b8d",
+        "type": "function",
+        "z": "f7932be9acc7391c",
+        "g": "1819134eccdf2660",
+        "name": "format radar_timedspeedcounts telemetry",
+        "func": "const newPayload = {\n    ts: msg.payload.TimedSpeedCounts.time * 1000,\n    values: {\n        radar: {\n            radar_timedspeedcounts: {\n                time: msg.payload.TimedSpeedCounts.time,\n                direction: msg.payload.TimedSpeedCounts.direction,\n                units: msg.payload.TimedSpeedCounts.units,\n                count: msg.payload.TimedSpeedCounts.count,\n                average: msg.payload.TimedSpeedCounts.average,\n                radarName: msg.payload.radarName,\n                deployment_id: msg.payload.deployment_id\n            }\n        }\n    }\n}\n\nmsg.payload = newPayload;\n\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 380,
+        "y": 260,
+        "wires": [
+            [
+                "221ddfedf40c108f",
+                "6c582e93dfb3d6fa"
+            ]
+        ]
+    },
+    {
+        "id": "1711871384d75e10",
+        "type": "debug",
+        "z": "f7932be9acc7391c",
+        "g": "1819134eccdf2660",
+        "name": "debug 4",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "false",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 900,
+        "y": 400,
+        "wires": []
+    },
+    {
+        "id": "6c582e93dfb3d6fa",
+        "type": "debug",
+        "z": "f7932be9acc7391c",
+        "g": "1819134eccdf2660",
+        "name": "debug 2",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "false",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 730,
+        "y": 260,
+        "wires": []
+    },
+    {
+        "id": "e507fdc9cbf67095",
+        "type": "function",
+        "z": "f7932be9acc7391c",
+        "g": "f034ca2ecdf9a2f6",
+        "name": "format system info client-side attributes",
+        "func": "const newPayload = {\n    sysinfo_tmVersion: msg.payload.tmVersion,\n    sysinfo_osHostname: msg.payload.osHostname,\n    sysinfo_osRelease: msg.payload.osRelease,\n    sysinfo_osTimeZone: msg.payload.osTimeZone,\n    sysinfo_deviceName: msg.payload.deviceName,\n    sysinfo_frigateVersion: msg.payload.frigateVersion,\n    sysinfo_ssid: msg.payload.ssid,\n    sysinfo_ipv4Address: msg.payload.ipv4Address\n}\n\nmsg.payload = newPayload;\n\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 410,
+        "y": 1120,
+        "wires": [
+            [
+                "75f7976086cc9838"
+            ]
+        ]
+    },
+    {
+        "id": "4af0d78e8bc39647",
+        "type": "link in",
+        "z": "f7932be9acc7391c",
+        "g": "f034ca2ecdf9a2f6",
+        "name": "backup link in",
+        "links": [
+            "7c96d66a8330a4fc"
+        ],
+        "x": 175,
+        "y": 1180,
+        "wires": [
+            [
+                "0b62cae60d488c85"
+            ]
+        ]
+    },
+    {
+        "id": "0b62cae60d488c85",
+        "type": "function",
+        "z": "f7932be9acc7391c",
+        "g": "f034ca2ecdf9a2f6",
+        "name": "format config backup client-side attribute",
+        "func": "const newPayload = {\n    backup_config: msg.payload\n}\n\nmsg.payload = newPayload;\n\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 420,
+        "y": 1180,
+        "wires": [
+            [
+                "75f7976086cc9838"
+            ]
+        ]
+    },
+    {
+        "id": "fdb3962b458f90c2",
+        "type": "comment",
+        "z": "f7932be9acc7391c",
+        "g": "fe1b9f6f9d89d353",
+        "name": "NOTE: instructions to delete client-side attributes",
+        "info": "To delete client-side attributes:\n\n`DELETE` for <TB_URL>/api/plugins/telemetry/{deviceId}/{scope}{?keys}\n\n- {deviceId} = <LONG_DEVICE_HEX_STRING> is from ThingsBoard web portal > Device > Details > Copy device deviceId\n- {scope} = 'CLIENT_SCOPE'\n- keys = comma-separated list of attributes with commas formatted for transmission \n    system_deviceName,system_frigateVersion,system_ipv4Address,system_osHostname,system_osRelease,system_osTimeZone,system_ssid,system_tmVersion\n    becomes system_deviceName%2Csystem_frigateVersion%2Csystem_ipv4Address%2Csystem_osHostname%2Csystem_osRelease%2Csystem_osTimeZone%2Csystem_ssid%2Csystem_tmVersion\n\n\nCan also access it at <TB_URL>/swagger-ui/index.html under 'telemetry-controller' section",
+        "x": 320,
+        "y": 1040,
+        "wires": []
     },
     {
         "id": "3985037239b671c5",
@@ -10858,7 +10954,7 @@
         "type": "link out",
         "z": "05fcb02c571dcfee",
         "g": "dc2934def36c6285",
-        "name": "system_metrics link out",
+        "name": "system_info link out",
         "mode": "link",
         "links": [
             "d367cb76b239682f"
@@ -11003,12 +11099,12 @@
                 "t": "move",
                 "p": "payload",
                 "pt": "msg",
-                "to": "payload.backup.frigate",
+                "to": "payload.frigate_config",
                 "tot": "msg"
             },
             {
                 "t": "set",
-                "p": "payload.backup.dateTime",
+                "p": "payload.dateTime",
                 "pt": "msg",
                 "to": "",
                 "tot": "date"
@@ -11215,7 +11311,7 @@
         "name": "backup link out",
         "mode": "link",
         "links": [
-            "d367cb76b239682f"
+            "4af0d78e8bc39647"
         ],
         "x": 885,
         "y": 1980,
@@ -11716,7 +11812,7 @@
         "id": "6dca925fad91c100",
         "type": "link out",
         "z": "f410f6aac9d1a3fc",
-        "name": "system_metrics",
+        "name": "system_metrics link out",
         "mode": "link",
         "links": [
             "24c1b5f3bff3834c"

--- a/node-red-project/flows.json
+++ b/node-red-project/flows.json
@@ -199,12 +199,15 @@
             "170ddffb726db9e0",
             "befe91e6862c72db",
             "13a061996f9322f3",
-            "98571c77b9801a83"
+            "98571c77b9801a83",
+            "bb08a223f0aaef0f",
+            "e3b795e05d7650b2",
+            "c7f00f59861cd00f"
         ],
         "x": 154,
-        "y": 2139,
+        "y": 2119,
         "w": 1172,
-        "h": 322
+        "h": 342
     },
     {
         "id": "1bd1f21fa0390c69",
@@ -265,12 +268,13 @@
             "673e45159a2dfccf",
             "2c7c7df250289562",
             "627ba0f672680054",
-            "b7398c4e0bc743e5"
+            "b7398c4e0bc743e5",
+            "a8aeffd2e5bc17f2"
         ],
         "x": 54,
         "y": 359,
-        "w": 1278,
-        "h": 548
+        "w": 1332,
+        "h": 628
     },
     {
         "id": "53e4faf6d3ece28c",
@@ -731,7 +735,7 @@
         "x": 48,
         "y": 233,
         "w": 1050,
-        "h": 920
+        "h": 840
     },
     {
         "id": "672f3b07194c5dd5",
@@ -1100,7 +1104,7 @@
         "x": 88,
         "y": 439,
         "w": 984,
-        "h": 688
+        "h": 608
     },
     {
         "id": "f35d3f484c2f6107",
@@ -1177,12 +1181,13 @@
             "61d6a19c99c60e0b",
             "a96d834e3571c549",
             "7f0ef976c7b79245",
-            "59a579e6a1fa9a08"
+            "b08a42e270ab5a4f",
+            "674346683479762a"
         ],
-        "x": 494,
+        "x": 734,
         "y": 759,
-        "w": 812,
-        "h": 122
+        "w": 572,
+        "h": 202
     },
     {
         "id": "43087a735f896849",
@@ -1220,8 +1225,6 @@
             "751ff2049a663e9c",
             "3cdbccf5dbcb1c4e",
             "f9a2f4f97e3ba1cf",
-            "928d7cafdc1ab7fa",
-            "8f4e9d81288d5abd",
             "ba3b41519066f03a",
             "f111096594207360",
             "c25adb99d55eb890"
@@ -1229,7 +1232,7 @@
         "x": 114,
         "y": 859,
         "w": 932,
-        "h": 242
+        "h": 162
     },
     {
         "id": "05a58d9ee463c696",
@@ -1359,6 +1362,20 @@
             [
                 "c4a024def66c8499",
                 "8c434de19f88fefc"
+            ]
+        ]
+    },
+    {
+        "id": "674346683479762a",
+        "type": "junction",
+        "z": "9269520ddb532b00",
+        "g": "b7398c4e0bc743e5",
+        "x": 760,
+        "y": 800,
+        "wires": [
+            [
+                "b08a42e270ab5a4f",
+                "a96d834e3571c549"
             ]
         ]
     },
@@ -2042,58 +2059,6 @@
         ]
     },
     {
-        "id": "928d7cafdc1ab7fa",
-        "type": "inject",
-        "z": "3dae026ab340962a",
-        "d": true,
-        "g": "a2b2e69319628779",
-        "name": "drop table deployment",
-        "props": [
-            {
-                "p": "topic",
-                "vt": "str"
-            }
-        ],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "DROP TABLE IF EXISTS deployment;",
-        "x": 540,
-        "y": 1020,
-        "wires": [
-            [
-                "8a6d4593a661c3df"
-            ]
-        ]
-    },
-    {
-        "id": "8f4e9d81288d5abd",
-        "type": "inject",
-        "z": "3dae026ab340962a",
-        "d": true,
-        "g": "a2b2e69319628779",
-        "name": "alter table deployment from 0.2.0 to 0.3.0",
-        "props": [
-            {
-                "p": "topic",
-                "vt": "str"
-            }
-        ],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "ALTER TABLE deployment RENAME COLUMN entryDateTime TO entryStartDateTime; ALTER TABLE deployment ADD COLUMN entryEndDateTime REAL; ALTER TABLE deployment RENAME COLUMN orientation TO bearing; ALTER TABLE deployment DROP COLUMN address; ALTER TABLE deployment DROP COLUMN description; ALTER TABLE deployment ADD COLUMN sensor TEXT;",
-        "x": 480,
-        "y": 1060,
-        "wires": [
-            [
-                "8a6d4593a661c3df"
-            ]
-        ]
-    },
-    {
         "id": "689b64c16a889e0a",
         "type": "function",
         "z": "3dae026ab340962a",
@@ -2359,7 +2324,7 @@
         "type": "debug",
         "z": "1c71c8f26f5b7b19",
         "name": "debug-radar-all-output",
-        "active": true,
+        "active": false,
         "tosidebar": true,
         "console": false,
         "tostatus": false,
@@ -2419,7 +2384,7 @@
         "z": "1c71c8f26f5b7b19",
         "g": "1eebfe6a2eca8ad4",
         "name": "debug-radar-write-DetectObjectVelocity",
-        "active": true,
+        "active": false,
         "tosidebar": true,
         "console": false,
         "tostatus": false,
@@ -2604,7 +2569,7 @@
         "z": "1c71c8f26f5b7b19",
         "g": "047f05d7650ba3cc",
         "name": "debug-radar-raws-speeds-write",
-        "active": true,
+        "active": false,
         "tosidebar": true,
         "console": false,
         "tostatus": false,
@@ -3890,7 +3855,7 @@
         "z": "1c71c8f26f5b7b19",
         "g": "da1c8c74261a93a4",
         "name": "radar_oc_payload",
-        "active": true,
+        "active": false,
         "tosidebar": true,
         "console": false,
         "tostatus": false,
@@ -4370,8 +4335,7 @@
         "wires": [
             [
                 "05a58d9ee463c696",
-                "09952039b0ab86aa",
-                "5e7c4009964478fc"
+                "09952039b0ab86aa"
             ]
         ]
     },
@@ -4445,22 +4409,6 @@
                 "3e9d121913d7feae"
             ]
         ]
-    },
-    {
-        "id": "5e7c4009964478fc",
-        "type": "debug",
-        "z": "1c71c8f26f5b7b19",
-        "name": "debug 1",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "false",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 810,
-        "y": 660,
-        "wires": []
     },
     {
         "id": "f20c74c0ccfd256c",
@@ -4572,7 +4520,7 @@
             "c249329109ac17d5",
             "ed447e5f8becbfad"
         ],
-        "x": 1265,
+        "x": 995,
         "y": 800,
         "wires": []
     },
@@ -4679,7 +4627,7 @@
         "y": 660,
         "wires": [
             [
-                "a96d834e3571c549"
+                "a8aeffd2e5bc17f2"
             ]
         ]
     },
@@ -4750,8 +4698,8 @@
         "sqlquery": "prepared",
         "sql": "INSERT INTO events (id, camera, label, sub_label, top_score, frame_time, start_time, end_time, entered_zones, score, area, ratio, motionless_count, position_changes, attributes, direction_calc, speed_calc, provenance, deployment_id, radarName) \nVALUES ($id, $camera, $label, $sub_label, $top_score, $frame_time, $start_time, $end_time, json($entered_zones), $score, $area, $ratio, $motionless_count, $position_changes, json($attributes), $direction_calc, $speed_calc, $provenance, $deployment_id, $radarName);",
         "name": "tmdb.events, Prepared Statement",
-        "x": 680,
-        "y": 840,
+        "x": 960,
+        "y": 920,
         "wires": [
             []
         ]
@@ -4762,19 +4710,18 @@
         "z": "9269520ddb532b00",
         "g": "b7398c4e0bc743e5",
         "name": "write params for events insert",
-        "func": "const newMsg = {};\nnewMsg.payload = {}; // contain everything going into a DB record, single record\n\n// Frigate Event info\nnewMsg.payload.id = msg.frigate_event.id;\nnewMsg.payload.camera = msg.frigate_event.camera;\nnewMsg.payload.label = msg.frigate_event.label;\nnewMsg.payload.sub_label = msg.frigate_event.sub_label;\nnewMsg.payload.top_score = msg.frigate_event.top_score;\n//for Timestamp, frigate event and radar use seconds\nnewMsg.payload.frame_time = msg.frigate_event.frame_time;\nnewMsg.payload.start_time = msg.frigate_event.start_time;\nnewMsg.payload.end_time = msg.frigate_event.end_time;\nnewMsg.payload.entered_zones = `${JSON.stringify(msg.frigate_event.entered_zones)}`; //array, wrap in single quote for sqlite insert as text\n\nnewMsg.payload.score = msg.frigate_event.score;\nnewMsg.payload.area = msg.frigate_event.area;\nnewMsg.payload.ratio = msg.frigate_event.ratio;\nnewMsg.payload.motionless_count = msg.frigate_event.motionless_count;\nnewMsg.payload.position_changes = msg.frigate_event.position_changes;\nnewMsg.payload.attributes = `${JSON.stringify(msg.frigate_event.attributes)}`; //array, wrap in single quote for sqlite insert as text\n\n\nnewMsg.payload.direction_calc = (msg.event_direction_speed.calc_event_direction || undefined);\nnewMsg.payload.speed_calc = (msg.event_direction_speed.calc_event_speed || undefined);\n\n//provenance, frigate first, then radar, if it matched\nnewMsg.payload.provenance = [];\nnewMsg.payload.provenance.push(\"frigate\");\nif (msg.status_radarMatch === true) {\n    newMsg.payload.provenance.push(\"radar\");\n}\n\nnewMsg.payload.deployment_id = msg.frigate_event.deployment_id;\nnewMsg.payload.radarName = msg.frigate_event.radarName;\n\nconst obj = newMsg.payload;\n\nmsg.payload = newMsg.payload;\n\nconst keyedObj = Object.keys(obj).reduce((acc, key) => {\n    acc[`$${key}`] = obj[key];\n    return acc;\n}, {});\n\nmsg.params = keyedObj;\n\nreturn msg;",
+        "func": "//JSON objects need to be text for SQLite\n\nmsg.payload.entered_zones = `${JSON.stringify(msg.payload.entered_zones)}`;\nmsg.payload.attributes = `${JSON.stringify(msg.payload.attributes)}`;\nmsg.payload.provenance = `${JSON.stringify(msg.payload.provenance)}`;\n\nconst obj = msg.payload;\n\nconst keyedObj = Object.keys(obj).reduce((acc, key) => {\n    acc[`$${key}`] = obj[key];\n    return acc;\n}, {});\n\nmsg.params = keyedObj;\n\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
         "noerr": 0,
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 650,
-        "y": 800,
+        "x": 930,
+        "y": 880,
         "wires": [
             [
-                "61d6a19c99c60e0b",
-                "59a579e6a1fa9a08"
+                "61d6a19c99c60e0b"
             ]
         ]
     },
@@ -4830,31 +4777,9 @@
         "targetType": "full",
         "statusVal": "",
         "statusType": "auto",
-        "x": 1040,
+        "x": 1120,
         "y": 840,
         "wires": []
-    },
-    {
-        "id": "59a579e6a1fa9a08",
-        "type": "function",
-        "z": "9269520ddb532b00",
-        "g": "b7398c4e0bc743e5",
-        "name": "cleanse final msg.payload to forward along",
-        "func": "let newMsg = {};\n\nnewMsg.topic = \"tm/event\"\nnewMsg.payload = msg.payload;\n\nreturn newMsg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 1030,
-        "y": 800,
-        "wires": [
-            [
-                "7f0ef976c7b79245",
-                "274f87c31437c2d7"
-            ]
-        ]
     },
     {
         "id": "b39062019fac1a66",
@@ -5048,6 +4973,56 @@
         "wires": [
             [
                 "510b389597efaf1b"
+            ]
+        ]
+    },
+    {
+        "id": "a8aeffd2e5bc17f2",
+        "type": "function",
+        "z": "9269520ddb532b00",
+        "g": "71c085648c20e329",
+        "name": "event finalize output",
+        "func": "\n//provenance, frigate first, then radar, if it matched\nvar thisProvenance = [];\nthisProvenance.push(\"frigate\");\nif (msg.payload.status_radarMatch === true) {\n    thisProvenance.push(\"radar\");\n}\n\nconst newPayload = {\n    id:                 msg.frigate_event.id,\n    camera:             msg.frigate_event.camera,\n    label:              msg.frigate_event.label,\n    sub_label:          msg.frigate_event.sub_label,\n    top_score:          msg.frigate_event.top_score,\n    frame_time:         msg.frigate_event.frame_time,\n    start_time:         msg.frigate_event.start_time,\n    end_time:           msg.frigate_event.end_time,\n    entered_zones:      msg.frigate_event.entered_zones,\n    score:              msg.frigate_event.score,\n    area:               msg.frigate_event.area,\n    ratio:              msg.frigate_event.ratio,\n    motionless_count:   msg.frigate_event.motionless_count,\n    position_changes:   msg.frigate_event.position_changes,\n    attributes:         msg.frigate_event.attributes,\n    direction_calc:     (msg.event_direction_speed.calc_event_direction || undefined),\n    speed_calc:         (msg.event_direction_speed.calc_event_speed || undefined),\n    provenance:         thisProvenance,\n    deployment_id:      msg.frigate_event.deployment_id,\n    radarName:          msg.frigate_event.radarName\n}\n\nmsg.payload = newPayload;\n\n\n\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 1260,
+        "y": 700,
+        "wires": [
+            [
+                "674346683479762a"
+            ]
+        ]
+    },
+    {
+        "id": "b08a42e270ab5a4f",
+        "type": "change",
+        "z": "9269520ddb532b00",
+        "g": "b7398c4e0bc743e5",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "topic",
+                "pt": "msg",
+                "to": "tm/event",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 870,
+        "y": 800,
+        "wires": [
+            [
+                "274f87c31437c2d7",
+                "7f0ef976c7b79245"
             ]
         ]
     },
@@ -6659,13 +6634,11 @@
         "z": "28627559bebdc324",
         "g": "9b9e4fc50b744fc3",
         "name": "only use radar cam",
-        "property": "payload.camera",
+        "property": "payload.radarName",
         "propertyType": "msg",
         "rules": [
             {
-                "t": "eq",
-                "v": "VAR_RADAR_CAMERA",
-                "vt": "env"
+                "t": "nnull"
             }
         ],
         "checkall": "true",
@@ -6707,7 +6680,7 @@
         "z": "28627559bebdc324",
         "g": "9b9e4fc50b744fc3",
         "name": "debug: event payload in",
-        "active": false,
+        "active": true,
         "tosidebar": true,
         "console": false,
         "tostatus": false,
@@ -7094,7 +7067,7 @@
         "repair": false,
         "outputs": 1,
         "x": 400,
-        "y": 2180,
+        "y": 2160,
         "wires": [
             [
                 "d23be15251ed6d73"
@@ -7122,7 +7095,7 @@
         "to": "",
         "reg": false,
         "x": 460,
-        "y": 2240,
+        "y": 2200,
         "wires": [
             [
                 "170ddffb726db9e0"
@@ -7465,7 +7438,7 @@
         "z": "28627559bebdc324",
         "g": "453513c49e4b1b60",
         "name": "create sqlite query, daily cumulative counts in zone_capture",
-        "func": "//frame_time is already in seconds\n\nconst query = `\nSELECT\n    label,\n    COUNT(*) as count\nFROM\n    events\nWHERE\n    frame_time >= unixepoch(strftime('%Y-%m-%dT04:00','now', 'localtime'),'utc')\n    AND camera = '${env.get(\"VAR_RADAR_CAMERA\")}'\n    AND entered_zones LIKE '%zone_capture%'\nGROUP BY \n    label\nORDER BY\n    label;\n`;\n\nmsg.topic = query;\nreturn msg;",
+        "func": "//frame_time is already in seconds\n\nconst query = `\nSELECT\n    label,\n    COUNT(*) as count\nFROM\n    events\nWHERE\n    frame_time >= unixepoch(strftime('%Y-%m-%dT04:00','now', 'localtime'),'utc')\n    AND camera = '${flow.get(\"sensor_cumulative_objects\")}'\n    AND entered_zones LIKE '%zone_capture%'\nGROUP BY \n    label\nORDER BY\n    label;\n`;\n\nmsg.topic = query;\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
         "noerr": 0,
@@ -7766,6 +7739,97 @@
         "className": "",
         "x": 800,
         "y": 1100,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "bb08a223f0aaef0f",
+        "type": "ui_dropdown",
+        "z": "28627559bebdc324",
+        "g": "453513c49e4b1b60",
+        "name": "",
+        "label": "",
+        "tooltip": "",
+        "place": "Select sensor to report cumulative daily object counts",
+        "group": "7866c2aa313ab8b9",
+        "order": 7,
+        "width": 0,
+        "height": 0,
+        "passthru": true,
+        "multiple": false,
+        "options": [
+            {
+                "label": "",
+                "value": "",
+                "type": "str"
+            }
+        ],
+        "payload": "",
+        "topic": "topic",
+        "topicType": "msg",
+        "className": "",
+        "x": 380,
+        "y": 2340,
+        "wires": [
+            [
+                "c7f00f59861cd00f"
+            ]
+        ]
+    },
+    {
+        "id": "e3b795e05d7650b2",
+        "type": "inject",
+        "z": "28627559bebdc324",
+        "g": "453513c49e4b1b60",
+        "name": "",
+        "props": [
+            {
+                "p": "payload"
+            },
+            {
+                "p": "options",
+                "v": "$keys($globalContext(\"config.sensors.cameras\"))\t",
+                "vt": "jsonata"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": true,
+        "onceDelay": "5",
+        "topic": "",
+        "payload": "$keys($globalContext(\"config.sensors.cameras\"))[0]\t",
+        "payloadType": "jsonata",
+        "x": 250,
+        "y": 2340,
+        "wires": [
+            [
+                "bb08a223f0aaef0f"
+            ]
+        ]
+    },
+    {
+        "id": "c7f00f59861cd00f",
+        "type": "change",
+        "z": "28627559bebdc324",
+        "g": "453513c49e4b1b60",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "sensor_cumulative_objects",
+                "pt": "flow",
+                "to": "payload",
+                "tot": "msg"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 360,
+        "y": 2400,
         "wires": [
             []
         ]

--- a/node-red-project/flows.json
+++ b/node-red-project/flows.json
@@ -541,12 +541,13 @@
             "55a1af374cc8ecb9",
             "99dfff63ac837bc8",
             "f35d3f484c2f6107",
-            "694f0242d0985c69"
+            "aa8d606460d6e410",
+            "221ddfedf40c108f"
         ],
         "x": 108,
         "y": 93,
-        "w": 1824,
-        "h": 894
+        "w": 1198,
+        "h": 794
     },
     {
         "id": "fe1b9f6f9d89d353",
@@ -559,33 +560,13 @@
         "nodes": [
             "fac72767826a76d9",
             "f034ca2ecdf9a2f6",
-            "8d3fe796e032166c"
+            "75f7976086cc9838",
+            "232db2c330aebd95"
         ],
         "x": 108,
         "y": 1053,
-        "w": 1864,
+        "w": 1198,
         "h": 234
-    },
-    {
-        "id": "8d3fe796e032166c",
-        "type": "group",
-        "z": "f7932be9acc7391c",
-        "g": "fe1b9f6f9d89d353",
-        "name": "send tb client-side attributes",
-        "style": {
-            "label": true
-        },
-        "nodes": [
-            "542b3b8720733a01",
-            "0a28f82092611160",
-            "058c390e87e3c283",
-            "9c111c8d0f212bf8",
-            "8ad71425a71a860e"
-        ],
-        "x": 1134,
-        "y": 1079,
-        "w": 812,
-        "h": 162
     },
     {
         "id": "9e0b1edd49eb4244",
@@ -604,27 +585,6 @@
         "y": 79,
         "w": 512,
         "h": 122
-    },
-    {
-        "id": "694f0242d0985c69",
-        "type": "group",
-        "z": "f7932be9acc7391c",
-        "g": "2f27e270200485b9",
-        "name": "send tb telemetry",
-        "style": {
-            "label": true
-        },
-        "nodes": [
-            "677a57bbf3619854",
-            "df6ac2f42ac6d8c7",
-            "21944450ecc08385",
-            "93aa421659d2c20b",
-            "9b8c2bcc16a637fd"
-        ],
-        "x": 1134,
-        "y": 119,
-        "w": 772,
-        "h": 162
     },
     {
         "id": "dea1b8828f8e501f",
@@ -832,7 +792,7 @@
         "x": 74,
         "y": 539,
         "w": 1032,
-        "h": 222
+        "h": 202
     },
     {
         "id": "efdb589a1b6e0c2f",
@@ -866,15 +826,13 @@
             "fill": "#e3f3d3"
         },
         "nodes": [
-            "4bec488857c0553f",
             "ed447e5f8becbfad",
-            "cc84d34370b6feb3",
-            "a473c7e4eeb01dcd"
+            "4bec488857c0553f"
         ],
         "x": 134,
         "y": 119,
-        "w": 352,
-        "h": 182
+        "w": 332,
+        "h": 82
     },
     {
         "id": "1819134eccdf2660",
@@ -903,7 +861,7 @@
             "9a894f4bd304f5a9"
         ],
         "x": 134,
-        "y": 319,
+        "y": 219,
         "w": 872,
         "h": 342
     },
@@ -922,7 +880,7 @@
             "c6ff73faf6fa9e98"
         ],
         "x": 134,
-        "y": 679,
+        "y": 579,
         "w": 372,
         "h": 82
     },
@@ -941,7 +899,7 @@
             "24c1b5f3bff3834c"
         ],
         "x": 134,
-        "y": 779,
+        "y": 679,
         "w": 392,
         "h": 82
     },
@@ -1121,7 +1079,7 @@
             "08da197b902c939e"
         ],
         "x": 134,
-        "y": 879,
+        "y": 779,
         "w": 352,
         "h": 82
     },
@@ -1208,6 +1166,46 @@
         "y": 859,
         "w": 932,
         "h": 242
+    },
+    {
+        "id": "694f0242d0985c69",
+        "type": "group",
+        "z": "f7932be9acc7391c",
+        "name": "send to tb",
+        "style": {
+            "label": true
+        },
+        "nodes": [
+            "21944450ecc08385",
+            "93aa421659d2c20b",
+            "9b8c2bcc16a637fd",
+            "43087a735f896849"
+        ],
+        "x": 1374,
+        "y": 93,
+        "w": 1118,
+        "h": 194
+    },
+    {
+        "id": "43087a735f896849",
+        "type": "group",
+        "z": "f7932be9acc7391c",
+        "g": "694f0242d0985c69",
+        "name": "tb http api",
+        "style": {
+            "label": true
+        },
+        "nodes": [
+            "677a57bbf3619854",
+            "df6ac2f42ac6d8c7",
+            "9c944328e288b2dc",
+            "dd3f9ef16332021c",
+            "d739b10ce5fa8f40"
+        ],
+        "x": 1714,
+        "y": 119,
+        "w": 752,
+        "h": 142
     },
     {
         "id": "05a58d9ee463c696",
@@ -1309,6 +1307,32 @@
             [
                 "1ba33a74f2d3a680",
                 "17455485af2d8cfc"
+            ]
+        ]
+    },
+    {
+        "id": "232db2c330aebd95",
+        "type": "junction",
+        "z": "f7932be9acc7391c",
+        "g": "fe1b9f6f9d89d353",
+        "x": 740,
+        "y": 1120,
+        "wires": [
+            [
+                "75f7976086cc9838"
+            ]
+        ]
+    },
+    {
+        "id": "aa8d606460d6e410",
+        "type": "junction",
+        "z": "f7932be9acc7391c",
+        "g": "2f27e270200485b9",
+        "x": 1060,
+        "y": 160,
+        "wires": [
+            [
+                "221ddfedf40c108f"
             ]
         ]
     },
@@ -1847,7 +1871,7 @@
         "z": "3dae026ab340962a",
         "g": "4bbb9e24b5507a00",
         "name": "init config defaults",
-        "func": "\n//thingsboard\n// default to enabled: false\nif (typeof msg.payload.thingsboard.enabled !== \"undefined\") {\n  msg.payload.thingsboard.enabled = msg.payload.thingsboard.enabled === true ? true : false;\n} else { msg.payload.thingsboard.enabled = false; }\n\nif (msg.payload.thingsboard.enabled === true) {\n  if (typeof msg.payload.thingsboard.host === \"undefined\") {\n    node.error(`Node-RED config.yml key thingsboard.host needs to be populated when thingsboard is enabled. Disabling ThingsBoard.`);\n    // and disable thingsboard\n    msg.payload.thingsboard.enabled = false;\n  }\n  else {\n    //assign TB url (domain, front part)\n    msg.payload.thingsboard.url = `${msg.payload.thingsboard.host}${msg.payload.thingsboard.port ? ':' + msg.payload.thingsboard.port : ''}`\n  }\n}\n\n\n//deployment\n//check deployment entries for valid values\nmsg.payload.deployment.lat = typeof msg.payload.deployment.lat === \"undefined\" ? '' : msg.payload.deployment.lat;\nmsg.payload.deployment.lon = typeof msg.payload.deployment.lon === \"undefined\" ? '' : msg.payload.deployment.lon;\nmsg.payload.deployment.bearing = typeof msg.payload.deployment.bearing === \"undefined\" ? '' : msg.payload.deployment.bearing;\n\n//check for numeric (decimal) lon and lat\nif (msg.payload.deployment.lat !== null) {\n  if (typeof msg.payload.deployment.lat !== \"number\") {\n    node.error(`Node-RED config.yml top-level deployment.lat is not a valid type; needs to be numeric`);\n  }\n}\nif (msg.payload.deployment.lon !== null) {\n  if (typeof msg.payload.deployment.lon !== \"number\") {\n    node.error(`Node-RED config.yml top-level deployment.lon is not a valid type; needs to be numeric`);\n  }\n}\nconst bearing_values = ['n', 's', 'e', 'w', 'ne', 'nw', 'se', 'sw'];\n//allow empty/null/undefined values\nif (msg.payload.deployment.bearing !== null) {\n  if (bearing_values.indexOf(msg.payload.deployment.bearing.toLowerCase()) !== -1) {\n    msg.payload.deployment.bearing = msg.payload.deployment.bearing.toLowerCase();\n  }\n  else {\n    node.error(`Node-RED config.yml top-level deployment.bearing is not a valid value; needs to be one of ${bearing_values}`);\n  }\n}\n\n// go through each of the sensors that have no deployment object and copy the top-level deployment object into them\n// do not overwrite any existing sensor deployment properties\nfor (const [sensorType, sensors] of Object.entries(msg.payload.sensors)) {\n  for (const [sensorName, sensor] of Object.entries(sensors)) {\n    if (sensor.hasOwnProperty('enabled') && sensor.enabled === true) {\n      if (sensor.hasOwnProperty('deployment')) {\n        const sensorDeployment = sensor.deployment;\n        const topLevelDeployment = msg.payload.deployment;\n        for (const [prop, value] of Object.entries(topLevelDeployment)) {\n          if (!sensorDeployment.hasOwnProperty(prop)) {\n            sensorDeployment[prop] = value;\n          }\n        }\n        if (sensorDeployment.hasOwnProperty('bearing')) {\n          const bearing = sensorDeployment.bearing.toLowerCase();\n          if (!bearing_values.includes(bearing)) {\n            node.error(`Invalid bearing value '${sensorDeployment.bearing}' for sensor '${sensorType}.${sensorName}'. Using default value ''.`, msg);\n            sensorDeployment.bearing = '';\n          }\n        }\n      } else {\n        msg.payload.sensors[sensorType][sensorName].deployment = { ...msg.payload.deployment };\n      }\n    }\n  }\n}\n\n//time\nmsg.payload.time.npt_set === false ? false : true;\n\nreturn msg;",
+        "func": "\n//thingsboard\n// default to enabled: false\nif (typeof msg.payload.thingsboard.enabled !== \"undefined\") {\n  msg.payload.thingsboard.enabled = msg.payload.thingsboard.enabled === true ? true : false;\n} else { msg.payload.thingsboard.enabled = false; }\n\nif (msg.payload.thingsboard.enabled === true) {\n  if (typeof msg.payload.thingsboard.host === \"undefined\") {\n    node.error(`Node-RED config.yml key thingsboard.host needs to be populated when thingsboard is enabled. Disabling ThingsBoard.`);\n    // and disable thingsboard\n    msg.payload.thingsboard.enabled = false;\n  }\n  else {\n    //assign TB url (domain, front part)\n    msg.payload.thingsboard.url = `${msg.payload.thingsboard.host}${msg.payload.thingsboard.port ? ':' + msg.payload.thingsboard.port : ''}`\n  }  \n  //check protocol http can be http or https\n  if (typeof msg.payload.thingsboard.protocol !== \"undefined\") {\n    msg.payload.thingsboard.protocol = msg.payload.thingsboard.protocol.includes('https') ? 'http' : msg.payload.thingsboard.protocol;\n    msg.payload.thingsboard.protocol = msg.payload.thingsboard.protocol.includes('mqtts') ? 'mqtt' : msg.payload.thingsboard.protocol;\n  }\n  //warn if no access_token\n  if (typeof msg.payload.thingsboard.access_token === \"undefined\") {\n    node.warn(`Node-RED config.yml key thingsboard.access_token is not populated when thingsboard is enabled. access_token may be required for authentication.`);\n  }\n}\n\n\n//deployment\n//check deployment entries for valid values\nmsg.payload.deployment.lat = typeof msg.payload.deployment.lat === \"undefined\" ? '' : msg.payload.deployment.lat;\nmsg.payload.deployment.lon = typeof msg.payload.deployment.lon === \"undefined\" ? '' : msg.payload.deployment.lon;\nmsg.payload.deployment.bearing = typeof msg.payload.deployment.bearing === \"undefined\" ? '' : msg.payload.deployment.bearing;\n\n//check for numeric (decimal) lon and lat\nif (msg.payload.deployment.lat !== null) {\n  if (typeof msg.payload.deployment.lat !== \"number\") {\n    node.error(`Node-RED config.yml top-level deployment.lat is not a valid type; needs to be numeric`);\n  }\n}\nif (msg.payload.deployment.lon !== null) {\n  if (typeof msg.payload.deployment.lon !== \"number\") {\n    node.error(`Node-RED config.yml top-level deployment.lon is not a valid type; needs to be numeric`);\n  }\n}\nconst bearing_values = ['n', 's', 'e', 'w', 'ne', 'nw', 'se', 'sw'];\n//allow empty/null/undefined values\nif (msg.payload.deployment.bearing !== null) {\n  if (bearing_values.indexOf(msg.payload.deployment.bearing.toLowerCase()) !== -1) {\n    msg.payload.deployment.bearing = msg.payload.deployment.bearing.toLowerCase();\n  }\n  else {\n    node.error(`Node-RED config.yml top-level deployment.bearing is not a valid value; needs to be one of ${bearing_values}`);\n  }\n}\n\n// go through each of the sensors that have no deployment object and copy the top-level deployment object into them\n// do not overwrite any existing sensor deployment properties\nfor (const [sensorType, sensors] of Object.entries(msg.payload.sensors)) {\n  for (const [sensorName, sensor] of Object.entries(sensors)) {\n    if (sensor.hasOwnProperty('enabled') && sensor.enabled === true) {\n      if (sensor.hasOwnProperty('deployment')) {\n        const sensorDeployment = sensor.deployment;\n        const topLevelDeployment = msg.payload.deployment;\n        for (const [prop, value] of Object.entries(topLevelDeployment)) {\n          if (!sensorDeployment.hasOwnProperty(prop)) {\n            sensorDeployment[prop] = value;\n          }\n        }\n        if (sensorDeployment.hasOwnProperty('bearing')) {\n          const bearing = sensorDeployment.bearing.toLowerCase();\n          if (!bearing_values.includes(bearing)) {\n            node.error(`Invalid bearing value '${sensorDeployment.bearing}' for sensor '${sensorType}.${sensorName}'. Using default value ''.`, msg);\n            sensorDeployment.bearing = '';\n          }\n        }\n      } else {\n        msg.payload.sensors[sensorType][sensorName].deployment = { ...msg.payload.deployment };\n      }\n    }\n  }\n}\n\n//time\nmsg.payload.time.npt_set === false ? false : true;\n\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
         "noerr": 0,
@@ -2049,7 +2073,7 @@
         "z": "3dae026ab340962a",
         "g": "8004ba7ad5a9bd83",
         "name": "capture deployment info, send diff sql queries",
-        "func": "// msg.sqlActiveDeployments (sql query results, array of objects)\n// msg.sensors (sensorType.sensorName.properties)\n\nlet newArr = {};\nnewArr.updatedDeployment = [];\nnewArr.currentDeployment = [];\n\nconst sqlresults = msg.sqlActiveDeployments;\n\n//go through each sensor, see if new deployment configs (lat, lon, bearing) are different from previous deployment\nfor (const [sensorType, sensors] of Object.entries(msg.sensors)) {\n    for (const [sensorName, sensor] of Object.entries(sensors)) {\n        if (sensor.hasOwnProperty('enabled') && sensor.enabled === true) {\n            if (sensor.hasOwnProperty('deployment')) {\n                const sensorDeployment = sensor.deployment;\n\n                let newMsg = {};\n                newMsg.payload = {};\n                let updateMsg = {};\n                updateMsg.payload = {};\n                let mergedMsg = {};\n\n                let hasDifference = false;\n                newMsg.sqlSend = false;\n\n                //find matching sqlresult(s)\n                const sqlMatchObj = sqlresults.find(o => o.sensorName === sensorName);\n\n                if (sqlMatchObj) {\n                    //fields to check for differences\n                    [\"lat\", \"lon\", \"bearing\"].forEach(property => {\n                        if (sqlMatchObj[property] !== sensorDeployment[property]) {\n                            hasDifference = true;\n                        }\n                    });\n                }\n\n                //if new deployment, UPDATE old record's entryEndDateTime \n                if (hasDifference) {\n                    updateMsg.payload.id = sqlMatchObj.id;\n                    updateMsg.payload.entryEndDateTime = (new Date()).getTime();\n\n                    //send update query, updateMsg\n                    updateMsg.topic = `UPDATE deployment SET entryEndDateTime = ${updateMsg.payload.entryEndDateTime} WHERE id = '${updateMsg.payload.id}'`;\n                    updateMsg.sqlSend = true;\n                    node.send(updateMsg);\n                    mergedMsg = {...updateMsg.payload, ...sqlMatchObj};\n                    newArr.updatedDeployment.push(mergedMsg);\n                }\n\n                //if new deployment from difference or non-existing, and add new record\n                if (hasDifference || !sqlMatchObj) {\n                    const newDateTime = new Date();\n                    newMsg.payload.id = newDateTime.getTime() + '-' + Math.floor(Math.random() * 0xFFFFFFFF).toString(16).padStart(8, '0') + '-d';\n                    newMsg.payload.entryStartDateTime = newDateTime.getTime();\n                    newMsg.payload.entryEndDateTime = '';\n                    newMsg.payload.lat = sensorDeployment[\"lat\"];\n                    newMsg.payload.lon = sensorDeployment[\"lon\"];\n                    newMsg.payload.bearing = sensorDeployment[\"bearing\"];\n                    newMsg.payload.sensorName = sensorName;\n                    newMsg.payload.deviceName = global.get(\"deviceAttributes.deviceName\", 'config');\n                    //send add record query, newPayload\n                    newMsg.topic = `INSERT INTO deployment (id, entryStartDateTime, lat, lon, bearing, sensorName, deviceName) VALUES ('${newMsg.payload.id}', ${newMsg.payload.entryStartDateTime}, ${newMsg.payload.lat}, ${newMsg.payload.lon}, '${newMsg.payload.bearing}', '${newMsg.payload.sensorName}', '${newMsg.payload.deviceName}')`;\n                    newMsg.sqlSend = true;\n                    node.send(newMsg);\n\n                    //update config with id\n                    global.set(`config.sensors.${sensorType}.${sensorName}.deployment.id`, newMsg.payload.id, 'config');\n                }\n                else {\n                    newMsg.payload = sqlMatchObj;\n                }\n                //collect all sensor info for output\n                newArr.currentDeployment.push(newMsg.payload);\n            }\n        }\n    }\n}\n\nmsg = {};\nmsg.payload = newArr;\n\nnode.done();\nreturn msg;",
+        "func": "// msg.sqlActiveDeployments (sql query results, array of objects)\n// msg.sensors (sensorType.sensorName.properties)\n\nlet newArr = {};\nnewArr.updatedDeployment = [];\nnewArr.currentDeployment = [];\n\nconst sqlresults = msg.sqlActiveDeployments;\n\n//go through each sensor, see if new deployment configs (lat, lon, bearing) are different from previous deployment\nfor (const [sensorType, sensors] of Object.entries(msg.sensors)) {\n    for (const [sensorName, sensor] of Object.entries(sensors)) {\n        if (sensor.hasOwnProperty('enabled') && sensor.enabled === true) {\n            if (sensor.hasOwnProperty('deployment')) {\n                const sensorDeployment = sensor.deployment;\n\n                let newMsg = {};\n                newMsg.payload = {};\n                let updateMsg = {};\n                updateMsg.payload = {};\n                let mergedMsg = {};\n\n                let hasDifference = false;\n                newMsg.sqlSend = false;\n\n                //find matching sqlresult(s)\n                const sqlMatchObj = sqlresults.find(o => o.sensorName === sensorName);\n\n                if (sqlMatchObj) {\n                    //fields to check for differences\n                    [\"lat\", \"lon\", \"bearing\"].forEach(property => {\n                        if (sqlMatchObj[property] !== sensorDeployment[property]) {\n                            hasDifference = true;\n                        }\n                    });\n                }\n\n                //if new deployment, UPDATE old record's entryEndDateTime \n                if (hasDifference) {\n                    updateMsg.payload.id = sqlMatchObj.id;\n                    updateMsg.payload.entryEndDateTime = (new Date()).getTime();\n\n                    //send update query, updateMsg\n                    updateMsg.topic = `UPDATE deployment SET entryEndDateTime = ${updateMsg.payload.entryEndDateTime} WHERE id = '${updateMsg.payload.id}'`;\n                    updateMsg.sqlSend = true;\n                    node.send(updateMsg);\n                    mergedMsg = {...updateMsg.payload, ...sqlMatchObj};\n                    newArr.updatedDeployment.push(mergedMsg);\n                }\n\n                //if new deployment from difference or non-existing, and add new record\n                if (hasDifference || !sqlMatchObj) {\n                    const newDateTime = new Date();\n                    newMsg.payload.id = newDateTime.getTime() + '-' + Math.floor(Math.random() * 0xFFFFFFFF).toString(16).padStart(8, '0') + '-d';\n                    newMsg.payload.entryStartDateTime = newDateTime.getTime();\n                    newMsg.payload.entryEndDateTime = '';\n                    newMsg.payload.lat = sensorDeployment[\"lat\"];\n                    newMsg.payload.lon = sensorDeployment[\"lon\"];\n                    newMsg.payload.bearing = sensorDeployment[\"bearing\"];\n                    newMsg.payload.sensorType = sensorType;\n                    newMsg.payload.sensorName = sensorName;\n                    newMsg.payload.deviceName = global.get(\"deviceAttributes.deviceName\");\n                    //send add record query, newPayload\n                    newMsg.topic = `INSERT INTO deployment (id, entryStartDateTime, lat, lon, bearing, sensorType, sensorName, deviceName) VALUES ('${newMsg.payload.id}', ${newMsg.payload.entryStartDateTime}, ${newMsg.payload.lat}, ${newMsg.payload.lon}, '${newMsg.payload.bearing}', '${newMsg.payload.sensorType}', '${newMsg.payload.sensorName}', '${newMsg.payload.deviceName}')`;\n                    newMsg.sqlSend = true;\n                    node.send(newMsg);\n\n                    //update config with id\n                    global.set(`config.sensors.${sensorType}.${sensorName}.deployment.id`, newMsg.payload.id);\n                }\n                else {\n                    newMsg.payload = sqlMatchObj;\n                }\n                //collect all sensor info for output\n                newArr.currentDeployment.push(newMsg.payload);\n            }\n        }\n    }\n}\n\nmsg = {};\nmsg.payload = newArr;\n\nnode.done();\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
         "noerr": 0,
@@ -2228,7 +2252,7 @@
         "fieldType": "msg",
         "format": "sql",
         "syntax": "mustache",
-        "template": "CREATE TABLE IF NOT EXISTS deployment (\n    id TEXT PRIMARY KEY, \n    entryStartDateTime REAL, \n    entryEndDateTime REAL, \n    lat REAL, \n    lon REAL, \n    bearing TEXT, \n    sensorName TEXT, \n    deviceName TEXT\n    );",
+        "template": "CREATE TABLE IF NOT EXISTS deployment (\n    id TEXT PRIMARY KEY, \n    entryStartDateTime REAL, \n    entryEndDateTime REAL, \n    lat REAL, \n    lon REAL, \n    bearing TEXT, \n    sensorType TEXT, \n    sensorName TEXT, \n    deviceName TEXT\n    );",
         "output": "str",
         "x": 530,
         "y": 900,
@@ -2244,7 +2268,7 @@
         "z": "3dae026ab340962a",
         "g": "a2b2e69319628779",
         "name": "select latest 5 rows from deployment",
-        "field": "payload",
+        "field": "topic",
         "fieldType": "msg",
         "format": "sql",
         "syntax": "mustache",
@@ -2268,12 +2292,14 @@
         "fieldType": "msg",
         "format": "sql",
         "syntax": "mustache",
-        "template": "SELECT id, entryStartDateTime, sensorName, deviceName \nFROM deployment \nWHERE entryStartDateTime IN (   \n    SELECT MAX(entryStartDateTime)   \n    FROM deployment   \n    WHERE entryEndDateTime IS NULL   \n    GROUP BY sensorName, deviceName \n    ) \nORDER BY sensorName, deviceName;",
+        "template": "SELECT id, entryStartDateTime, sensorType, sensorName, deviceName \nFROM deployment \nWHERE entryStartDateTime IN (   \n    SELECT MAX(entryStartDateTime)   \n    FROM deployment   \n    WHERE entryEndDateTime IS NULL   \n    GROUP BY sensorName, deviceName \n    ) \nORDER BY sensorName, deviceName;",
         "output": "str",
         "x": 510,
         "y": 980,
         "wires": [
-            []
+            [
+                "8a6d4593a661c3df"
+            ]
         ]
     },
     {
@@ -5006,7 +5032,7 @@
         "type": "debug",
         "z": "b1fde507a4b80c79",
         "name": "debug: published airquality messages",
-        "active": true,
+        "active": false,
         "tosidebar": true,
         "console": false,
         "tostatus": false,
@@ -5299,6 +5325,7 @@
         "id": "f1530cb4468b517b",
         "type": "inject",
         "z": "b1fde507a4b80c79",
+        "d": true,
         "g": "672f3b07194c5dd5",
         "name": "inject manually",
         "props": [],
@@ -5308,7 +5335,7 @@
         "onceDelay": 0.1,
         "topic": "",
         "x": 200,
-        "y": 680,
+        "y": 660,
         "wires": [
             [
                 "f11bc2c9463f8c85"
@@ -5319,6 +5346,7 @@
         "id": "f11bc2c9463f8c85",
         "type": "template",
         "z": "b1fde507a4b80c79",
+        "d": true,
         "g": "672f3b07194c5dd5",
         "name": "drop",
         "field": "topic",
@@ -5328,7 +5356,7 @@
         "template": "DROP TABLE airquality;",
         "output": "str",
         "x": 470,
-        "y": 680,
+        "y": 660,
         "wires": [
             [
                 "35d0362b1f8a5e1a"
@@ -5339,6 +5367,7 @@
         "id": "3ac16ca7857d43a0",
         "type": "inject",
         "z": "b1fde507a4b80c79",
+        "d": true,
         "g": "672f3b07194c5dd5",
         "name": "inject manually",
         "props": [],
@@ -5348,7 +5377,7 @@
         "onceDelay": 0.1,
         "topic": "",
         "x": 200,
-        "y": 720,
+        "y": 700,
         "wires": [
             [
                 "88e51d22037ef437"
@@ -5359,6 +5388,7 @@
         "id": "88e51d22037ef437",
         "type": "template",
         "z": "b1fde507a4b80c79",
+        "d": true,
         "g": "672f3b07194c5dd5",
         "name": "pragma",
         "field": "topic",
@@ -5368,7 +5398,7 @@
         "template": "PRAGMA table_info(airquality);",
         "output": "str",
         "x": 480,
-        "y": 720,
+        "y": 700,
         "wires": [
             [
                 "35d0362b1f8a5e1a"
@@ -5379,12 +5409,12 @@
         "id": "677a57bbf3619854",
         "type": "http request",
         "z": "f7932be9acc7391c",
-        "g": "694f0242d0985c69",
-        "name": "tb telemetry http api",
+        "g": "43087a735f896849",
+        "name": "tb post http api",
         "method": "POST",
         "ret": "txt",
         "paytoqs": "ignore",
-        "url": "{{global.config.thingsboard.url}}/api/v1/{{global.config.access_token}}/telemetry",
+        "url": "",
         "tls": "",
         "persist": false,
         "proxy": "",
@@ -5392,8 +5422,8 @@
         "authType": "",
         "senderr": true,
         "headers": [],
-        "x": 1550,
-        "y": 220,
+        "x": 2240,
+        "y": 160,
         "wires": [
             [
                 "df6ac2f42ac6d8c7"
@@ -5404,9 +5434,9 @@
         "id": "df6ac2f42ac6d8c7",
         "type": "debug",
         "z": "f7932be9acc7391c",
-        "g": "694f0242d0985c69",
+        "g": "43087a735f896849",
         "name": "tb telemetry response",
-        "active": true,
+        "active": false,
         "tosidebar": true,
         "console": false,
         "tostatus": false,
@@ -5414,30 +5444,9 @@
         "targetType": "full",
         "statusVal": "",
         "statusType": "auto",
-        "x": 1760,
+        "x": 2320,
         "y": 220,
         "wires": []
-    },
-    {
-        "id": "4bec488857c0553f",
-        "type": "function",
-        "z": "f7932be9acc7391c",
-        "g": "b334a2375eb8cb42",
-        "name": "format event telemetry",
-        "func": "// format the payload with a timestamp\nlet values = {\n    ...msg.payload,\n}\n//ts in milliseconds\nmsg.payload = {\n    ts: values.frame_time * 1000,\n    values: {\n        event: values\n    }\n}\n\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 340,
-        "y": 220,
-        "wires": [
-            [
-                "93aa421659d2c20b"
-            ]
-        ]
     },
     {
         "id": "ed447e5f8becbfad",
@@ -5452,28 +5461,9 @@
         "y": 160,
         "wires": [
             [
-                "4bec488857c0553f",
-                "cc84d34370b6feb3"
+                "4bec488857c0553f"
             ]
         ]
-    },
-    {
-        "id": "cc84d34370b6feb3",
-        "type": "debug",
-        "z": "f7932be9acc7391c",
-        "g": "b334a2375eb8cb42",
-        "name": "event link in",
-        "active": false,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "payload",
-        "targetType": "msg",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 370,
-        "y": 160,
-        "wires": []
     },
     {
         "id": "695200d405f2d323",
@@ -5517,7 +5507,7 @@
             "01307f2f13f465f2"
         ],
         "x": 175,
-        "y": 460,
+        "y": 360,
         "wires": [
             [
                 "5d3596375bd695c0"
@@ -5534,7 +5524,7 @@
             "4094c101f6b59d95"
         ],
         "x": 175,
-        "y": 360,
+        "y": 260,
         "wires": [
             [
                 "2a979d76853ee0ab"
@@ -5551,7 +5541,7 @@
             "080fd00489701aa1"
         ],
         "x": 175,
-        "y": 500,
+        "y": 400,
         "wires": [
             [
                 "4796b517d7d045a7"
@@ -5568,7 +5558,7 @@
             "95186b0fee06a3f5"
         ],
         "x": 175,
-        "y": 540,
+        "y": 440,
         "wires": [
             [
                 "9a894f4bd304f5a9"
@@ -5585,7 +5575,7 @@
             "59a9c9a7ba535641"
         ],
         "x": 175,
-        "y": 580,
+        "y": 480,
         "wires": [
             [
                 "cc21b9e657cba081"
@@ -5597,10 +5587,10 @@
         "type": "comment",
         "z": "f7932be9acc7391c",
         "g": "1819134eccdf2660",
-        "name": "send immediately",
+        "name": "send radar_timedspeedcounts immediately",
         "info": "",
-        "x": 240,
-        "y": 400,
+        "x": 320,
+        "y": 300,
         "wires": []
     },
     {
@@ -5611,7 +5601,7 @@
         "name": "send radar_oc_payload w others to avoid hundreds of messages per object (oc = radar object detection end)",
         "info": "",
         "x": 530,
-        "y": 620,
+        "y": 520,
         "wires": []
     },
     {
@@ -5620,7 +5610,7 @@
         "z": "f7932be9acc7391c",
         "g": "1819134eccdf2660",
         "name": "format radar_timedspeedcounts telemetry",
-        "func": "// format the payload with a timestamp\nlet values = {\n    ...msg.payload,\n}\n//ts in milliseconds\nmsg.payload = {\n    ts: values.time * 1000,\n    values: {\n        radar_timedspeedcounts: values\n    }\n}\n\nreturn msg;",
+        "func": "// format the payload with a timestamp\nlet values = {\n    ...msg.payload,\n}\n//ts in milliseconds\nmsg.payload = {\n    ts: values.TimedSpeedCounts.time * 1000,\n    values: {\n        radar_timedspeedcounts: values.TimedSpeedCounts\n    }\n}\n\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
         "noerr": 0,
@@ -5628,10 +5618,10 @@
         "finalize": "",
         "libs": [],
         "x": 380,
-        "y": 360,
+        "y": 260,
         "wires": [
             [
-                "93aa421659d2c20b"
+                "aa8d606460d6e410"
             ]
         ]
     },
@@ -5649,7 +5639,7 @@
         "finalize": "",
         "libs": [],
         "x": 360,
-        "y": 580,
+        "y": 480,
         "wires": [
             [
                 "d3f14c01ec3c7250"
@@ -5674,7 +5664,7 @@
         "drop": false,
         "allowrate": false,
         "outputs": 1,
-        "x": 1290,
+        "x": 1530,
         "y": 200,
         "wires": [
             [
@@ -5705,10 +5695,10 @@
         "reduceInitType": "",
         "reduceFixup": "",
         "x": 820,
-        "y": 460,
+        "y": 360,
         "wires": [
             [
-                "93aa421659d2c20b"
+                "aa8d606460d6e410"
             ]
         ]
     },
@@ -5733,7 +5723,7 @@
         "to": "",
         "reg": false,
         "x": 610,
-        "y": 580,
+        "y": 480,
         "wires": [
             [
                 "ff1719e60656a2e6"
@@ -5754,7 +5744,7 @@
         "finalize": "",
         "libs": [],
         "x": 340,
-        "y": 460,
+        "y": 360,
         "wires": [
             [
                 "ff1719e60656a2e6"
@@ -5775,7 +5765,7 @@
         "finalize": "",
         "libs": [],
         "x": 400,
-        "y": 500,
+        "y": 400,
         "wires": [
             [
                 "ff1719e60656a2e6"
@@ -5796,7 +5786,7 @@
         "finalize": "",
         "libs": [],
         "x": 420,
-        "y": 540,
+        "y": 440,
         "wires": [
             [
                 "ff1719e60656a2e6"
@@ -5813,7 +5803,7 @@
             "1ba33a74f2d3a680"
         ],
         "x": 175,
-        "y": 720,
+        "y": 620,
         "wires": [
             [
                 "c6ff73faf6fa9e98"
@@ -5834,10 +5824,10 @@
         "finalize": "",
         "libs": [],
         "x": 360,
-        "y": 720,
+        "y": 620,
         "wires": [
             [
-                "93aa421659d2c20b"
+                "aa8d606460d6e410"
             ]
         ]
     },
@@ -5855,10 +5845,10 @@
         "finalize": "",
         "libs": [],
         "x": 370,
-        "y": 820,
+        "y": 720,
         "wires": [
             [
-                "93aa421659d2c20b"
+                "aa8d606460d6e410"
             ]
         ]
     },
@@ -5872,60 +5862,10 @@
             "6dca925fad91c100"
         ],
         "x": 175,
-        "y": 820,
+        "y": 720,
         "wires": [
             [
                 "521115ddd5741eea"
-            ]
-        ]
-    },
-    {
-        "id": "542b3b8720733a01",
-        "type": "debug",
-        "z": "f7932be9acc7391c",
-        "g": "8d3fe796e032166c",
-        "name": "tb attributes response",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "true",
-        "targetType": "full",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 1800,
-        "y": 1180,
-        "wires": []
-    },
-    {
-        "id": "0a28f82092611160",
-        "type": "http request",
-        "z": "f7932be9acc7391c",
-        "g": "8d3fe796e032166c",
-        "name": "send client-side attributes",
-        "method": "POST",
-        "ret": "txt",
-        "paytoqs": "ignore",
-        "url": "{{global.config.thingsboard.url}}/api/v1/{{global.config.access_token}}/attributes",
-        "tls": "",
-        "persist": false,
-        "proxy": "",
-        "insecureHTTPParser": false,
-        "authType": "",
-        "senderr": false,
-        "headers": [
-            {
-                "keyType": "Content-Type",
-                "keyValue": "",
-                "valueType": "application/json",
-                "valueValue": ""
-            }
-        ],
-        "x": 1570,
-        "y": 1180,
-        "wires": [
-            [
-                "542b3b8720733a01"
             ]
         ]
     },
@@ -5935,7 +5875,7 @@
         "z": "f7932be9acc7391c",
         "g": "fac72767826a76d9",
         "name": "set deployment client side attribute payload",
-        "func": "var newMsg = {};\n\n// format the payload with a timestamp\nlet values = {\n    ...msg.payload.currentDeployment,\n}\n//ts in milliseconds\nnewMsg.payload = {\n    ts: new Date().getTime(),\n    values: {\n        deploymentSensors: values,\n        deploymentTopLat: global.get(\"config.deployment.lat\",'config'),\n        deploymentTopLon: global.get(\"config.deployment.lon\",'config'),\n        deploymentTopBearing: global.get(\"config.deployment.bearing\",'config')\n    }\n}\n\nreturn newMsg;\n\n//global.set(`config.sensors.${sensorType}.${sensorName}.deployment.id`, newPayload.id, 'config');\n",
+        "func": "var newMsg = {};\n\n// format the payload with a timestamp\nlet values = {\n    ...msg.payload.currentDeployment,\n}\n//ts in milliseconds\nnewMsg.payload = {\n    ts: new Date().getTime(),\n    values: {\n        deploymentSensors: values,\n        deploymentTopLat: global.get(\"config.deployment.lat\"),\n        deploymentTopLon: global.get(\"config.deployment.lon\"),\n        deploymentTopBearing: global.get(\"config.deployment.bearing\")\n    }\n}\n\nreturn newMsg;\n\n",
         "outputs": 1,
         "timeout": 0,
         "noerr": 0,
@@ -5946,7 +5886,7 @@
         "y": 1220,
         "wires": [
             [
-                "058c390e87e3c283"
+                "232db2c330aebd95"
             ]
         ]
     },
@@ -5981,7 +5921,7 @@
         "y": 1120,
         "wires": [
             [
-                "058c390e87e3c283"
+                "232db2c330aebd95"
             ]
         ]
     },
@@ -5991,7 +5931,7 @@
         "z": "f7932be9acc7391c",
         "g": "694f0242d0985c69",
         "name": "thingsboard.enabled",
-        "property": "#:(config)::thingsboard.enabled",
+        "property": "config.thingsboard.enabled",
         "propertyType": "global",
         "rules": [
             {
@@ -6001,7 +5941,7 @@
         "checkall": "true",
         "repair": false,
         "outputs": 1,
-        "x": 1260,
+        "x": 1500,
         "y": 160,
         "wires": [
             [
@@ -6014,8 +5954,8 @@
         "type": "switch",
         "z": "f7932be9acc7391c",
         "g": "694f0242d0985c69",
-        "name": "tb protocol",
-        "property": "#:(config)::thingsboard.protocol",
+        "name": "tb protocol?",
+        "property": "config.thingsboard.protocol",
         "propertyType": "global",
         "rules": [
             {
@@ -6032,116 +5972,15 @@
         "checkall": "true",
         "repair": false,
         "outputs": 2,
-        "x": 1350,
+        "x": 1590,
         "y": 240,
         "wires": [
             [
-                "677a57bbf3619854"
+                "dd3f9ef16332021c"
             ],
             []
         ],
         "info": "see https://thingsboard.io/docs/reference/protocols/"
-    },
-    {
-        "id": "058c390e87e3c283",
-        "type": "switch",
-        "z": "f7932be9acc7391c",
-        "g": "8d3fe796e032166c",
-        "name": "thingsboard.enabled",
-        "property": "#:(config)::thingsboard.enabled",
-        "propertyType": "global",
-        "rules": [
-            {
-                "t": "true"
-            }
-        ],
-        "checkall": "true",
-        "repair": false,
-        "outputs": 1,
-        "x": 1260,
-        "y": 1120,
-        "wires": [
-            [
-                "9c111c8d0f212bf8"
-            ]
-        ]
-    },
-    {
-        "id": "9c111c8d0f212bf8",
-        "type": "delay",
-        "z": "f7932be9acc7391c",
-        "g": "8d3fe796e032166c",
-        "name": "",
-        "pauseType": "rate",
-        "timeout": "5",
-        "timeoutUnits": "seconds",
-        "rate": "1000",
-        "nbRateUnits": "1",
-        "rateUnits": "minute",
-        "randomFirst": "1",
-        "randomLast": "5",
-        "randomUnits": "seconds",
-        "drop": false,
-        "allowrate": false,
-        "outputs": 1,
-        "x": 1290,
-        "y": 1160,
-        "wires": [
-            [
-                "8ad71425a71a860e"
-            ]
-        ]
-    },
-    {
-        "id": "8ad71425a71a860e",
-        "type": "switch",
-        "z": "f7932be9acc7391c",
-        "g": "8d3fe796e032166c",
-        "name": "tb protocol",
-        "property": "#:(config)::thingsboard.protocol",
-        "propertyType": "global",
-        "rules": [
-            {
-                "t": "eq",
-                "v": "http",
-                "vt": "str"
-            },
-            {
-                "t": "eq",
-                "v": "mqtt",
-                "vt": "str"
-            }
-        ],
-        "checkall": "true",
-        "repair": false,
-        "outputs": 2,
-        "x": 1350,
-        "y": 1200,
-        "wires": [
-            [
-                "0a28f82092611160"
-            ],
-            []
-        ],
-        "info": "see https://thingsboard.io/docs/reference/protocols/"
-    },
-    {
-        "id": "a473c7e4eeb01dcd",
-        "type": "template",
-        "z": "f7932be9acc7391c",
-        "g": "b334a2375eb8cb42",
-        "name": "",
-        "field": "payload",
-        "fieldType": "msg",
-        "format": "handlebars",
-        "syntax": "mustache",
-        "template": "This is the payload: {{payload}} !",
-        "output": "str",
-        "x": 300,
-        "y": 260,
-        "wires": [
-            []
-        ]
     },
     {
         "id": "2be1c8d04ce69a48",
@@ -6153,7 +5992,7 @@
             "ef6ffe823574c1d1"
         ],
         "x": 175,
-        "y": 920,
+        "y": 820,
         "wires": [
             [
                 "08da197b902c939e"
@@ -6173,10 +6012,161 @@
         "template": "{\n    \"ts\":{{payload.entryDateTime}},\n    \"values\": {\n        \"airquality\": {\n            \"entryDateTime\": {{payload.entryDateTime}},\n            \"gas_calibrated\": {{payload.gas_calibrated}},\n            \"temp\": {{payload.temp}},\n            \"bar\": {{payload.bar}},\n            \"hum\": {{payload.hum}},\n            \"dew\": {{payload.dew}},\n            \"temp_raw\": {{payload.temp_raw}},\n            \"bar_raw\": {{payload.bar_raw}},\n            \"hum_raw\": {{payload.hum_raw}},\n            \"pm01\": {{payload.pm01}},\n            \"pm025\": {{payload.pm025}},\n            \"pm10\": {{payload.pm10}},\n            \"gas_red\": {{payload.gas_red}},\n            \"gas_oxi\": {{payload.gas_oxi}},\n            \"gas_nh3\": {{payload.gas_nh3}},\n            \"gas_red_raw\": {{payload.gas_red_raw}},\n            \"gas_oxi_raw\": {{payload.gas_oxi_raw}},\n            \"gas_nh3_raw\": {{payload.gas_nh3_raw}},\n            \"lux\": {{payload.lux}},\n            \"lux_raw\": {{payload.lux_raw}},\n            \"proximity\": {{payload.proximity}},\n            \"sensorName\": \"{{payload.sensorName}}\",\n            \"deployment_id\": \"{{payload.deployment_id}}\"\n        }\n    }\n}",
         "output": "json",
         "x": 350,
-        "y": 920,
+        "y": 820,
+        "wires": [
+            [
+                "aa8d606460d6e410"
+            ]
+        ]
+    },
+    {
+        "id": "9c944328e288b2dc",
+        "type": "template",
+        "z": "f7932be9acc7391c",
+        "g": "43087a735f896849",
+        "name": "telemetry msg.url",
+        "field": "url",
+        "fieldType": "msg",
+        "format": "handlebars",
+        "syntax": "mustache",
+        "template": "{{{global.config.thingsboard.url}}}/api/v1/{{{global.config.thingsboard.access_token}}}/telemetry",
+        "output": "str",
+        "x": 2010,
+        "y": 160,
+        "wires": [
+            [
+                "677a57bbf3619854"
+            ]
+        ]
+    },
+    {
+        "id": "75f7976086cc9838",
+        "type": "change",
+        "z": "f7932be9acc7391c",
+        "g": "fe1b9f6f9d89d353",
+        "name": "msg.type = attributes",
+        "rules": [
+            {
+                "t": "set",
+                "p": "type",
+                "pt": "msg",
+                "to": "attributes",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 1180,
+        "y": 1120,
         "wires": [
             [
                 "93aa421659d2c20b"
+            ]
+        ]
+    },
+    {
+        "id": "221ddfedf40c108f",
+        "type": "change",
+        "z": "f7932be9acc7391c",
+        "g": "2f27e270200485b9",
+        "name": "msg.type = telemetry",
+        "rules": [
+            {
+                "t": "set",
+                "p": "type",
+                "pt": "msg",
+                "to": "telemetry",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 1180,
+        "y": 160,
+        "wires": [
+            [
+                "93aa421659d2c20b"
+            ]
+        ]
+    },
+    {
+        "id": "dd3f9ef16332021c",
+        "type": "switch",
+        "z": "f7932be9acc7391c",
+        "g": "43087a735f896849",
+        "name": "msg.type?",
+        "property": "type",
+        "propertyType": "msg",
+        "rules": [
+            {
+                "t": "eq",
+                "v": "telemetry",
+                "vt": "str"
+            },
+            {
+                "t": "eq",
+                "v": "attributes",
+                "vt": "str"
+            }
+        ],
+        "checkall": "true",
+        "repair": false,
+        "outputs": 2,
+        "x": 1810,
+        "y": 180,
+        "wires": [
+            [
+                "9c944328e288b2dc"
+            ],
+            [
+                "d739b10ce5fa8f40"
+            ]
+        ]
+    },
+    {
+        "id": "d739b10ce5fa8f40",
+        "type": "template",
+        "z": "f7932be9acc7391c",
+        "g": "43087a735f896849",
+        "name": "attributes msg.url",
+        "field": "url",
+        "fieldType": "msg",
+        "format": "handlebars",
+        "syntax": "mustache",
+        "template": "{{{global.config.thingsboard.url}}}/api/v1/{{{global.config.thingsboard.access_token}}}/attributes",
+        "output": "str",
+        "x": 2010,
+        "y": 200,
+        "wires": [
+            [
+                "677a57bbf3619854"
+            ]
+        ]
+    },
+    {
+        "id": "4bec488857c0553f",
+        "type": "function",
+        "z": "f7932be9acc7391c",
+        "g": "b334a2375eb8cb42",
+        "name": "format event telemetry",
+        "func": "// format the payload with a timestamp\nlet values = {\n    ...msg.payload,\n}\n//ts in milliseconds\nmsg.payload = {\n    ts: values.frame_time * 1000,\n    values: {\n        event: values\n    }\n}\n\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 340,
+        "y": 160,
+        "wires": [
+            [
+                "aa8d606460d6e410"
             ]
         ]
     },

--- a/node-red-project/flows.json
+++ b/node-red-project/flows.json
@@ -567,7 +567,7 @@
         "x": 108,
         "y": 999,
         "w": 1198,
-        "h": 408
+        "h": 468
     },
     {
         "id": "9e0b1edd49eb4244",
@@ -1087,11 +1087,12 @@
             "ecc317fcd059b4c3",
             "b0252bd49dc8e61d",
             "94136e5a6f092bb6",
-            "5ffb7c9c38b8c5b0"
+            "5ffb7c9c38b8c5b0",
+            "2fa46892748adc43"
         ],
         "x": 74,
         "y": 259,
-        "w": 732,
+        "w": 832,
         "h": 162
     },
     {
@@ -1133,7 +1134,7 @@
         },
         "nodes": [
             "2be1c8d04ce69a48",
-            "08da197b902c939e"
+            "87d3892038bb3e5f"
         ],
         "x": 134,
         "y": 779,
@@ -1155,7 +1156,7 @@
             "9b0f7197fe82bbfa"
         ],
         "x": 134,
-        "y": 1299,
+        "y": 1359,
         "w": 492,
         "h": 82
     },
@@ -1175,12 +1176,14 @@
             "0b62cae60d488c85",
             "4af0d78e8bc39647",
             "66bace5cf805a4fb",
-            "22f397ac5c294b6e"
+            "22f397ac5c294b6e",
+            "c49d311e5668de52",
+            "9941048ea93dc79c"
         ],
         "x": 134,
         "y": 1079,
         "w": 472,
-        "h": 202
+        "h": 262
     },
     {
         "id": "b7398c4e0bc743e5",
@@ -1951,7 +1954,8 @@
         "y": 340,
         "wires": [
             [
-                "b0252bd49dc8e61d"
+                "b0252bd49dc8e61d",
+                "2fa46892748adc43"
             ]
         ]
     },
@@ -2318,6 +2322,20 @@
                 "8a6d4593a661c3df"
             ]
         ]
+    },
+    {
+        "id": "2fa46892748adc43",
+        "type": "link out",
+        "z": "3dae026ab340962a",
+        "g": "4bbb9e24b5507a00",
+        "name": "init-config link out",
+        "mode": "link",
+        "links": [
+            "c49d311e5668de52"
+        ],
+        "x": 865,
+        "y": 340,
+        "wires": []
     },
     {
         "id": "0612ca7936dee14a",
@@ -5154,7 +5172,7 @@
         "z": "b1fde507a4b80c79",
         "g": "672f3b07194c5dd5",
         "name": "debug: airquality query",
-        "active": false,
+        "active": true,
         "tosidebar": true,
         "console": false,
         "tostatus": false,
@@ -5276,7 +5294,7 @@
         "fieldType": "msg",
         "format": "handlebars",
         "syntax": "mustache",
-        "template": "{\n    \"entryDateTime\": {{payload.current_time}},\n    \"gas_calibrated\": {{#payload.gas_calibrated}}1{{/payload.gas_calibrated}}{{^payload.gas_calibrated}}0{{/payload.gas_calibrated}},\n    \"temp\": {{payload.temp}},\n    \"bar\": {{payload.bar.0}},\n    \"hum\": {{payload.hum.0}},\n    \"dew\": {{payload.dew}},\n    \"temp_raw\": {{payload.temp_raw}},\n    \"bar_raw\": {{payload.bar_raw}},\n    \"hum_raw\": {{payload.hum_raw}},\n    \"pm01\": {{payload.pm01}},\n    \"pm025\": {{payload.pm025}},\n    \"pm10\": {{payload.pm10}},\n    \"gas_red\": {{payload.gas_red}},\n    \"gas_oxi\": {{payload.gas_oxi}},\n    \"gas_nh3\": {{payload.gas_nh3}},\n    \"gas_red_raw\": {{payload.gas_red_raw}},\n    \"gas_oxi_raw\": {{payload.gas_oxi_raw}},\n    \"gas_nh3_raw\": {{payload.gas_nh3_raw}},\n    \"lux\": {{payload.lux}},\n    \"lux_raw\": {{payload.lux_raw}},\n    \"proximity\": {{payload.proximity}},\n    \"sensorName\": \"{{sensor.name}}\",\n    \"deployment_id\": \"{{sensor.deployment_id}}\"\n}",
+        "template": "{\n    \"entryDateTime\": {{payload.current_time}},\n    \"gas_calibrated\": {{#payload.gas_calibrated}}1{{/payload.gas_calibrated}}{{^payload.gas_calibrated}}0{{/payload.gas_calibrated}},\n    \"temp\": {{payload.temp}},\n    \"bar\": {{payload.bar.0}},\n    \"hum\": {{payload.hum.0}},\n    \"dew\": {{payload.dew}},\n    \"temp_raw\": {{payload.temp_raw}},\n    \"bar_raw\": {{payload.bar_raw}},\n    \"hum_raw\": {{payload.hum_raw}},\n    \"pm01\": {{payload.pm01}},\n    \"pm025\": {{payload.pm025}},\n    \"pm10\": {{payload.pm10}},\n    \"gas_red\": {{payload.gas_red}},\n    \"gas_oxi\": {{payload.gas_oxi}},\n    \"gas_nh3\": {{payload.gas_nh3}},\n    \"gas_red_raw\": {{payload.gas_red_raw}},\n    \"gas_oxi_raw\": {{payload.gas_oxi_raw}},\n    \"gas_nh3_raw\": {{payload.gas_nh3_raw}},\n    \"lux\": {{payload.lux}},\n    \"lux_raw\": {{payload.lux_raw}},\n    \"proximity\": {{payload.proximity}},\n    \"sensorName\": \"{{sensor.name}}\",\n    \"deployment_id\": \"{{sensor.deployment.id}}\"\n}",
         "output": "json",
         "x": 740,
         "y": 240,
@@ -5884,7 +5902,7 @@
             "1ba33a74f2d3a680"
         ],
         "x": 175,
-        "y": 1340,
+        "y": 1400,
         "wires": [
             [
                 "9b0f7197fe82bbfa"
@@ -5978,27 +5996,7 @@
         "y": 820,
         "wires": [
             [
-                "08da197b902c939e"
-            ]
-        ]
-    },
-    {
-        "id": "08da197b902c939e",
-        "type": "template",
-        "z": "f7932be9acc7391c",
-        "g": "f35d3f484c2f6107",
-        "name": "format airquality telemetry",
-        "field": "payload",
-        "fieldType": "msg",
-        "format": "handlebars",
-        "syntax": "mustache",
-        "template": "{\n    \"ts\":{{payload.entryDateTime}},\n    \"values\": {\n        \"airquality\": {\n            \"entryDateTime\": {{payload.entryDateTime}},\n            \"gas_calibrated\": {{payload.gas_calibrated}},\n            \"temp\": {{payload.temp}},\n            \"bar\": {{payload.bar}},\n            \"hum\": {{payload.hum}},\n            \"dew\": {{payload.dew}},\n            \"temp_raw\": {{payload.temp_raw}},\n            \"bar_raw\": {{payload.bar_raw}},\n            \"hum_raw\": {{payload.hum_raw}},\n            \"pm01\": {{payload.pm01}},\n            \"pm025\": {{payload.pm025}},\n            \"pm10\": {{payload.pm10}},\n            \"gas_red\": {{payload.gas_red}},\n            \"gas_oxi\": {{payload.gas_oxi}},\n            \"gas_nh3\": {{payload.gas_nh3}},\n            \"gas_red_raw\": {{payload.gas_red_raw}},\n            \"gas_oxi_raw\": {{payload.gas_oxi_raw}},\n            \"gas_nh3_raw\": {{payload.gas_nh3_raw}},\n            \"lux\": {{payload.lux}},\n            \"lux_raw\": {{payload.lux_raw}},\n            \"proximity\": {{payload.proximity}},\n            \"sensorName\": \"{{payload.sensorName}}\",\n            \"deployment_id\": \"{{payload.deployment_id}}\"\n        }\n    }\n}",
-        "output": "json",
-        "x": 350,
-        "y": 820,
-        "wires": [
-            [
-                "8c521232f464d27a"
+                "87d3892038bb3e5f"
             ]
         ]
     },
@@ -6166,7 +6164,7 @@
         "template": "{\n    \"deployments\": {\n        {{#payload.currentDeployment}}\n        \"{{sensorName}}\": {\n            \"sensorType\": \"{{sensorType}}\",\n            \"lat\": {{lat}},\n            \"lon\": {{lon}},\n            \"bearing\": \"{{bearing}}\",\n            \"id\": \"{{id}}\"\n        },\n        {{/payload.currentDeployment}}\n        \"deploymentTopLevel\": {\n            \"lat\": {{global.config.deployment.lat}},\n            \"lon\": {{global.config.deployment.lon}},\n            \"bearing\": \"{{global.config.deployment.bearing}}\"\n        }\n    }\n}",
         "output": "json",
         "x": 430,
-        "y": 1340,
+        "y": 1400,
         "wires": [
             [
                 "75f7976086cc9838"
@@ -6317,6 +6315,65 @@
         "libs": [],
         "x": 410,
         "y": 1240,
+        "wires": [
+            [
+                "75f7976086cc9838"
+            ]
+        ]
+    },
+    {
+        "id": "87d3892038bb3e5f",
+        "type": "function",
+        "z": "f7932be9acc7391c",
+        "g": "f35d3f484c2f6107",
+        "name": "format airquality telemetry",
+        "func": "const newPayload = {\n    ts: (msg.payload.entryDateTime * 1000),\n    values: {\n        airquality: {\n            entryDateTime:  msg.payload.entryDateTime,\n            gas_calibrated: msg.payload.gas_calibrated,\n            temp:           msg.payload.temp,\n            bar:            msg.payload.bar,\n            hum:            msg.payload.hum,\n            dew:            msg.payload.dew,\n            temp_raw:       msg.payload.temp_raw,\n            bar_raw:        msg.payload.bar_raw,\n            hum_raw:        msg.payload.hum_raw,\n            pm01:           msg.payload.pm01,\n            pm025:          msg.payload.pm025,\n            pm10:           msg.payload.pm10,\n            gas_red:        msg.payload.gas_red,\n            gas_oxi:        msg.payload.gas_oxi,\n            gas_nh3:        msg.payload.gas_nh3,\n            gas_red_raw:    msg.payload.gas_red_raw,\n            gas_oxi_raw:    msg.payload.gas_oxi_raw,\n            gas_nh3_raw:    msg.payload.gas_nh3_raw,\n            lux:            msg.payload.lux,\n            lux_raw:        msg.payload.lux_raw,\n            proximity:      msg.payload.proximity,\n            sensorName:     msg.payload.sensorName,\n            deployment_id:  msg.payload.deployment_id\n        }\n    }\n}\n\nmsg.payload = newPayload;\n\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 350,
+        "y": 820,
+        "wires": [
+            [
+                "8c521232f464d27a"
+            ]
+        ]
+    },
+    {
+        "id": "c49d311e5668de52",
+        "type": "link in",
+        "z": "f7932be9acc7391c",
+        "g": "f034ca2ecdf9a2f6",
+        "name": "init-config device attributes link in",
+        "links": [
+            "2fa46892748adc43"
+        ],
+        "x": 175,
+        "y": 1300,
+        "wires": [
+            [
+                "9941048ea93dc79c"
+            ]
+        ]
+    },
+    {
+        "id": "9941048ea93dc79c",
+        "type": "function",
+        "z": "f7932be9acc7391c",
+        "g": "f034ca2ecdf9a2f6",
+        "name": "format init-config client-side attributes",
+        "func": "const newPayload = {\n    config_tm: msg.payload\n}\n\nmsg.payload = newPayload;\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 410,
+        "y": 1300,
         "wires": [
             [
                 "75f7976086cc9838"

--- a/node-red-project/flows.json
+++ b/node-red-project/flows.json
@@ -542,12 +542,13 @@
             "b334a2375eb8cb42",
             "1819134eccdf2660",
             "55a1af374cc8ecb9",
-            "99dfff63ac837bc8"
+            "99dfff63ac837bc8",
+            "f35d3f484c2f6107"
         ],
         "x": 108,
         "y": 93,
         "w": 924,
-        "h": 834
+        "h": 934
     },
     {
         "id": "fe1b9f6f9d89d353",
@@ -563,7 +564,7 @@
             "d367cb76b239682f"
         ],
         "x": 114,
-        "y": 979,
+        "y": 1119,
         "w": 492,
         "h": 142
     },
@@ -583,7 +584,7 @@
             "8ad71425a71a860e"
         ],
         "x": 1114,
-        "y": 979,
+        "y": 1119,
         "w": 812,
         "h": 162
     },
@@ -809,13 +810,60 @@
         "h": 854
     },
     {
+        "id": "672f3b07194c5dd5",
+        "type": "group",
+        "z": "b1fde507a4b80c79",
+        "name": "set up airquality database table",
+        "style": {
+            "label": true
+        },
+        "nodes": [
+            "35d0362b1f8a5e1a",
+            "ad3b1bd4bcdd6731",
+            "e063e562cca50f31",
+            "9ec2c67401c5aebc",
+            "d61da5053d3a100e",
+            "e13414feb4f512b8",
+            "f1530cb4468b517b",
+            "f11bc2c9463f8c85",
+            "3ac16ca7857d43a0",
+            "88e51d22037ef437"
+        ],
+        "x": 74,
+        "y": 539,
+        "w": 1032,
+        "h": 222
+    },
+    {
+        "id": "efdb589a1b6e0c2f",
+        "type": "group",
+        "z": "b1fde507a4b80c79",
+        "name": "capture airquality messages, assign properties, format message, save and send",
+        "style": {
+            "label": true
+        },
+        "nodes": [
+            "8cae4cba37aecc0d",
+            "99bfb6c2ced810ec",
+            "014464d29b72fa53",
+            "24ae834ea737eac6",
+            "ef6ffe823574c1d1",
+            "4ef1e892a6b1c695"
+        ],
+        "x": 294,
+        "y": 159,
+        "w": 952,
+        "h": 222
+    },
+    {
         "id": "b334a2375eb8cb42",
         "type": "group",
         "z": "f7932be9acc7391c",
         "g": "2f27e270200485b9",
         "name": "event",
         "style": {
-            "label": true
+            "label": true,
+            "fill": "#e3f3d3"
         },
         "nodes": [
             "4bec488857c0553f",
@@ -835,7 +883,8 @@
         "g": "2f27e270200485b9",
         "name": "radar",
         "style": {
-            "label": true
+            "label": true,
+            "fill": "#ffbfbf"
         },
         "nodes": [
             "fee85b1886270ac6",
@@ -865,7 +914,8 @@
         "g": "2f27e270200485b9",
         "name": "deployment",
         "style": {
-            "label": true
+            "label": true,
+            "fill": "#ffffbf"
         },
         "nodes": [
             "8a83d59ee0db1198",
@@ -884,7 +934,8 @@
         "g": "2f27e270200485b9",
         "name": "system-metrics",
         "style": {
-            "label": true
+            "label": true,
+            "fill": "#dbcbe7"
         },
         "nodes": [
             "521115ddd5741eea",
@@ -1066,46 +1117,23 @@
         "h": 622
     },
     {
-        "id": "672f3b07194c5dd5",
+        "id": "f35d3f484c2f6107",
         "type": "group",
-        "z": "b1fde507a4b80c79",
-        "name": "set up airquality database table",
+        "z": "f7932be9acc7391c",
+        "g": "2f27e270200485b9",
+        "name": "airquality",
         "style": {
-            "label": true
+            "label": true,
+            "fill": "#bfdbef"
         },
         "nodes": [
-            "35d0362b1f8a5e1a",
-            "ad3b1bd4bcdd6731",
-            "e063e562cca50f31",
-            "9ec2c67401c5aebc",
-            "d61da5053d3a100e",
-            "e13414feb4f512b8"
+            "2be1c8d04ce69a48",
+            "08da197b902c939e"
         ],
-        "x": 74,
-        "y": 539,
-        "w": 1042,
-        "h": 122
-    },
-    {
-        "id": "efdb589a1b6e0c2f",
-        "type": "group",
-        "z": "b1fde507a4b80c79",
-        "name": "capture airquality messages, assign properties, format message, save and send",
-        "style": {
-            "label": true
-        },
-        "nodes": [
-            "8cae4cba37aecc0d",
-            "99bfb6c2ced810ec",
-            "014464d29b72fa53",
-            "24ae834ea737eac6",
-            "a40ef3730c08bfce",
-            "ef6ffe823574c1d1"
-        ],
-        "x": 234,
-        "y": 159,
-        "w": 872,
-        "h": 302
+        "x": 134,
+        "y": 919,
+        "w": 252,
+        "h": 82
     },
     {
         "id": "05a58d9ee463c696",
@@ -3231,7 +3259,9 @@
         "g": "1eebfe6a2eca8ad4",
         "name": "radar_dov link out",
         "mode": "link",
-        "links": [],
+        "links": [
+            "fee85b1886270ac6"
+        ],
         "x": 475,
         "y": 580,
         "wires": []
@@ -3243,7 +3273,9 @@
         "g": "da1c8c74261a93a4",
         "name": "radar_oc_payload link out",
         "mode": "link",
-        "links": [],
+        "links": [
+            "e05e91362c933e94"
+        ],
         "x": 475,
         "y": 1780,
         "wires": []
@@ -3255,7 +3287,9 @@
         "g": "fcbf8999ca05a371",
         "name": "radar_raw_speed_magnitude_single link out",
         "mode": "link",
-        "links": [],
+        "links": [
+            "0124afc74d86b533"
+        ],
         "x": 485,
         "y": 1640,
         "wires": []
@@ -3267,7 +3301,9 @@
         "g": "047f05d7650ba3cc",
         "name": "radar_raw_speed_magnitude link out",
         "mode": "link",
-        "links": [],
+        "links": [
+            "fc5e2cd719fa680a"
+        ],
         "x": 475,
         "y": 1160,
         "wires": []
@@ -3279,7 +3315,9 @@
         "g": "dea1b8828f8e501f",
         "name": "radar_timedspeedcounts link out",
         "mode": "link",
-        "links": [],
+        "links": [
+            "087588593911f398"
+        ],
         "x": 475,
         "y": 880,
         "wires": []
@@ -5005,7 +5043,9 @@
         "z": "f7932be9acc7391c",
         "g": "1819134eccdf2660",
         "name": "radar_dov link in",
-        "links": [],
+        "links": [
+            "01307f2f13f465f2"
+        ],
         "x": 175,
         "y": 460,
         "wires": [
@@ -5020,7 +5060,9 @@
         "z": "f7932be9acc7391c",
         "g": "1819134eccdf2660",
         "name": "radar_timedspeedcounts link in",
-        "links": [],
+        "links": [
+            "4094c101f6b59d95"
+        ],
         "x": 175,
         "y": 360,
         "wires": [
@@ -5035,7 +5077,9 @@
         "z": "f7932be9acc7391c",
         "g": "1819134eccdf2660",
         "name": "radar_raw_speed_magnitude link in",
-        "links": [],
+        "links": [
+            "080fd00489701aa1"
+        ],
         "x": 175,
         "y": 500,
         "wires": [
@@ -5050,7 +5094,9 @@
         "z": "f7932be9acc7391c",
         "g": "1819134eccdf2660",
         "name": "radar_raw_speed_magnitude_single link in",
-        "links": [],
+        "links": [
+            "95186b0fee06a3f5"
+        ],
         "x": 175,
         "y": 540,
         "wires": [
@@ -5065,7 +5111,9 @@
         "z": "f7932be9acc7391c",
         "g": "1819134eccdf2660",
         "name": "radar_oc_payload link in",
-        "links": [],
+        "links": [
+            "59a9c9a7ba535641"
+        ],
         "x": 175,
         "y": 580,
         "wires": [
@@ -5387,7 +5435,7 @@
         "statusVal": "",
         "statusType": "auto",
         "x": 1780,
-        "y": 1080,
+        "y": 1220,
         "wires": []
     },
     {
@@ -5415,7 +5463,7 @@
             }
         ],
         "x": 1550,
-        "y": 1080,
+        "y": 1220,
         "wires": [
             [
                 "542b3b8720733a01"
@@ -5436,7 +5484,7 @@
         "finalize": "",
         "libs": [],
         "x": 410,
-        "y": 1080,
+        "y": 1220,
         "wires": [
             [
                 "058c390e87e3c283"
@@ -5453,7 +5501,7 @@
             "1ba33a74f2d3a680"
         ],
         "x": 155,
-        "y": 1080,
+        "y": 1220,
         "wires": [
             [
                 "f453ff6136f95abe"
@@ -5471,7 +5519,7 @@
             "7c96d66a8330a4fc"
         ],
         "x": 155,
-        "y": 1020,
+        "y": 1160,
         "wires": [
             [
                 "058c390e87e3c283"
@@ -5552,7 +5600,7 @@
         "repair": false,
         "outputs": 1,
         "x": 1240,
-        "y": 1020,
+        "y": 1160,
         "wires": [
             [
                 "9c111c8d0f212bf8"
@@ -5578,7 +5626,7 @@
         "allowrate": false,
         "outputs": 1,
         "x": 1270,
-        "y": 1060,
+        "y": 1200,
         "wires": [
             [
                 "8ad71425a71a860e"
@@ -5609,7 +5657,7 @@
         "repair": false,
         "outputs": 2,
         "x": 1330,
-        "y": 1100,
+        "y": 1240,
         "wires": [
             [
                 "0a28f82092611160"
@@ -5632,6 +5680,41 @@
         "output": "str",
         "x": 300,
         "y": 260,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "2be1c8d04ce69a48",
+        "type": "link in",
+        "z": "f7932be9acc7391c",
+        "g": "f35d3f484c2f6107",
+        "name": "airquality link in",
+        "links": [
+            "ef6ffe823574c1d1"
+        ],
+        "x": 175,
+        "y": 960,
+        "wires": [
+            [
+                "08da197b902c939e"
+            ]
+        ]
+    },
+    {
+        "id": "08da197b902c939e",
+        "type": "template",
+        "z": "f7932be9acc7391c",
+        "g": "f35d3f484c2f6107",
+        "name": "",
+        "field": "payload",
+        "fieldType": "msg",
+        "format": "handlebars",
+        "syntax": "mustache",
+        "template": "This is the payload: {{payload}} !",
+        "output": "str",
+        "x": 300,
+        "y": 960,
         "wires": [
             []
         ]
@@ -11236,7 +11319,7 @@
         "wires": [
             [
                 "3da49a479e99f3b5",
-                "a40ef3730c08bfce"
+                "4ef1e892a6b1c695"
             ]
         ]
     },
@@ -11319,7 +11402,7 @@
         "type": "debug",
         "z": "b1fde507a4b80c79",
         "g": "672f3b07194c5dd5",
-        "name": "debug: last 5 rows airquality",
+        "name": "debug: airquality query",
         "active": true,
         "tosidebar": true,
         "console": false,
@@ -11328,7 +11411,7 @@
         "targetType": "msg",
         "statusVal": "",
         "statusType": "auto",
-        "x": 950,
+        "x": 960,
         "y": 620,
         "wires": []
     },
@@ -11341,8 +11424,8 @@
         "sqlquery": "prepared",
         "sql": "INSERT INTO airquality (entryDateTime, gas_calibrated, temp, bar, hum, dew, temp_raw, bar_raw, hum_raw, pm01, pm025, pm10, gas_red, gas_oxi, gas_nh3, gas_red_raw, gas_oxi_raw, gas_nh3_raw, lux, lux_raw, proximity, noise_level, sensorName, deployment_id)\nVALUES ($entryDateTime, $gas_calibrated, $temp, $bar, $hum, $dew, $temp_raw, $bar_raw, $hum_raw, $pm01, $pm025, $pm10, $gas_red, $gas_oxi, $gas_nh3, $gas_red_raw, $gas_oxi_raw, $gas_nh3_raw, $lux, $lux_raw, $proximity, $noise_level, $sensorName, $deployment_id);\n",
         "name": "",
-        "x": 940,
-        "y": 360,
+        "x": 1080,
+        "y": 280,
         "wires": [
             []
         ]
@@ -11360,8 +11443,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 890,
-        "y": 320,
+        "x": 1030,
+        "y": 240,
         "wires": [
             [
                 "8cae4cba37aecc0d"
@@ -11378,7 +11461,7 @@
         "fieldType": "msg",
         "format": "sql",
         "syntax": "mustache",
-        "template": "CREATE TABLE IF NOT EXISTS airquality (\n    entryDateTime REAL\n    gas_calibrated INTEGER\n    temp REAL\n    bar REAL\n    hum REAL\n    dew REAL\n    temp_raw REAL\n    bar_raw REAL\n    hum_raw REAL\n    pm01 REAL\n    pm025 REAL\n    pm10 REAL\n    gas_red REAL\n    gas_oxi REAL\n    gas_nh3 REAL\n    gas_red_raw REAL\n    gas_oxi_raw REAL\n    gas_nh3_raw REAL\n    lux REAL\n    lux_raw REAL\n    proximity REAL\n    noise_level REAL\n    sensorName TEXT\n    deployment_id TEXT\n    );",
+        "template": "CREATE TABLE IF NOT EXISTS airquality (\n    entryDateTime REAL,\n    gas_calibrated INTEGER,\n    temp REAL,\n    bar REAL,\n    hum REAL,\n    dew REAL,\n    temp_raw REAL,\n    bar_raw REAL,\n    hum_raw REAL,\n    pm01 REAL,\n    pm025 REAL,\n    pm10 REAL,\n    gas_red REAL,\n    gas_oxi REAL,\n    gas_nh3 REAL,\n    gas_red_raw REAL,\n    gas_oxi_raw REAL,\n    gas_nh3_raw REAL,\n    lux REAL,\n    lux_raw REAL,\n    proximity REAL,\n    noise_level REAL,\n    sensorName TEXT,\n    deployment_id TEXT\n);",
         "output": "str",
         "x": 600,
         "y": 580,
@@ -11424,10 +11507,12 @@
         "checkall": "true",
         "repair": false,
         "outputs": 1,
-        "x": 500,
+        "x": 520,
         "y": 240,
         "wires": [
-            []
+            [
+                "24ae834ea737eac6"
+            ]
         ]
     },
     {
@@ -11440,35 +11525,14 @@
         "fieldType": "msg",
         "format": "handlebars",
         "syntax": "mustache",
-        "template": "{\n    \"entryDateTime\": {{payload.current_time}},\n    \"gas_calibrated\": {{#payload.Gas Calibrated}}1{{/payload.Gas Calibrated}}{{^payload.Gas Calibrated}}0{{/payload.Gas Calibrated}},\n    \"temp\": {{payload.Temp}},\n    \"bar\": {{#payload}}{{#Bar}}{{.[0]}}{{/Bar}}{{/payload}},\n    \"hum\": {{#payload}}{{#Hum}}{{.[0]}}{{/Hum}}{{/payload}},\n    \"dew\": {{payload.Dew}},\n    \"temp_raw\": {{payload.temp_raw}},\n    \"bar_raw\": {{payload.bar_raw}},\n    \"hum_raw\": {{payload.hum_raw}},\n    \"pm01\": {{payload.P1}},\n    \"pm025\": {{payload.P2.5}},\n    \"pm10\": {{payload.P10}},\n    \"gas_red\": {{payload.Red}},\n    \"gas_oxi\": {{payload.Oxi}},\n    \"gas_nh3\": {{payload.NH3}},\n    \"gas_red_raw\": {{payload.gas_red_raw}},\n    \"gas_oxi_raw\": {{payload.gas_oxi_raw}},\n    \"gas_nh3_raw\": {{payload.gas_nh3_raw}},\n    \"lux\": {{payload.lux}},\n    \"lux_raw\": {{payload.lux_raw}},\n    \"proximity\": {{payload.proximity}},\n    \"noise_level\": \"\",\n    \"sensorName\": {{sensor.name}},\n    \"deployment_id\": {{sensor.deployment_id}}\n}",
+        "template": "{\n    \"entryDateTime\": {{payload.current_time}},\n    \"gas_calibrated\": {{#payload.gas_calibrated}}1{{/payload.gas_calibrated}}{{^payload.gas_calibrated}}0{{/payload.gas_calibrated}},\n    \"temp\": {{payload.temp}},\n    \"bar\": {{payload.bar.0}},\n    \"hum\": {{payload.hum.0}},\n    \"dew\": {{payload.dew}},\n    \"temp_raw\": {{payload.temp_raw}},\n    \"bar_raw\": {{payload.bar_raw}},\n    \"hum_raw\": {{payload.hum_raw}},\n    \"pm01\": {{payload.p01}},\n    \"pm025\": {{payload.p025}},\n    \"pm10\": {{payload.p10}},\n    \"gas_red\": {{payload.gas_red}},\n    \"gas_oxi\": {{payload.gas_oxi}},\n    \"gas_nh3\": {{payload.gas_nh3}},\n    \"gas_red_raw\": {{payload.gas_red_raw}},\n    \"gas_oxi_raw\": {{payload.gas_oxi_raw}},\n    \"gas_nh3_raw\": {{payload.gas_nh3_raw}},\n    \"lux\": {{payload.lux}},\n    \"lux_raw\": {{payload.lux_raw}},\n    \"proximity\": {{payload.proximity}},\n    \"noise_level\": \"\",\n    \"sensorName\": \"{{sensor.name}}\",\n    \"deployment_id\": \"{{sensor.deployment_id}}\"\n}",
         "output": "json",
-        "x": 600,
-        "y": 320,
+        "x": 740,
+        "y": 240,
         "wires": [
             [
                 "99bfb6c2ced810ec",
                 "ef6ffe823574c1d1"
-            ]
-        ]
-    },
-    {
-        "id": "a40ef3730c08bfce",
-        "type": "function",
-        "z": "b1fde507a4b80c79",
-        "g": "efdb589a1b6e0c2f",
-        "name": "append config, deployment properties",
-        "func": "// attach deployment_id, if applicable\nmsg.sensor = {}\n\n//pull the airquality_monitor name, will be second element in mqtt topic; e.g. aq/sensorname01/readings\nconst sensor = global.get(`config.sensors.airquality_monitors.${msg.topic.split('/')[1]}`);\nmsg.sensor.name = msg.topic.split('/')[1];\n\n//indicate if sensor is enabled in TM for capture\nif (sensor.hasOwnProperty('enabled')) {\n    msg.sensor.enabled = sensor.enabled;\n}\n\n//attach deployment_id to message\nif (sensor.hasOwnProperty('deployment')) {\n    msg.sensor.deployment_id = sensor.deployment.id;\n}\n\n//attach mqtt topic to message\nif (sensor.hasOwnProperty('mqtt_topic_incoming')) {\n    msg.sensor.mqtt_topic_incoming = sensor.mqtt_topic_incoming;\n}\n\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 410,
-        "y": 200,
-        "wires": [
-            [
-                "014464d29b72fa53"
             ]
         ]
     },
@@ -11479,9 +11543,11 @@
         "g": "efdb589a1b6e0c2f",
         "name": "airquality link out",
         "mode": "link",
-        "links": [],
-        "x": 775,
-        "y": 420,
+        "links": [
+            "2be1c8d04ce69a48"
+        ],
+        "x": 915,
+        "y": 340,
         "wires": []
     },
     {
@@ -11515,5 +11581,120 @@
         "x": 400,
         "y": 40,
         "wires": []
+    },
+    {
+        "id": "4ef1e892a6b1c695",
+        "type": "change",
+        "z": "b1fde507a4b80c79",
+        "g": "efdb589a1b6e0c2f",
+        "name": "set sensor config properties",
+        "rules": [
+            {
+                "t": "set",
+                "p": "sensor",
+                "pt": "msg",
+                "to": "$globalContext(\"config.sensors.airquality_monitors.\" & $split(topic, '/', limit)[1])\t ",
+                "tot": "jsonata"
+            },
+            {
+                "t": "set",
+                "p": "sensor.name",
+                "pt": "msg",
+                "to": "$split(topic, '/', limit)[1]",
+                "tot": "jsonata"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 440,
+        "y": 200,
+        "wires": [
+            [
+                "014464d29b72fa53"
+            ]
+        ]
+    },
+    {
+        "id": "f1530cb4468b517b",
+        "type": "inject",
+        "z": "b1fde507a4b80c79",
+        "g": "672f3b07194c5dd5",
+        "name": "inject manually",
+        "props": [],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "x": 200,
+        "y": 680,
+        "wires": [
+            [
+                "f11bc2c9463f8c85"
+            ]
+        ]
+    },
+    {
+        "id": "f11bc2c9463f8c85",
+        "type": "template",
+        "z": "b1fde507a4b80c79",
+        "g": "672f3b07194c5dd5",
+        "name": "drop",
+        "field": "topic",
+        "fieldType": "msg",
+        "format": "sql",
+        "syntax": "mustache",
+        "template": "DROP TABLE airquality;",
+        "output": "str",
+        "x": 470,
+        "y": 680,
+        "wires": [
+            [
+                "35d0362b1f8a5e1a"
+            ]
+        ]
+    },
+    {
+        "id": "3ac16ca7857d43a0",
+        "type": "inject",
+        "z": "b1fde507a4b80c79",
+        "g": "672f3b07194c5dd5",
+        "name": "inject manually",
+        "props": [],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "x": 200,
+        "y": 720,
+        "wires": [
+            [
+                "88e51d22037ef437"
+            ]
+        ]
+    },
+    {
+        "id": "88e51d22037ef437",
+        "type": "template",
+        "z": "b1fde507a4b80c79",
+        "g": "672f3b07194c5dd5",
+        "name": "pragma",
+        "field": "topic",
+        "fieldType": "msg",
+        "format": "sql",
+        "syntax": "mustache",
+        "template": "PRAGMA table_info(airquality);",
+        "output": "str",
+        "x": 480,
+        "y": 720,
+        "wires": [
+            [
+                "35d0362b1f8a5e1a"
+            ]
+        ]
     }
 ]

--- a/node-red-project/flows.json
+++ b/node-red-project/flows.json
@@ -309,7 +309,8 @@
             "840802d34d143ded",
             "8d65b604e8d9e7f9",
             "db1f35650c8d6448",
-            "6e2a152aecd929d3"
+            "6e2a152aecd929d3",
+            "d53997b3fec84e3a"
         ],
         "x": 14,
         "y": 19,
@@ -805,8 +806,8 @@
         ],
         "x": 48,
         "y": 233,
-        "w": 1024,
-        "h": 854
+        "w": 1050,
+        "h": 920
     },
     {
         "id": "672f3b07194c5dd5",
@@ -1088,14 +1089,7 @@
             "label": true
         },
         "nodes": [
-            "8a6d4593a661c3df",
-            "ff28acdecfc4ebb1",
-            "751ff2049a663e9c",
-            "3cdbccf5dbcb1c4e",
             "f6ecdd18d8e03f91",
-            "f9a2f4f97e3ba1cf",
-            "928d7cafdc1ab7fa",
-            "8f4e9d81288d5abd",
             "689b64c16a889e0a",
             "bc398ad5de3bd112",
             "6d2f607b324415b4",
@@ -1105,14 +1099,12 @@
             "05c37560dd57ea90",
             "ac8b2de05ec27001",
             "696c3a7b0b83f7b5",
-            "ba3b41519066f03a",
-            "f111096594207360",
-            "c25adb99d55eb890"
+            "a2b2e69319628779"
         ],
-        "x": 74,
+        "x": 88,
         "y": 439,
-        "w": 972,
-        "h": 622
+        "w": 984,
+        "h": 688
     },
     {
         "id": "f35d3f484c2f6107",
@@ -1190,6 +1182,32 @@
         "y": 759,
         "w": 812,
         "h": 122
+    },
+    {
+        "id": "a2b2e69319628779",
+        "type": "group",
+        "z": "3dae026ab340962a",
+        "g": "8004ba7ad5a9bd83",
+        "name": "create deployment table",
+        "style": {
+            "label": true
+        },
+        "nodes": [
+            "8a6d4593a661c3df",
+            "ff28acdecfc4ebb1",
+            "751ff2049a663e9c",
+            "3cdbccf5dbcb1c4e",
+            "f9a2f4f97e3ba1cf",
+            "928d7cafdc1ab7fa",
+            "8f4e9d81288d5abd",
+            "ba3b41519066f03a",
+            "f111096594207360",
+            "c25adb99d55eb890"
+        ],
+        "x": 114,
+        "y": 859,
+        "w": 932,
+        "h": 242
     },
     {
         "id": "05a58d9ee463c696",
@@ -1865,13 +1883,13 @@
         "id": "8a6d4593a661c3df",
         "type": "sqlite",
         "z": "3dae026ab340962a",
-        "g": "8004ba7ad5a9bd83",
+        "g": "a2b2e69319628779",
         "mydb": "2f60c1ab30a6fc8f",
         "sqlquery": "msg.topic",
         "sql": "",
         "name": "",
-        "x": 820,
-        "y": 860,
+        "x": 860,
+        "y": 900,
         "wires": [
             [
                 "3cdbccf5dbcb1c4e"
@@ -1882,7 +1900,7 @@
         "id": "ff28acdecfc4ebb1",
         "type": "inject",
         "z": "3dae026ab340962a",
-        "g": "8004ba7ad5a9bd83",
+        "g": "a2b2e69319628779",
         "name": "inject after 0.1 sec",
         "props": [],
         "repeat": "",
@@ -1890,8 +1908,8 @@
         "once": true,
         "onceDelay": 0.1,
         "topic": "",
-        "x": 210,
-        "y": 860,
+        "x": 250,
+        "y": 900,
         "wires": [
             [
                 "ba3b41519066f03a"
@@ -1902,7 +1920,7 @@
         "id": "751ff2049a663e9c",
         "type": "inject",
         "z": "3dae026ab340962a",
-        "g": "8004ba7ad5a9bd83",
+        "g": "a2b2e69319628779",
         "name": "inject manually",
         "props": [],
         "repeat": "",
@@ -1910,8 +1928,8 @@
         "once": false,
         "onceDelay": 0.1,
         "topic": "",
-        "x": 200,
-        "y": 900,
+        "x": 240,
+        "y": 940,
         "wires": [
             [
                 "f111096594207360"
@@ -1922,7 +1940,7 @@
         "id": "3cdbccf5dbcb1c4e",
         "type": "debug",
         "z": "3dae026ab340962a",
-        "g": "8004ba7ad5a9bd83",
+        "g": "a2b2e69319628779",
         "name": "sqlite select last 5 msgs",
         "active": true,
         "tosidebar": true,
@@ -1932,8 +1950,8 @@
         "targetType": "msg",
         "statusVal": "",
         "statusType": "auto",
-        "x": 850,
-        "y": 900,
+        "x": 890,
+        "y": 940,
         "wires": []
     },
     {
@@ -1957,7 +1975,7 @@
         "id": "f9a2f4f97e3ba1cf",
         "type": "inject",
         "z": "3dae026ab340962a",
-        "g": "8004ba7ad5a9bd83",
+        "g": "a2b2e69319628779",
         "name": "inject manually",
         "props": [],
         "repeat": "",
@@ -1965,8 +1983,8 @@
         "once": false,
         "onceDelay": "5",
         "topic": "",
-        "x": 200,
-        "y": 940,
+        "x": 240,
+        "y": 980,
         "wires": [
             [
                 "c25adb99d55eb890"
@@ -1978,7 +1996,7 @@
         "type": "inject",
         "z": "3dae026ab340962a",
         "d": true,
-        "g": "8004ba7ad5a9bd83",
+        "g": "a2b2e69319628779",
         "name": "drop table deployment",
         "props": [
             {
@@ -1991,8 +2009,8 @@
         "once": false,
         "onceDelay": 0.1,
         "topic": "DROP TABLE IF EXISTS deployment;",
-        "x": 500,
-        "y": 980,
+        "x": 540,
+        "y": 1020,
         "wires": [
             [
                 "8a6d4593a661c3df"
@@ -2004,7 +2022,7 @@
         "type": "inject",
         "z": "3dae026ab340962a",
         "d": true,
-        "g": "8004ba7ad5a9bd83",
+        "g": "a2b2e69319628779",
         "name": "alter table deployment from 0.2.0 to 0.3.0",
         "props": [
             {
@@ -2017,8 +2035,8 @@
         "once": false,
         "onceDelay": 0.1,
         "topic": "ALTER TABLE deployment RENAME COLUMN entryDateTime TO entryStartDateTime; ALTER TABLE deployment ADD COLUMN entryEndDateTime REAL; ALTER TABLE deployment RENAME COLUMN orientation TO bearing; ALTER TABLE deployment DROP COLUMN address; ALTER TABLE deployment DROP COLUMN description; ALTER TABLE deployment ADD COLUMN sensor TEXT;",
-        "x": 440,
-        "y": 1020,
+        "x": 480,
+        "y": 1060,
         "wires": [
             [
                 "8a6d4593a661c3df"
@@ -2204,7 +2222,7 @@
         "id": "ba3b41519066f03a",
         "type": "template",
         "z": "3dae026ab340962a",
-        "g": "8004ba7ad5a9bd83",
+        "g": "a2b2e69319628779",
         "name": "create table deployment",
         "field": "topic",
         "fieldType": "msg",
@@ -2212,8 +2230,8 @@
         "syntax": "mustache",
         "template": "CREATE TABLE IF NOT EXISTS deployment (\n    id TEXT PRIMARY KEY, \n    entryStartDateTime REAL, \n    entryEndDateTime REAL, \n    lat REAL, \n    lon REAL, \n    bearing TEXT, \n    sensorName TEXT, \n    deviceName TEXT\n    );",
         "output": "str",
-        "x": 490,
-        "y": 860,
+        "x": 530,
+        "y": 900,
         "wires": [
             [
                 "8a6d4593a661c3df"
@@ -2224,7 +2242,7 @@
         "id": "f111096594207360",
         "type": "template",
         "z": "3dae026ab340962a",
-        "g": "8004ba7ad5a9bd83",
+        "g": "a2b2e69319628779",
         "name": "select latest 5 rows from deployment",
         "field": "payload",
         "fieldType": "msg",
@@ -2232,8 +2250,8 @@
         "syntax": "mustache",
         "template": "SELECT * \nFROM deployment \nORDER BY entryStartDateTime DESC \nLIMIT 5;",
         "output": "str",
-        "x": 450,
-        "y": 900,
+        "x": 490,
+        "y": 940,
         "wires": [
             [
                 "8a6d4593a661c3df"
@@ -2244,7 +2262,7 @@
         "id": "c25adb99d55eb890",
         "type": "template",
         "z": "3dae026ab340962a",
-        "g": "8004ba7ad5a9bd83",
+        "g": "a2b2e69319628779",
         "name": "select latest active deployments",
         "field": "topic",
         "fieldType": "msg",
@@ -2252,8 +2270,8 @@
         "syntax": "mustache",
         "template": "SELECT id, entryStartDateTime, sensorName, deviceName \nFROM deployment \nWHERE entryStartDateTime IN (   \n    SELECT MAX(entryStartDateTime)   \n    FROM deployment   \n    WHERE entryEndDateTime IS NULL   \n    GROUP BY sensorName, deviceName \n    ) \nORDER BY sensorName, deviceName;",
         "output": "str",
-        "x": 470,
-        "y": 940,
+        "x": 510,
+        "y": 980,
         "wires": [
             []
         ]
@@ -7807,7 +7825,9 @@
         "x": 710,
         "y": 100,
         "wires": [
-            []
+            [
+                "d53997b3fec84e3a"
+            ]
         ]
     },
     {
@@ -8906,6 +8926,26 @@
         "wires": [
             []
         ]
+    },
+    {
+        "id": "d53997b3fec84e3a",
+        "type": "ui_toast",
+        "z": "239d7b3ba410ad5e",
+        "g": "541d31d14bcd8b00",
+        "position": "top right",
+        "displayTime": "3",
+        "highlight": "",
+        "sendall": true,
+        "outputs": 0,
+        "ok": "OK",
+        "cancel": "",
+        "raw": false,
+        "className": "",
+        "topic": "",
+        "name": "",
+        "x": 1010,
+        "y": 100,
+        "wires": []
     },
     {
         "id": "9fe1b87c70ae182d",

--- a/node-red-project/flows.json
+++ b/node-red-project/flows.json
@@ -87,7 +87,7 @@
             "ec7a0e0b1c62e91d"
         ],
         "x": 14,
-        "y": 319,
+        "y": 599,
         "w": 852,
         "h": 202
     },
@@ -106,7 +106,7 @@
             "eb140f61419c6a08"
         ],
         "x": 14,
-        "y": 79,
+        "y": 379,
         "w": 852,
         "h": 202
     },
@@ -126,7 +126,7 @@
             "4f84bcb60e4be762"
         ],
         "x": 14,
-        "y": 559,
+        "y": 819,
         "w": 1052,
         "h": 222
     },
@@ -149,7 +149,7 @@
             "7db4b197df9eb075"
         ],
         "x": 14,
-        "y": 839,
+        "y": 1059,
         "w": 1178,
         "h": 508
     },
@@ -177,8 +177,8 @@
             "c2270f3050bf35ab",
             "3214e8cd3ea79630"
         ],
-        "x": 224,
-        "y": 1539,
+        "x": 214,
+        "y": 1599,
         "w": 1022,
         "h": 542
     },
@@ -199,13 +199,10 @@
             "170ddffb726db9e0",
             "befe91e6862c72db",
             "13a061996f9322f3",
-            "98571c77b9801a83",
-            "bb08a223f0aaef0f",
-            "e3b795e05d7650b2",
-            "c7f00f59861cd00f"
+            "98571c77b9801a83"
         ],
-        "x": 154,
-        "y": 2119,
+        "x": 214,
+        "y": 2179,
         "w": 1172,
         "h": 342
     },
@@ -224,8 +221,8 @@
             "9cf49f0891d25df1",
             "6d81c8e3c89b68f6"
         ],
-        "x": 54,
-        "y": 2519,
+        "x": 214,
+        "y": 2559,
         "w": 1252,
         "h": 242
     },
@@ -961,7 +958,7 @@
             "57fa6ca2b7d290e3"
         ],
         "x": 54,
-        "y": 1159,
+        "y": 1379,
         "w": 1112,
         "h": 162
     },
@@ -980,8 +977,8 @@
             "9226865e3385eb56",
             "aa0afb5180297e2b"
         ],
-        "x": 304,
-        "y": 1739,
+        "x": 294,
+        "y": 1799,
         "w": 612,
         "h": 122
     },
@@ -1235,6 +1232,24 @@
         "h": 162
     },
     {
+        "id": "2df66c6bc991dbf4",
+        "type": "group",
+        "z": "28627559bebdc324",
+        "name": "camera selection",
+        "style": {
+            "label": true
+        },
+        "nodes": [
+            "bb08a223f0aaef0f",
+            "e3b795e05d7650b2",
+            "c7f00f59861cd00f"
+        ],
+        "x": 14,
+        "y": 79,
+        "w": 312,
+        "h": 142
+    },
+    {
         "id": "05a58d9ee463c696",
         "type": "junction",
         "z": "1c71c8f26f5b7b19",
@@ -1424,7 +1439,7 @@
         "type": "ui_group",
         "name": "Events aggregates",
         "tab": "665d947f9a312a33",
-        "order": 1,
+        "order": 2,
         "disp": true,
         "width": "12",
         "collapse": false,
@@ -1435,7 +1450,7 @@
         "type": "ui_group",
         "name": "Live updates",
         "tab": "665d947f9a312a33",
-        "order": 2,
+        "order": 3,
         "disp": true,
         "width": 12,
         "collapse": false,
@@ -1723,6 +1738,17 @@
         "name": "Backup & Restore",
         "tab": "0fd9a947334c7d0f",
         "order": 2,
+        "disp": true,
+        "width": "6",
+        "collapse": false,
+        "className": ""
+    },
+    {
+        "id": "202181a361213d6d",
+        "type": "ui_group",
+        "name": "Camera Selector",
+        "tab": "665d947f9a312a33",
+        "order": 1,
         "disp": true,
         "width": "6",
         "collapse": false,
@@ -6320,7 +6346,7 @@
         "payload": "",
         "payloadType": "date",
         "x": 200,
-        "y": 600,
+        "y": 860,
         "wires": [
             [
                 "928b71f25ce6e7b6"
@@ -6367,7 +6393,7 @@
         "useDifferentColor": false,
         "className": "",
         "x": 710,
-        "y": 240,
+        "y": 540,
         "wires": [
             []
         ]
@@ -6390,7 +6416,7 @@
         "senderr": false,
         "headers": [],
         "x": 310,
-        "y": 180,
+        "y": 480,
         "wires": [
             [
                 "eb140f61419c6a08"
@@ -6411,7 +6437,7 @@
         "onceDelay": "5",
         "topic": "",
         "x": 230,
-        "y": 120,
+        "y": 420,
         "wires": [
             [
                 "b241a0ef89fd7ce4"
@@ -6424,7 +6450,7 @@
         "z": "28627559bebdc324",
         "g": "5aac1262472b0205",
         "name": "structure frigate api/summary",
-        "func": "var newMsg = [{}];\nnewMsg[0].series = [];\nnewMsg[0].data = [];\nnewMsg[0].label = [];\n\nmsg.payload.forEach((myItem) => {\n\n    //only do this for the radar camera and 10 days or less ago\n    if (myItem.camera == env.get(\"VAR_RADAR_CAMERA\") && new Date(myItem.day).getTime() >= Math.floor((Date.now() - 86400000 * 10))) {\n        //if label doesn't exist, push it\n        if (newMsg[0].series.indexOf(myItem.label) < 0) {\n            newMsg[0].series.push(myItem.label);\n            //create new data array element that matches the series index\n            newMsg[0].data[newMsg[0].series.indexOf(myItem.label)] = [];\n        }\n\n        //Check if it's a new date or existing in data[0][0].x\n        //datapoint for date \n        let xIndex = newMsg[0].data[newMsg[0].series.indexOf(myItem.label)].findIndex((element) => element.x == String(new Date(myItem.day)));\n        if (xIndex < 0) {\n            //new date\n            let thisDataPoint = {};\n            thisDataPoint.x = new Date(myItem.day);\n            thisDataPoint.y = myItem.count;\n            newMsg[0].data[newMsg[0].series.indexOf(myItem.label)].push(thisDataPoint);\n        }\n        else {\n            //date exists, sum counts\n            newMsg[0].data[newMsg[0].series.indexOf(myItem.label)][xIndex].y += myItem.count;\n        }\n\n    };\n    \n});\n\nmsg.payload = newMsg;\n\nreturn msg;",
+        "func": "var newMsg = [{}];\nnewMsg[0].series = [];\nnewMsg[0].data = [];\nnewMsg[0].label = [];\n\nmsg.payload.forEach((myItem) => {\n\n    //only do this for the radar camera and 10 days or less ago\n    if (myItem.camera == flow.get(\"camera_selection\") && new Date(myItem.day).getTime() >= Math.floor((Date.now() - 86400000 * 10))) {\n        //if label doesn't exist, push it\n        if (newMsg[0].series.indexOf(myItem.label) < 0) {\n            newMsg[0].series.push(myItem.label);\n            //create new data array element that matches the series index\n            newMsg[0].data[newMsg[0].series.indexOf(myItem.label)] = [];\n        }\n\n        //Check if it's a new date or existing in data[0][0].x\n        //datapoint for date \n        let xIndex = newMsg[0].data[newMsg[0].series.indexOf(myItem.label)].findIndex((element) => element.x == String(new Date(myItem.day)));\n        if (xIndex < 0) {\n            //new date\n            let thisDataPoint = {};\n            thisDataPoint.x = new Date(myItem.day);\n            thisDataPoint.y = myItem.count;\n            newMsg[0].data[newMsg[0].series.indexOf(myItem.label)].push(thisDataPoint);\n        }\n        else {\n            //date exists, sum counts\n            newMsg[0].data[newMsg[0].series.indexOf(myItem.label)][xIndex].y += myItem.count;\n        }\n\n    };\n    \n});\n\nmsg.payload = newMsg;\n\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
         "noerr": 0,
@@ -6432,7 +6458,7 @@
         "finalize": "",
         "libs": [],
         "x": 400,
-        "y": 240,
+        "y": 540,
         "wires": [
             [
                 "08d030ffc3fe6adb"
@@ -6462,7 +6488,7 @@
         "payload": "",
         "payloadType": "date",
         "x": 200,
-        "y": 360,
+        "y": 640,
         "wires": [
             [
                 "5f3716d2176c3ab4"
@@ -6509,7 +6535,7 @@
         "useDifferentColor": false,
         "className": "",
         "x": 710,
-        "y": 480,
+        "y": 760,
         "wires": [
             []
         ]
@@ -6522,8 +6548,8 @@
         "links": [
             "274f87c31437c2d7"
         ],
-        "x": 165,
-        "y": 1580,
+        "x": 145,
+        "y": 1640,
         "wires": [
             [
                 "5ec2d3ba52f944f5",
@@ -6551,8 +6577,8 @@
         "checkall": "true",
         "repair": false,
         "outputs": 1,
-        "x": 750,
-        "y": 1940,
+        "x": 740,
+        "y": 2000,
         "wires": [
             [
                 "c788d632f5e93a73"
@@ -6577,8 +6603,8 @@
         "checkall": "true",
         "repair": false,
         "outputs": 1,
-        "x": 390,
-        "y": 1660,
+        "x": 380,
+        "y": 1720,
         "wires": [
             [
                 "c2270f3050bf35ab"
@@ -6598,8 +6624,8 @@
         "initialize": "// Code added here will be run once\n// whenever the node is started.\n\nif (flow.get(\"events_recent_radar\") === undefined) {\n    flow.set(\"events_recent_radar\", [])\n}\n",
         "finalize": "",
         "libs": [],
-        "x": 800,
-        "y": 1980,
+        "x": 790,
+        "y": 2040,
         "wires": [
             [
                 "4c087723a1d698e9"
@@ -6619,8 +6645,8 @@
         "initialize": "// Code added here will be run once\n// whenever the node is started.\n\nif (flow.get(\"events_recent_radar\") === undefined) {\n    flow.set(\"events_recent_radar\", [])\n}\n",
         "finalize": "",
         "libs": [],
-        "x": 760,
-        "y": 1900,
+        "x": 750,
+        "y": 1960,
         "wires": [
             [
                 "c36c71706e494b5e",
@@ -6633,9 +6659,9 @@
         "type": "switch",
         "z": "28627559bebdc324",
         "g": "9b9e4fc50b744fc3",
-        "name": "only use radar cam",
-        "property": "payload.radarName",
-        "propertyType": "msg",
+        "name": "only use selected camera",
+        "property": "camera_selection",
+        "propertyType": "flow",
         "rules": [
             {
                 "t": "nnull"
@@ -6644,8 +6670,8 @@
         "checkall": "true",
         "repair": false,
         "outputs": 1,
-        "x": 340,
-        "y": 1620,
+        "x": 350,
+        "y": 1680,
         "wires": [
             [
                 "2e680914d7da5c94"
@@ -6668,8 +6694,8 @@
         "resendOnRefresh": true,
         "templateScope": "local",
         "className": "",
-        "x": 1060,
-        "y": 1900,
+        "x": 1050,
+        "y": 1960,
         "wires": [
             []
         ]
@@ -6688,8 +6714,8 @@
         "targetType": "msg",
         "statusVal": "",
         "statusType": "auto",
-        "x": 360,
-        "y": 1580,
+        "x": 350,
+        "y": 1640,
         "wires": []
     },
     {
@@ -6764,7 +6790,7 @@
         "useDifferentColor": false,
         "className": "",
         "x": 880,
-        "y": 740,
+        "y": 1000,
         "wires": [
             []
         ]
@@ -6792,7 +6818,7 @@
         "payload": "",
         "payloadType": "date",
         "x": 200,
-        "y": 880,
+        "y": 1100,
         "wires": [
             [
                 "158e6edae533bfdc",
@@ -6813,8 +6839,8 @@
         "initialize": "// Code added here will be run once\n// whenever the node is started.\n\nif (flow.get(\"events_recent_radar\") === undefined) {\n    flow.set(\"events_recent_radar\", [])\n}\n",
         "finalize": "",
         "libs": [],
-        "x": 400,
-        "y": 2040,
+        "x": 390,
+        "y": 2100,
         "wires": [
             [
                 "5b307e65106f3540"
@@ -6839,8 +6865,8 @@
         "font": "Courier,monospace",
         "fontSize": "10",
         "color": "#000000",
-        "x": 1070,
-        "y": 2040,
+        "x": 1060,
+        "y": 2100,
         "wires": []
     },
     {
@@ -6859,8 +6885,8 @@
         "resendOnRefresh": true,
         "templateScope": "local",
         "className": "",
-        "x": 1090,
-        "y": 1980,
+        "x": 1080,
+        "y": 2040,
         "wires": [
             []
         ]
@@ -6905,7 +6931,7 @@
         "useDifferentColor": false,
         "className": "",
         "x": 970,
-        "y": 1280,
+        "y": 1500,
         "wires": [
             []
         ]
@@ -6949,8 +6975,8 @@
         "outputs": 1,
         "useDifferentColor": false,
         "className": "",
-        "x": 1140,
-        "y": 2380,
+        "x": 1200,
+        "y": 2440,
         "wires": [
             []
         ]
@@ -6970,8 +6996,8 @@
         "correl": "",
         "expiry": "",
         "broker": "a5d65dd0e3566daa",
-        "x": 1040,
-        "y": 2420,
+        "x": 1100,
+        "y": 2480,
         "wires": []
     },
     {
@@ -6987,8 +7013,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 470,
-        "y": 1900,
+        "x": 460,
+        "y": 1960,
         "wires": [
             [
                 "e5391514131a2b5a",
@@ -7018,8 +7044,8 @@
         "topic": "query",
         "payload": "",
         "payloadType": "date",
-        "x": 240,
-        "y": 2560,
+        "x": 400,
+        "y": 2600,
         "wires": [
             [
                 "584504e6c8935eaf"
@@ -7042,8 +7068,8 @@
         "resendOnRefresh": true,
         "templateScope": "local",
         "className": "",
-        "x": 1130,
-        "y": 2720,
+        "x": 1290,
+        "y": 2760,
         "wires": [
             []
         ]
@@ -7066,8 +7092,8 @@
         "checkall": "true",
         "repair": false,
         "outputs": 1,
-        "x": 400,
-        "y": 2160,
+        "x": 460,
+        "y": 2220,
         "wires": [
             [
                 "d23be15251ed6d73"
@@ -7094,8 +7120,8 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 460,
-        "y": 2200,
+        "x": 520,
+        "y": 2260,
         "wires": [
             [
                 "170ddffb726db9e0"
@@ -7114,8 +7140,8 @@
         "once": false,
         "onceDelay": 0.1,
         "topic": "",
-        "x": 250,
-        "y": 2280,
+        "x": 310,
+        "y": 2340,
         "wires": [
             [
                 "170ddffb726db9e0"
@@ -7139,8 +7165,8 @@
         "authType": "",
         "senderr": false,
         "headers": [],
-        "x": 450,
-        "y": 1780,
+        "x": 440,
+        "y": 1840,
         "wires": [
             [
                 "9226865e3385eb56",
@@ -7168,8 +7194,8 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 760,
-        "y": 1820,
+        "x": 750,
+        "y": 1880,
         "wires": [
             [
                 "0f65ceafe3f7c069"
@@ -7189,8 +7215,8 @@
         "active": false,
         "pass": false,
         "outputs": 0,
-        "x": 710,
-        "y": 1780,
+        "x": 700,
+        "y": 1840,
         "wires": []
     },
     {
@@ -7201,8 +7227,8 @@
         "name": "",
         "action": "",
         "property": "payload",
-        "x": 550,
-        "y": 1820,
+        "x": 540,
+        "y": 1880,
         "wires": [
             [
                 "08121a31488784bc"
@@ -7229,8 +7255,8 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 440,
-        "y": 1700,
+        "x": 430,
+        "y": 1760,
         "wires": [
             [
                 "09f99c931e5535bf"
@@ -7251,8 +7277,8 @@
         "targetType": "full",
         "statusVal": "",
         "statusType": "auto",
-        "x": 1080,
-        "y": 1840,
+        "x": 1070,
+        "y": 1900,
         "wires": []
     },
     {
@@ -7261,7 +7287,7 @@
         "z": "28627559bebdc324",
         "g": "0a6e123f5e53c029",
         "name": "create sqlite query, daily summary in zone_capture",
-        "func": "//frame_time is already in seconds\n\nconst query = `\nSELECT\n    date(frame_time, 'unixepoch') as day,\n    label,\n    camera,\n    COUNT(*) as count\nFROM\n    events\nWHERE\n    frame_time > (unixepoch('now') - (86400 * 10))\n    AND camera = '${env.get(\"VAR_RADAR_CAMERA\")}'\n    AND entered_zones LIKE '%zone_capture%'\nGROUP BY\n    label, date(frame_time, 'unixepoch'), camera\nORDER BY\n    label, day, camera;\n`;\n\nmsg.topic = query;\nreturn msg;",
+        "func": "//frame_time is already in seconds\n\nconst query = `\nSELECT\n    date(frame_time, 'unixepoch') as day,\n    label,\n    camera,\n    COUNT(*) as count\nFROM\n    events\nWHERE\n    frame_time > (unixepoch('now') - (86400 * 10))\n    AND camera = '${flow.get(\"camera_selection\")}'\n    AND entered_zones LIKE '%zone_capture%'\nGROUP BY\n    label, date(frame_time, 'unixepoch'), camera\nORDER BY\n    label, day, camera;\n`;\n\nmsg.topic = query;\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
         "noerr": 0,
@@ -7269,7 +7295,7 @@
         "finalize": "",
         "libs": [],
         "x": 250,
-        "y": 400,
+        "y": 680,
         "wires": [
             [
                 "bdb4b259d648b1f0"
@@ -7286,7 +7312,7 @@
         "sql": "",
         "name": "",
         "x": 390,
-        "y": 440,
+        "y": 720,
         "wires": [
             [
                 "ec7a0e0b1c62e91d"
@@ -7307,7 +7333,7 @@
         "finalize": "",
         "libs": [],
         "x": 330,
-        "y": 480,
+        "y": 760,
         "wires": [
             [
                 "b65e1877b1e04881"
@@ -7320,7 +7346,7 @@
         "z": "28627559bebdc324",
         "g": "5173f4b3ac03407a",
         "name": "create sqlite query, 1-hour counts last day in zone_capture",
-        "func": "//frame_time is already in seconds\n\nconst query = `\nSELECT\n    strftime('%FT%H:00:00.000Z', frame_time, 'unixepoch') as hour,\n    label,\n    camera,\n    COUNT(*) as count\nFROM\n    events\nWHERE\n    frame_time > (unixepoch('now') - (86400 * 1))\n    AND camera = '${env.get(\"VAR_RADAR_CAMERA\")}'\n    AND entered_zones LIKE '%zone_capture%'\nGROUP BY\n    label, strftime('%F %H', frame_time, 'unixepoch'), camera\nORDER BY\n    label, hour, camera;\n`;\n\nmsg.topic = query;\nreturn msg;",
+        "func": "//frame_time is already in seconds\n\nconst query = `\nSELECT\n    strftime('%FT%H:00:00.000Z', frame_time, 'unixepoch') as hour,\n    label,\n    camera,\n    COUNT(*) as count\nFROM\n    events\nWHERE\n    frame_time > (unixepoch('now') - (86400 * 1))\n    AND camera = '${flow.get(\"camera_selection\")}'\n    AND entered_zones LIKE '%zone_capture%'\nGROUP BY\n    label, strftime('%F %H', frame_time, 'unixepoch'), camera\nORDER BY\n    label, hour, camera;\n`;\n\nmsg.topic = query;\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
         "noerr": 0,
@@ -7328,7 +7354,7 @@
         "finalize": "",
         "libs": [],
         "x": 290,
-        "y": 660,
+        "y": 920,
         "wires": [
             [
                 "c03516d1eb65598d"
@@ -7345,7 +7371,7 @@
         "sql": "",
         "name": "",
         "x": 450,
-        "y": 700,
+        "y": 960,
         "wires": [
             [
                 "4f84bcb60e4be762"
@@ -7366,7 +7392,7 @@
         "finalize": "",
         "libs": [],
         "x": 410,
-        "y": 740,
+        "y": 1000,
         "wires": [
             [
                 "02469f2425072f7b"
@@ -7379,7 +7405,7 @@
         "z": "28627559bebdc324",
         "g": "0e1614cf2e5f9942",
         "name": "create sqlite query, 1-hour counts last day in zone_radar",
-        "func": "//frame_time is already in seconds\n//frame_time as 5-minute intervals, rounded up\n\nconst query = `\nSELECT\n    strftime('%Y-%m-%d %H:%M:00', (frame_time + 299), 'unixepoch', '-' || ((frame_time + 299) % 300) || ' seconds', 'localtime') AS bin_time,\n    label,\n    camera,\n    COUNT(*) as count\nFROM\n    events\nWHERE\n    frame_time > (unixepoch('now') - (3600))\n    AND camera = '${env.get(\"VAR_RADAR_CAMERA\")}'\n    AND entered_zones LIKE '%zone_radar%'\nGROUP BY\n    label, strftime('%Y-%m-%d %H:%M:00', (frame_time + 299), 'unixepoch', '-' || ((frame_time + 299) % 300) || ' seconds', 'localtime'), camera\nORDER BY\n    label, bin_time, camera;\n`;\n\nmsg.topic = query;\nreturn msg;",
+        "func": "//frame_time is already in seconds\n//frame_time as 5-minute intervals, rounded up\n\nconst query = `\nSELECT\n    strftime('%Y-%m-%d %H:%M:00', (frame_time + 299), 'unixepoch', '-' || ((frame_time + 299) % 300) || ' seconds', 'localtime') AS bin_time,\n    label,\n    camera,\n    COUNT(*) as count\nFROM\n    events\nWHERE\n    frame_time > (unixepoch('now') - (3600))\n    AND camera = '${flow.get(\"camera_selection\")}'\n    AND entered_zones LIKE '%zone_radar%'\nGROUP BY\n    label, strftime('%Y-%m-%d %H:%M:00', (frame_time + 299), 'unixepoch', '-' || ((frame_time + 299) % 300) || ' seconds', 'localtime'), camera\nORDER BY\n    label, bin_time, camera;\n`;\n\nmsg.topic = query;\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
         "noerr": 0,
@@ -7387,7 +7413,7 @@
         "finalize": "",
         "libs": [],
         "x": 290,
-        "y": 1200,
+        "y": 1420,
         "wires": [
             [
                 "eff2193c8246a9d2"
@@ -7404,7 +7430,7 @@
         "sql": "",
         "name": "",
         "x": 450,
-        "y": 1240,
+        "y": 1460,
         "wires": [
             [
                 "57fa6ca2b7d290e3"
@@ -7425,7 +7451,7 @@
         "finalize": "",
         "libs": [],
         "x": 410,
-        "y": 1280,
+        "y": 1500,
         "wires": [
             [
                 "11fa2826769befc7"
@@ -7438,15 +7464,15 @@
         "z": "28627559bebdc324",
         "g": "453513c49e4b1b60",
         "name": "create sqlite query, daily cumulative counts in zone_capture",
-        "func": "//frame_time is already in seconds\n\nconst query = `\nSELECT\n    label,\n    COUNT(*) as count\nFROM\n    events\nWHERE\n    frame_time >= unixepoch(strftime('%Y-%m-%dT04:00','now', 'localtime'),'utc')\n    AND camera = '${flow.get(\"sensor_cumulative_objects\")}'\n    AND entered_zones LIKE '%zone_capture%'\nGROUP BY \n    label\nORDER BY\n    label;\n`;\n\nmsg.topic = query;\nreturn msg;",
+        "func": "//frame_time is already in seconds\n\nconst query = `\nSELECT\n    label,\n    COUNT(*) as count\nFROM\n    events\nWHERE\n    frame_time >= unixepoch(strftime('%Y-%m-%dT04:00','now', 'localtime'),'utc')\n    AND camera = '${flow.get(\"camera_selection\")}'\n    AND entered_zones LIKE '%zone_capture%'\nGROUP BY \n    label\nORDER BY\n    label;\n`;\n\nmsg.topic = query;\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
         "noerr": 0,
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 600,
-        "y": 2280,
+        "x": 660,
+        "y": 2340,
         "wires": [
             [
                 "befe91e6862c72db"
@@ -7462,8 +7488,8 @@
         "sqlquery": "msg.topic",
         "sql": "",
         "name": "",
-        "x": 770,
-        "y": 2320,
+        "x": 830,
+        "y": 2380,
         "wires": [
             [
                 "13a061996f9322f3",
@@ -7484,8 +7510,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 770,
-        "y": 2380,
+        "x": 830,
+        "y": 2440,
         "wires": [
             [
                 "6d738ed81fefbedc"
@@ -7505,8 +7531,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 780,
-        "y": 2420,
+        "x": 840,
+        "y": 2480,
         "wires": [
             [
                 "d856c68660eb2202"
@@ -7519,15 +7545,15 @@
         "z": "28627559bebdc324",
         "g": "1bd1f21fa0390c69",
         "name": "create sqlite query, daily cumulative CAR counts in zone_capture + zone_radar that HAVE valid speed_calc",
-        "func": "//frame_time is already in seconds\n//cars with speeds in zone_radar AND zone_capture since 0400 today\n\nconst query = `\nWITH results AS (\n  SELECT \n    COUNT(*) AS count,\n    AVG(ABS(speed_calc)) AS mean_speed,\n    MAX(CASE WHEN ntile = 5 THEN ABS(speed_calc) ELSE NULL END) AS p25_speed,\n    MAX(CASE WHEN ntile = 10 THEN ABS(speed_calc) ELSE NULL END) AS p50_speed,\n    MAX(CASE WHEN ntile = 15 THEN ABS(speed_calc) ELSE NULL END) AS p75_speed,\n    MAX(CASE WHEN ntile = 17 THEN ABS(speed_calc) ELSE NULL END) AS p85_speed,\n    MAX(ABS(speed_calc)) AS max_speed,\n    SUM(CASE WHEN ABS(speed_calc) > 25 THEN 1 ELSE 0 END) AS count_over_25,\n    JSON_GROUP_ARRAY(speed_calc) AS speeds\n  FROM \n    (SELECT \n       ABS(speed_calc) as speed_calc,\n       NTILE(20) OVER (ORDER BY ABS(speed_calc)) AS ntile\n     FROM \n       events\n     WHERE \n       frame_time >= unixepoch(strftime('%Y-%m-%dT04:00','now', 'localtime'),'utc') AND\n       label = 'car' AND\n       entered_zones LIKE '%zone_radar%' AND\n       entered_zones LIKE '%zone_capture%' AND\n       ABS(speed_calc) NOT NULL AND\n       camera = '${env.get(\"VAR_RADAR_CAMERA\")}'\n    )\n)\nSELECT \n  *, \n  p75_speed + 1.5 * (p75_speed - p25_speed) AS iqr_upper,\n  (SELECT COUNT(*) FROM json_each(results.speeds) WHERE json_each.value > p75_speed + 1.5 * (p75_speed - p25_speed)) AS iqr_upper_freq\nFROM \n  results;\n`;\n\nmsg.topic = query;\nreturn msg;",
+        "func": "//frame_time is already in seconds\n//cars with speeds in zone_radar AND zone_capture since 0400 today\n\nconst query = `\nWITH results AS (\n  SELECT \n    COUNT(*) AS count,\n    AVG(ABS(speed_calc)) AS mean_speed,\n    MAX(CASE WHEN ntile = 5 THEN ABS(speed_calc) ELSE NULL END) AS p25_speed,\n    MAX(CASE WHEN ntile = 10 THEN ABS(speed_calc) ELSE NULL END) AS p50_speed,\n    MAX(CASE WHEN ntile = 15 THEN ABS(speed_calc) ELSE NULL END) AS p75_speed,\n    MAX(CASE WHEN ntile = 17 THEN ABS(speed_calc) ELSE NULL END) AS p85_speed,\n    MAX(ABS(speed_calc)) AS max_speed,\n    SUM(CASE WHEN ABS(speed_calc) > 25 THEN 1 ELSE 0 END) AS count_over_25,\n    JSON_GROUP_ARRAY(speed_calc) AS speeds\n  FROM \n    (SELECT \n       ABS(speed_calc) as speed_calc,\n       NTILE(20) OVER (ORDER BY ABS(speed_calc)) AS ntile\n     FROM \n       events\n     WHERE \n       frame_time >= unixepoch(strftime('%Y-%m-%dT04:00','now', 'localtime'),'utc') AND\n       label = 'car' AND\n       entered_zones LIKE '%zone_radar%' AND\n       entered_zones LIKE '%zone_capture%' AND\n       ABS(speed_calc) NOT NULL AND\n       camera = '${flow.get(\"camera_selection\")}'\n    )\n)\nSELECT \n  *, \n  p75_speed + 1.5 * (p75_speed - p25_speed) AS iqr_upper,\n  (SELECT COUNT(*) FROM json_each(results.speeds) WHERE json_each.value > p75_speed + 1.5 * (p75_speed - p25_speed)) AS iqr_upper_freq\nFROM \n  results;\n`;\n\nmsg.topic = query;\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
         "noerr": 0,
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 470,
-        "y": 2620,
+        "x": 630,
+        "y": 2660,
         "wires": [
             [
                 "9cf49f0891d25df1"
@@ -7543,8 +7569,8 @@
         "sqlquery": "msg.topic",
         "sql": "",
         "name": "",
-        "x": 790,
-        "y": 2660,
+        "x": 950,
+        "y": 2700,
         "wires": [
             [
                 "6d81c8e3c89b68f6"
@@ -7564,8 +7590,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 740,
-        "y": 2720,
+        "x": 900,
+        "y": 2760,
         "wires": [
             [
                 "5417aae0d14fa661"
@@ -7582,7 +7608,7 @@
         "sql": "",
         "name": "",
         "x": 370,
-        "y": 980,
+        "y": 1200,
         "wires": [
             [
                 "39d895a16ca6f6f1",
@@ -7604,7 +7630,7 @@
         "finalize": "",
         "libs": [],
         "x": 220,
-        "y": 940,
+        "y": 1160,
         "wires": [
             [
                 "7cc031e5a7d773a4"
@@ -7625,7 +7651,7 @@
         "finalize": "",
         "libs": [],
         "x": 710,
-        "y": 980,
+        "y": 1200,
         "wires": [
             [
                 "cbb3b02ca505a55b"
@@ -7646,7 +7672,7 @@
         "finalize": "",
         "libs": [],
         "x": 730,
-        "y": 1060,
+        "y": 1280,
         "wires": [
             [
                 "7db4b197df9eb075"
@@ -7693,7 +7719,7 @@
         "useDifferentColor": false,
         "className": "",
         "x": 770,
-        "y": 1020,
+        "y": 1240,
         "wires": [
             []
         ]
@@ -7738,7 +7764,7 @@
         "useDifferentColor": false,
         "className": "",
         "x": 800,
-        "y": 1100,
+        "y": 1320,
         "wires": [
             []
         ]
@@ -7747,12 +7773,12 @@
         "id": "bb08a223f0aaef0f",
         "type": "ui_dropdown",
         "z": "28627559bebdc324",
-        "g": "453513c49e4b1b60",
+        "g": "2df66c6bc991dbf4",
         "name": "",
         "label": "",
         "tooltip": "",
         "place": "Select sensor to report cumulative daily object counts",
-        "group": "7866c2aa313ab8b9",
+        "group": "202181a361213d6d",
         "order": 7,
         "width": 0,
         "height": 0,
@@ -7769,8 +7795,8 @@
         "topic": "topic",
         "topicType": "msg",
         "className": "",
-        "x": 380,
-        "y": 2340,
+        "x": 240,
+        "y": 120,
         "wires": [
             [
                 "c7f00f59861cd00f"
@@ -7781,7 +7807,7 @@
         "id": "e3b795e05d7650b2",
         "type": "inject",
         "z": "28627559bebdc324",
-        "g": "453513c49e4b1b60",
+        "g": "2df66c6bc991dbf4",
         "name": "",
         "props": [
             {
@@ -7800,8 +7826,8 @@
         "topic": "",
         "payload": "$keys($globalContext(\"config.sensors.cameras\"))[0]\t",
         "payloadType": "jsonata",
-        "x": 250,
-        "y": 2340,
+        "x": 110,
+        "y": 120,
         "wires": [
             [
                 "bb08a223f0aaef0f"
@@ -7812,12 +7838,12 @@
         "id": "c7f00f59861cd00f",
         "type": "change",
         "z": "28627559bebdc324",
-        "g": "453513c49e4b1b60",
+        "g": "2df66c6bc991dbf4",
         "name": "",
         "rules": [
             {
                 "t": "set",
-                "p": "sensor_cumulative_objects",
+                "p": "camera_selection",
                 "pt": "flow",
                 "to": "payload",
                 "tot": "msg"
@@ -7828,8 +7854,8 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 360,
-        "y": 2400,
+        "x": 190,
+        "y": 180,
         "wires": [
             []
         ]

--- a/node-red-project/flows.json
+++ b/node-red-project/flows.json
@@ -75,7 +75,7 @@
         "id": "0a6e123f5e53c029",
         "type": "group",
         "z": "28627559bebdc324",
-        "name": "group summary daily",
+        "name": "event; group summary daily",
         "style": {
             "label": true
         },
@@ -87,15 +87,15 @@
             "ec7a0e0b1c62e91d"
         ],
         "x": 14,
-        "y": 599,
-        "w": 852,
-        "h": 202
+        "y": 459,
+        "w": 1372,
+        "h": 122
     },
     {
         "id": "5aac1262472b0205",
         "type": "group",
         "z": "28627559bebdc324",
-        "name": "group frigate api/events/summary",
+        "name": "event; group frigate api/events/summary",
         "style": {
             "label": true
         },
@@ -106,15 +106,15 @@
             "eb140f61419c6a08"
         ],
         "x": 14,
-        "y": 379,
-        "w": 852,
-        "h": 202
+        "y": 319,
+        "w": 1092,
+        "h": 122
     },
     {
         "id": "5173f4b3ac03407a",
         "type": "group",
         "z": "28627559bebdc324",
-        "name": "show object counts/speeds last 24-hours",
+        "name": "event; show object counts/speeds last 24-hours",
         "style": {
             "label": true
         },
@@ -126,15 +126,15 @@
             "4f84bcb60e4be762"
         ],
         "x": 14,
-        "y": 819,
-        "w": 1052,
-        "h": 222
+        "y": 599,
+        "w": 1452,
+        "h": 122
     },
     {
         "id": "76417db2b472ef4f",
         "type": "group",
         "z": "28627559bebdc324",
-        "name": "radar TimedSpeedCounts (.counts, .speed_average)",
+        "name": "radar; TimedSpeedCounts (.counts, .speed_average)",
         "style": {
             "label": true
         },
@@ -149,14 +149,15 @@
             "7db4b197df9eb075"
         ],
         "x": 14,
-        "y": 1059,
-        "w": 1178,
-        "h": 508
+        "y": 739,
+        "w": 1532,
+        "h": 348
     },
     {
         "id": "9b9e4fc50b744fc3",
         "type": "group",
         "z": "28627559bebdc324",
+        "g": "91096cd6c9c741e2",
         "name": "last N events, radar",
         "style": {
             "label": true
@@ -174,18 +175,18 @@
             "4c087723a1d698e9",
             "0f65ceafe3f7c069",
             "f5d2d92d50d18ce2",
-            "c2270f3050bf35ab",
-            "3214e8cd3ea79630"
+            "c2270f3050bf35ab"
         ],
-        "x": 214,
-        "y": 1599,
-        "w": 1022,
-        "h": 542
+        "x": 194,
+        "y": 1279,
+        "w": 1292,
+        "h": 362
     },
     {
         "id": "453513c49e4b1b60",
         "type": "group",
         "z": "28627559bebdc324",
+        "g": "91096cd6c9c741e2",
         "name": "cumulative events today by object",
         "style": {
             "label": true
@@ -201,16 +202,16 @@
             "13a061996f9322f3",
             "98571c77b9801a83"
         ],
-        "x": 214,
-        "y": 2179,
-        "w": 1172,
-        "h": 342
+        "x": 194,
+        "y": 1659,
+        "w": 1592,
+        "h": 182
     },
     {
         "id": "1bd1f21fa0390c69",
         "type": "group",
         "z": "28627559bebdc324",
-        "name": "car event speed stats",
+        "name": "event; car event speed stats",
         "style": {
             "label": true
         },
@@ -221,10 +222,10 @@
             "9cf49f0891d25df1",
             "6d81c8e3c89b68f6"
         ],
-        "x": 214,
-        "y": 2559,
-        "w": 1252,
-        "h": 242
+        "x": 14,
+        "y": 1099,
+        "w": 1492,
+        "h": 122
     },
     {
         "id": "0a5faeac9fbd6d55",
@@ -865,12 +866,19 @@
         "nodes": [
             "bb08a223f0aaef0f",
             "e3b795e05d7650b2",
-            "c7f00f59861cd00f"
+            "c7f00f59861cd00f",
+            "ff783e21c3b96d4b",
+            "62c9240d45e9c8d6",
+            "59d0c8b142295eee",
+            "f50a7968e032532a",
+            "af02df2daa211e5b",
+            "1feaed96b954867a",
+            "946c6bc353743bc4"
         ],
         "x": 14,
         "y": 79,
-        "w": 312,
-        "h": 142
+        "w": 1232,
+        "h": 202
     },
     {
         "id": "b334a2375eb8cb42",
@@ -975,10 +983,10 @@
             "eff2193c8246a9d2",
             "57fa6ca2b7d290e3"
         ],
-        "x": 54,
-        "y": 1379,
-        "w": 1112,
-        "h": 162
+        "x": 334,
+        "y": 939,
+        "w": 1152,
+        "h": 122
     },
     {
         "id": "f5d2d92d50d18ce2",
@@ -995,8 +1003,8 @@
             "9226865e3385eb56",
             "aa0afb5180297e2b"
         ],
-        "x": 294,
-        "y": 1799,
+        "x": 594,
+        "y": 1319,
         "w": 612,
         "h": 122
     },
@@ -1253,6 +1261,83 @@
         "h": 162
     },
     {
+        "id": "7c19b3698bb02613",
+        "type": "group",
+        "z": "28627559bebdc324",
+        "name": "aq; gas",
+        "style": {
+            "label": true
+        },
+        "nodes": [
+            "a3672e4c4c84d721",
+            "e5ed08571761bd2c",
+            "441e03047af79373",
+            "9d1978d68c96feb9",
+            "2227d1c8d929c91d",
+            "9573839489d3567f"
+        ],
+        "x": 14,
+        "y": 1899,
+        "w": 1312,
+        "h": 127
+    },
+    {
+        "id": "91096cd6c9c741e2",
+        "type": "group",
+        "z": "28627559bebdc324",
+        "name": "event-based ui",
+        "style": {
+            "label": true
+        },
+        "nodes": [
+            "c249329109ac17d5",
+            "9b9e4fc50b744fc3",
+            "453513c49e4b1b60"
+        ],
+        "x": 94,
+        "y": 1253,
+        "w": 1718,
+        "h": 614
+    },
+    {
+        "id": "83eedcc325ccc21d",
+        "type": "group",
+        "z": "28627559bebdc324",
+        "name": "aq, particulate matter (PM)",
+        "style": {
+            "label": true
+        },
+        "nodes": [
+            "bd1b7f16edeb4ed3",
+            "bf4e488edf28469b",
+            "0d4ff80748d1c876",
+            "56bbbcd2844a4c13"
+        ],
+        "x": 234,
+        "y": 2179,
+        "w": 1052,
+        "h": 122
+    },
+    {
+        "id": "d16177f416c9a0ef",
+        "type": "group",
+        "z": "28627559bebdc324",
+        "name": "event; object counts/speeds individually last 24-hours",
+        "style": {
+            "label": true
+        },
+        "nodes": [
+            "12df4fdffa628238",
+            "6a292f3905fe5405",
+            "76e813b1b7a4b63e",
+            "5cf61952cb6823de"
+        ],
+        "x": 234,
+        "y": 2039,
+        "w": 1092,
+        "h": 122
+    },
+    {
         "id": "05a58d9ee463c696",
         "type": "junction",
         "z": "1c71c8f26f5b7b19",
@@ -1398,6 +1483,20 @@
         ]
     },
     {
+        "id": "9573839489d3567f",
+        "type": "junction",
+        "z": "28627559bebdc324",
+        "g": "7c19b3698bb02613",
+        "x": 140,
+        "y": 2000,
+        "wires": [
+            [
+                "bf4e488edf28469b",
+                "12df4fdffa628238"
+            ]
+        ]
+    },
+    {
         "id": "a5d65dd0e3566daa",
         "type": "mqtt-broker",
         "name": "mqtt-broker-local",
@@ -1455,7 +1554,7 @@
         "tab": "665d947f9a312a33",
         "order": 3,
         "disp": true,
-        "width": 12,
+        "width": 6,
         "collapse": false,
         "className": ""
     },
@@ -1596,12 +1695,12 @@
             }
         },
         "site": {
-            "name": "Node-RED Dashboard",
+            "name": "On-Device Dashboard - Traffic Monitor",
             "hideToolbar": "false",
             "allowSwipe": "false",
             "lockMenu": "false",
             "allowTempTheme": "true",
-            "dateFormat": "DD/MM/YYYY",
+            "dateFormat": "YYYY-MM-DD",
             "sizes": {
                 "sx": 48,
                 "sy": 48,
@@ -1749,9 +1848,20 @@
     {
         "id": "202181a361213d6d",
         "type": "ui_group",
-        "name": "Camera Selector",
+        "name": "Sensor Selector",
         "tab": "665d947f9a312a33",
         "order": 1,
+        "disp": true,
+        "width": 3,
+        "collapse": false,
+        "className": ""
+    },
+    {
+        "id": "62cdf198fe42de7e",
+        "type": "ui_group",
+        "name": "Air Quality",
+        "tab": "665d947f9a312a33",
+        "order": 4,
         "disp": true,
         "width": "6",
         "collapse": false,
@@ -2817,7 +2927,7 @@
         "z": "1c71c8f26f5b7b19",
         "g": "dea1b8828f8e501f",
         "name": "write params for radar_timedspeedcounts insert",
-        "func": "//get rid of outer TimedSpeedCounts object\nmsg.payload = msg.payload.TimedSpeedCounts;\n\nconst obj = msg.payload;\n\nconst keyedObj = Object.keys(obj).reduce((acc, key) => {\n    acc[`$${key}`] = obj[key];\n    return acc;\n}, {});\n\nmsg.params = keyedObj;\n\nreturn msg;",
+        "func": "const newPayload = {\n    time: msg.payload.TimedSpeedCounts.time,\n    direction: msg.payload.TimedSpeedCounts.direction,\n    units: msg.payload.TimedSpeedCounts.units,\n    count: msg.payload.TimedSpeedCounts.count,\n    average: msg.payload.TimedSpeedCounts.average,\n    radarName: msg.payload.radarName,\n    deployment_id: msg.payload.deployment_id\n}\n\nmsg.payload = newPayload;\n\nconst obj = msg.payload;\n\nconst keyedObj = Object.keys(obj).reduce((acc, key) => {\n    acc[`$${key}`] = obj[key];\n    return acc;\n}, {});\n\nmsg.params = keyedObj;\n\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
         "noerr": 0,
@@ -6403,7 +6513,7 @@
         "payload": "",
         "payloadType": "date",
         "x": 200,
-        "y": 860,
+        "y": 640,
         "wires": [
             [
                 "928b71f25ce6e7b6"
@@ -6417,7 +6527,7 @@
         "g": "5aac1262472b0205",
         "name": "frigate summary daily, objects",
         "group": "06dde4be9a9a6b27",
-        "order": 3,
+        "order": 4,
         "width": 6,
         "height": 7,
         "label": "frigate api/events/summary daily object count for the last 10-days",
@@ -6449,8 +6559,8 @@
         "outputs": 1,
         "useDifferentColor": false,
         "className": "",
-        "x": 710,
-        "y": 540,
+        "x": 950,
+        "y": 400,
         "wires": [
             []
         ]
@@ -6472,8 +6582,8 @@
         "authType": "",
         "senderr": false,
         "headers": [],
-        "x": 310,
-        "y": 480,
+        "x": 590,
+        "y": 360,
         "wires": [
             [
                 "eb140f61419c6a08"
@@ -6494,7 +6604,7 @@
         "onceDelay": "5",
         "topic": "",
         "x": 230,
-        "y": 420,
+        "y": 360,
         "wires": [
             [
                 "b241a0ef89fd7ce4"
@@ -6514,8 +6624,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 400,
-        "y": 540,
+        "x": 900,
+        "y": 360,
         "wires": [
             [
                 "08d030ffc3fe6adb"
@@ -6545,7 +6655,7 @@
         "payload": "",
         "payloadType": "date",
         "x": 200,
-        "y": 640,
+        "y": 500,
         "wires": [
             [
                 "5f3716d2176c3ab4"
@@ -6559,7 +6669,7 @@
         "g": "0a6e123f5e53c029",
         "name": "events summary daily, objects",
         "group": "06dde4be9a9a6b27",
-        "order": 4,
+        "order": 5,
         "width": 6,
         "height": 7,
         "label": "events daily object count for the last 10-days",
@@ -6591,8 +6701,8 @@
         "outputs": 1,
         "useDifferentColor": false,
         "className": "",
-        "x": 710,
-        "y": 760,
+        "x": 1230,
+        "y": 540,
         "wires": [
             []
         ]
@@ -6601,12 +6711,13 @@
         "id": "c249329109ac17d5",
         "type": "link in",
         "z": "28627559bebdc324",
+        "g": "91096cd6c9c741e2",
         "name": "link in event capture",
         "links": [
             "274f87c31437c2d7"
         ],
-        "x": 145,
-        "y": 1640,
+        "x": 135,
+        "y": 1320,
         "wires": [
             [
                 "5ec2d3ba52f944f5",
@@ -6634,8 +6745,8 @@
         "checkall": "true",
         "repair": false,
         "outputs": 1,
-        "x": 740,
-        "y": 2000,
+        "x": 1020,
+        "y": 1520,
         "wires": [
             [
                 "c788d632f5e93a73"
@@ -6660,8 +6771,8 @@
         "checkall": "true",
         "repair": false,
         "outputs": 1,
-        "x": 380,
-        "y": 1720,
+        "x": 360,
+        "y": 1400,
         "wires": [
             [
                 "c2270f3050bf35ab"
@@ -6681,8 +6792,8 @@
         "initialize": "// Code added here will be run once\n// whenever the node is started.\n\nif (flow.get(\"events_recent_radar\") === undefined) {\n    flow.set(\"events_recent_radar\", [])\n}\n",
         "finalize": "",
         "libs": [],
-        "x": 790,
-        "y": 2040,
+        "x": 1050,
+        "y": 1560,
         "wires": [
             [
                 "4c087723a1d698e9"
@@ -6702,12 +6813,11 @@
         "initialize": "// Code added here will be run once\n// whenever the node is started.\n\nif (flow.get(\"events_recent_radar\") === undefined) {\n    flow.set(\"events_recent_radar\", [])\n}\n",
         "finalize": "",
         "libs": [],
-        "x": 750,
-        "y": 1960,
+        "x": 1030,
+        "y": 1480,
         "wires": [
             [
-                "c36c71706e494b5e",
-                "3214e8cd3ea79630"
+                "c36c71706e494b5e"
             ]
         ]
     },
@@ -6727,8 +6837,8 @@
         "checkall": "true",
         "repair": false,
         "outputs": 1,
-        "x": 350,
-        "y": 1680,
+        "x": 330,
+        "y": 1360,
         "wires": [
             [
                 "2e680914d7da5c94"
@@ -6740,7 +6850,7 @@
         "type": "ui_template",
         "z": "28627559bebdc324",
         "g": "9b9e4fc50b744fc3",
-        "group": "7866c2aa313ab8b9",
+        "group": "06dde4be9a9a6b27",
         "name": "last N radar events",
         "order": 2,
         "width": 0,
@@ -6751,8 +6861,8 @@
         "resendOnRefresh": true,
         "templateScope": "local",
         "className": "",
-        "x": 1050,
-        "y": 1960,
+        "x": 1310,
+        "y": 1480,
         "wires": [
             []
         ]
@@ -6771,8 +6881,8 @@
         "targetType": "msg",
         "statusVal": "",
         "statusType": "auto",
-        "x": 350,
-        "y": 1640,
+        "x": 330,
+        "y": 1320,
         "wires": []
     },
     {
@@ -6813,8 +6923,8 @@
         "z": "28627559bebdc324",
         "g": "5173f4b3ac03407a",
         "name": "",
-        "group": "06dde4be9a9a6b27",
-        "order": 2,
+        "group": "7866c2aa313ab8b9",
+        "order": 1,
         "width": 0,
         "height": 0,
         "label": "events by object (60-min) for last 24-hours",
@@ -6846,8 +6956,8 @@
         "outputs": 1,
         "useDifferentColor": false,
         "className": "",
-        "x": 880,
-        "y": 1000,
+        "x": 1280,
+        "y": 680,
         "wires": [
             []
         ]
@@ -6875,7 +6985,7 @@
         "payload": "",
         "payloadType": "date",
         "x": 200,
-        "y": 1100,
+        "y": 780,
         "wires": [
             [
                 "158e6edae533bfdc",
@@ -6888,7 +6998,7 @@
         "type": "function",
         "z": "28627559bebdc324",
         "g": "9b9e4fc50b744fc3",
-        "name": "store last N any frigate events",
+        "name": "store last N frigate events as text, any zone",
         "func": "//events_recent_radar should show the last N events where payload.entered_zones CONTAINS zone_radar\n\nvar myEvents = flow.get(\"events_all\") || [];\n//Keep only last X elements\nvar myArrLength = 10;\n\n//invert array so OLDEST IS FIRST, for functions\nmyEvents.reverse();\n\nif (myEvents.length >= myArrLength) {\n    //remove first element (oldest event)\n    myEvents.shift();\n}\n\n//keep only specific elements\nconst newObj = {\n    id: msg.payload.id, \n    label: msg.payload.label,  \n    direction_calc: msg.payload.direction_calc, \n    speed_calc: msg.payload.speed_calc, \n    };\n\n//add current event to end of array\nmyEvents.push(newObj);\n\n//invert array so NEWEST IS FIRST, for display\nmyEvents.reverse();\n\nflow.set(\"events_all\", myEvents);\n\nmsg.payload = myEvents;\n\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
@@ -6896,8 +7006,8 @@
         "initialize": "// Code added here will be run once\n// whenever the node is started.\n\nif (flow.get(\"events_recent_radar\") === undefined) {\n    flow.set(\"events_recent_radar\", [])\n}\n",
         "finalize": "",
         "libs": [],
-        "x": 390,
-        "y": 2100,
+        "x": 470,
+        "y": 1600,
         "wires": [
             [
                 "5b307e65106f3540"
@@ -6910,9 +7020,9 @@
         "z": "28627559bebdc324",
         "g": "9b9e4fc50b744fc3",
         "group": "7866c2aa313ab8b9",
-        "order": 4,
-        "width": 12,
-        "height": 5,
+        "order": 6,
+        "width": 0,
+        "height": 0,
         "name": "",
         "label": "last N events, text output",
         "format": "{{msg.payload}}",
@@ -6922,8 +7032,8 @@
         "font": "Courier,monospace",
         "fontSize": "10",
         "color": "#000000",
-        "x": 1060,
-        "y": 2100,
+        "x": 1330,
+        "y": 1600,
         "wires": []
     },
     {
@@ -6931,7 +7041,7 @@
         "type": "ui_template",
         "z": "28627559bebdc324",
         "g": "9b9e4fc50b744fc3",
-        "group": "7866c2aa313ab8b9",
+        "group": "06dde4be9a9a6b27",
         "name": "last N radar speeding events",
         "order": 3,
         "width": 0,
@@ -6942,8 +7052,8 @@
         "resendOnRefresh": true,
         "templateScope": "local",
         "className": "",
-        "x": 1080,
-        "y": 2040,
+        "x": 1340,
+        "y": 1560,
         "wires": [
             []
         ]
@@ -6954,8 +7064,8 @@
         "z": "28627559bebdc324",
         "g": "0e1614cf2e5f9942",
         "name": "",
-        "group": "06dde4be9a9a6b27",
-        "order": 7,
+        "group": "7866c2aa313ab8b9",
+        "order": 3,
         "width": 0,
         "height": 0,
         "label": "Events in zone_radar (5-min) for last 60-min",
@@ -6987,8 +7097,8 @@
         "outputs": 1,
         "useDifferentColor": false,
         "className": "",
-        "x": 970,
-        "y": 1500,
+        "x": 1290,
+        "y": 1020,
         "wires": [
             []
         ]
@@ -6999,7 +7109,7 @@
         "z": "28627559bebdc324",
         "g": "453513c49e4b1b60",
         "name": "",
-        "group": "7866c2aa313ab8b9",
+        "group": "06dde4be9a9a6b27",
         "order": 1,
         "width": 0,
         "height": 0,
@@ -7032,8 +7142,8 @@
         "outputs": 1,
         "useDifferentColor": false,
         "className": "",
-        "x": 1200,
-        "y": 2440,
+        "x": 1600,
+        "y": 1760,
         "wires": [
             []
         ]
@@ -7053,8 +7163,8 @@
         "correl": "",
         "expiry": "",
         "broker": "a5d65dd0e3566daa",
-        "x": 1100,
-        "y": 2480,
+        "x": 1500,
+        "y": 1800,
         "wires": []
     },
     {
@@ -7070,8 +7180,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 460,
-        "y": 1960,
+        "x": 740,
+        "y": 1480,
         "wires": [
             [
                 "e5391514131a2b5a",
@@ -7101,8 +7211,8 @@
         "topic": "query",
         "payload": "",
         "payloadType": "date",
-        "x": 400,
-        "y": 2600,
+        "x": 200,
+        "y": 1140,
         "wires": [
             [
                 "584504e6c8935eaf"
@@ -7114,9 +7224,9 @@
         "type": "ui_template",
         "z": "28627559bebdc324",
         "g": "1bd1f21fa0390c69",
-        "group": "06dde4be9a9a6b27",
+        "group": "7866c2aa313ab8b9",
         "name": "car speed stats for today, since 0400",
-        "order": 1,
+        "order": 2,
         "width": 0,
         "height": 0,
         "format": "<p class=\"label nr-dashboard-chart-title nr-dashboard-chart-titlel\">car speed stats for today, since 0400</p>\n<table class=\"table\">\n    <tr ng-repeat=\"payload in msg.payload\">\n        <td ng-repeat =\"(key,value) in payload\">{{key}}: </td>\n        <td ng-repeat =\"(key,value) in payload\">{{value}}</td>\n    </tr>\n</table>",
@@ -7125,8 +7235,8 @@
         "resendOnRefresh": true,
         "templateScope": "local",
         "className": "",
-        "x": 1290,
-        "y": 2760,
+        "x": 1330,
+        "y": 1180,
         "wires": [
             []
         ]
@@ -7149,8 +7259,8 @@
         "checkall": "true",
         "repair": false,
         "outputs": 1,
-        "x": 460,
-        "y": 2220,
+        "x": 320,
+        "y": 1700,
         "wires": [
             [
                 "d23be15251ed6d73"
@@ -7177,8 +7287,8 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 520,
-        "y": 2260,
+        "x": 380,
+        "y": 1740,
         "wires": [
             [
                 "170ddffb726db9e0"
@@ -7197,8 +7307,8 @@
         "once": false,
         "onceDelay": 0.1,
         "topic": "",
-        "x": 310,
-        "y": 2340,
+        "x": 430,
+        "y": 1800,
         "wires": [
             [
                 "170ddffb726db9e0"
@@ -7222,8 +7332,8 @@
         "authType": "",
         "senderr": false,
         "headers": [],
-        "x": 440,
-        "y": 1840,
+        "x": 740,
+        "y": 1360,
         "wires": [
             [
                 "9226865e3385eb56",
@@ -7251,8 +7361,8 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 750,
-        "y": 1880,
+        "x": 1050,
+        "y": 1400,
         "wires": [
             [
                 "0f65ceafe3f7c069"
@@ -7272,8 +7382,8 @@
         "active": false,
         "pass": false,
         "outputs": 0,
-        "x": 700,
-        "y": 1840,
+        "x": 1000,
+        "y": 1360,
         "wires": []
     },
     {
@@ -7284,8 +7394,8 @@
         "name": "",
         "action": "",
         "property": "payload",
-        "x": 540,
-        "y": 1880,
+        "x": 840,
+        "y": 1400,
         "wires": [
             [
                 "08121a31488784bc"
@@ -7312,8 +7422,8 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 430,
-        "y": 1760,
+        "x": 410,
+        "y": 1440,
         "wires": [
             [
                 "09f99c931e5535bf"
@@ -7321,29 +7431,11 @@
         ]
     },
     {
-        "id": "3214e8cd3ea79630",
-        "type": "debug",
-        "z": "28627559bebdc324",
-        "g": "9b9e4fc50b744fc3",
-        "name": "debug: last N radar events",
-        "active": false,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "true",
-        "targetType": "full",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 1070,
-        "y": 1900,
-        "wires": []
-    },
-    {
         "id": "5f3716d2176c3ab4",
         "type": "function",
         "z": "28627559bebdc324",
         "g": "0a6e123f5e53c029",
-        "name": "create sqlite query, daily summary in zone_capture",
+        "name": "query, daily summary last 10 days in zone_capture",
         "func": "//frame_time is already in seconds\n\nconst query = `\nSELECT\n    date(frame_time, 'unixepoch') as day,\n    label,\n    camera,\n    COUNT(*) as count\nFROM\n    events\nWHERE\n    frame_time > (unixepoch('now') - (86400 * 10))\n    AND camera = '${flow.get(\"camera_selection\")}'\n    AND entered_zones LIKE '%zone_capture%'\nGROUP BY\n    label, date(frame_time, 'unixepoch'), camera\nORDER BY\n    label, day, camera;\n`;\n\nmsg.topic = query;\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
@@ -7351,8 +7443,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 250,
-        "y": 680,
+        "x": 550,
+        "y": 500,
         "wires": [
             [
                 "bdb4b259d648b1f0"
@@ -7368,8 +7460,8 @@
         "sqlquery": "msg.topic",
         "sql": "",
         "name": "",
-        "x": 390,
-        "y": 720,
+        "x": 900,
+        "y": 500,
         "wires": [
             [
                 "ec7a0e0b1c62e91d"
@@ -7389,8 +7481,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 330,
-        "y": 760,
+        "x": 1190,
+        "y": 500,
         "wires": [
             [
                 "b65e1877b1e04881"
@@ -7402,7 +7494,7 @@
         "type": "function",
         "z": "28627559bebdc324",
         "g": "5173f4b3ac03407a",
-        "name": "create sqlite query, 1-hour counts last day in zone_capture",
+        "name": "query, 1-h counts last 24-h in zone_capture",
         "func": "//frame_time is already in seconds\n\nconst query = `\nSELECT\n    strftime('%FT%H:00:00.000Z', frame_time, 'unixepoch') as hour,\n    label,\n    camera,\n    COUNT(*) as count\nFROM\n    events\nWHERE\n    frame_time > (unixepoch('now') - (86400 * 1))\n    AND camera = '${flow.get(\"camera_selection\")}'\n    AND entered_zones LIKE '%zone_capture%'\nGROUP BY\n    label, strftime('%F %H', frame_time, 'unixepoch'), camera\nORDER BY\n    label, hour, camera;\n`;\n\nmsg.topic = query;\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
@@ -7410,8 +7502,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 290,
-        "y": 920,
+        "x": 530,
+        "y": 640,
         "wires": [
             [
                 "c03516d1eb65598d"
@@ -7427,8 +7519,8 @@
         "sqlquery": "msg.topic",
         "sql": "",
         "name": "",
-        "x": 450,
-        "y": 960,
+        "x": 940,
+        "y": 640,
         "wires": [
             [
                 "4f84bcb60e4be762"
@@ -7448,8 +7540,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 410,
-        "y": 1000,
+        "x": 1230,
+        "y": 640,
         "wires": [
             [
                 "02469f2425072f7b"
@@ -7461,7 +7553,7 @@
         "type": "function",
         "z": "28627559bebdc324",
         "g": "0e1614cf2e5f9942",
-        "name": "create sqlite query, 1-hour counts last day in zone_radar",
+        "name": "query, 5-min event speed counts for last 1-h in zone_radar",
         "func": "//frame_time is already in seconds\n//frame_time as 5-minute intervals, rounded up\n\nconst query = `\nSELECT\n    strftime('%Y-%m-%d %H:%M:00', (frame_time + 299), 'unixepoch', '-' || ((frame_time + 299) % 300) || ' seconds', 'localtime') AS bin_time,\n    label,\n    camera,\n    COUNT(*) as count\nFROM\n    events\nWHERE\n    frame_time > (unixepoch('now') - (3600))\n    AND camera = '${flow.get(\"camera_selection\")}'\n    AND entered_zones LIKE '%zone_radar%'\nGROUP BY\n    label, strftime('%Y-%m-%d %H:%M:00', (frame_time + 299), 'unixepoch', '-' || ((frame_time + 299) % 300) || ' seconds', 'localtime'), camera\nORDER BY\n    label, bin_time, camera;\n`;\n\nmsg.topic = query;\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
@@ -7469,8 +7561,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 290,
-        "y": 1420,
+        "x": 570,
+        "y": 980,
         "wires": [
             [
                 "eff2193c8246a9d2"
@@ -7486,8 +7578,8 @@
         "sqlquery": "msg.topic",
         "sql": "",
         "name": "",
-        "x": 450,
-        "y": 1460,
+        "x": 940,
+        "y": 980,
         "wires": [
             [
                 "57fa6ca2b7d290e3"
@@ -7507,8 +7599,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 410,
-        "y": 1500,
+        "x": 1230,
+        "y": 980,
         "wires": [
             [
                 "11fa2826769befc7"
@@ -7528,8 +7620,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 660,
-        "y": 2340,
+        "x": 760,
+        "y": 1700,
         "wires": [
             [
                 "befe91e6862c72db"
@@ -7545,8 +7637,8 @@
         "sqlquery": "msg.topic",
         "sql": "",
         "name": "",
-        "x": 830,
-        "y": 2380,
+        "x": 1140,
+        "y": 1700,
         "wires": [
             [
                 "13a061996f9322f3",
@@ -7567,8 +7659,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 830,
-        "y": 2440,
+        "x": 1230,
+        "y": 1760,
         "wires": [
             [
                 "6d738ed81fefbedc"
@@ -7588,8 +7680,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 840,
-        "y": 2480,
+        "x": 1240,
+        "y": 1800,
         "wires": [
             [
                 "d856c68660eb2202"
@@ -7601,7 +7693,7 @@
         "type": "function",
         "z": "28627559bebdc324",
         "g": "1bd1f21fa0390c69",
-        "name": "create sqlite query, daily cumulative CAR counts in zone_capture + zone_radar that HAVE valid speed_calc",
+        "name": "query, daily cum car counts in zone_radar with speed_calc",
         "func": "//frame_time is already in seconds\n//cars with speeds in zone_radar AND zone_capture since 0400 today\n\nconst query = `\nWITH results AS (\n  SELECT \n    COUNT(*) AS count,\n    AVG(ABS(speed_calc)) AS mean_speed,\n    MAX(CASE WHEN ntile = 5 THEN ABS(speed_calc) ELSE NULL END) AS p25_speed,\n    MAX(CASE WHEN ntile = 10 THEN ABS(speed_calc) ELSE NULL END) AS p50_speed,\n    MAX(CASE WHEN ntile = 15 THEN ABS(speed_calc) ELSE NULL END) AS p75_speed,\n    MAX(CASE WHEN ntile = 17 THEN ABS(speed_calc) ELSE NULL END) AS p85_speed,\n    MAX(ABS(speed_calc)) AS max_speed,\n    SUM(CASE WHEN ABS(speed_calc) > 25 THEN 1 ELSE 0 END) AS count_over_25,\n    JSON_GROUP_ARRAY(speed_calc) AS speeds\n  FROM \n    (SELECT \n       ABS(speed_calc) as speed_calc,\n       NTILE(20) OVER (ORDER BY ABS(speed_calc)) AS ntile\n     FROM \n       events\n     WHERE \n       frame_time >= unixepoch(strftime('%Y-%m-%dT04:00','now', 'localtime'),'utc') AND\n       label = 'car' AND\n       entered_zones LIKE '%zone_radar%' AND\n       entered_zones LIKE '%zone_capture%' AND\n       ABS(speed_calc) NOT NULL AND\n       camera = '${flow.get(\"camera_selection\")}'\n    )\n)\nSELECT \n  *, \n  p75_speed + 1.5 * (p75_speed - p25_speed) AS iqr_upper,\n  (SELECT COUNT(*) FROM json_each(results.speeds) WHERE json_each.value > p75_speed + 1.5 * (p75_speed - p25_speed)) AS iqr_upper_freq\nFROM \n  results;\n`;\n\nmsg.topic = query;\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
@@ -7609,8 +7701,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 630,
-        "y": 2660,
+        "x": 590,
+        "y": 1140,
         "wires": [
             [
                 "9cf49f0891d25df1"
@@ -7626,8 +7718,8 @@
         "sqlquery": "msg.topic",
         "sql": "",
         "name": "",
-        "x": 950,
-        "y": 2700,
+        "x": 960,
+        "y": 1140,
         "wires": [
             [
                 "6d81c8e3c89b68f6"
@@ -7647,8 +7739,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 900,
-        "y": 2760,
+        "x": 1280,
+        "y": 1140,
         "wires": [
             [
                 "5417aae0d14fa661"
@@ -7664,8 +7756,8 @@
         "sqlquery": "msg.topic",
         "sql": "",
         "name": "",
-        "x": 370,
-        "y": 1200,
+        "x": 840,
+        "y": 780,
         "wires": [
             [
                 "39d895a16ca6f6f1",
@@ -7679,15 +7771,15 @@
         "z": "28627559bebdc324",
         "g": "76417db2b472ef4f",
         "name": "query TimedSpeedCounts for last 60-min",
-        "func": "//time is already in seconds\n//get for last 60-minutes, 3600 seconds\n\nconst query = `\nSELECT\n    strftime('%Y-%m-%d %H:%M:00', datetime(time, 'unixepoch', 'localtime'), '+0 minutes') AS time,\n    direction,\n    count,\n    ABS(average) as speed\nFROM\n    radar_timed_speed_counts\nWHERE\n    time > (unixepoch('now') - (3600))\nORDER BY\n    time;\n`;\n\nmsg.topic = query;\nreturn msg;",
+        "func": "//time is already in seconds\n//get for last 60-minutes, 3600 seconds\n\nconst query = `\nSELECT\n    strftime('%Y-%m-%d %H:%M:00', datetime(time, 'unixepoch', 'localtime'), '+0 minutes') AS time,\n    direction,\n    count,\n    ABS(average) as speed\nFROM\n    radar_timed_speed_counts\nWHERE\n    time > (unixepoch('now') - (3600))\n    AND radarName = '${flow.get(\"radar_selection\")}'\nORDER BY\n    time;\n`;\n\nmsg.topic = query;\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
         "noerr": 0,
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 220,
-        "y": 1160,
+        "x": 520,
+        "y": 780,
         "wires": [
             [
                 "7cc031e5a7d773a4"
@@ -7707,8 +7799,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 710,
-        "y": 1200,
+        "x": 1190,
+        "y": 780,
         "wires": [
             [
                 "cbb3b02ca505a55b"
@@ -7728,8 +7820,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 730,
-        "y": 1280,
+        "x": 1210,
+        "y": 860,
         "wires": [
             [
                 "7db4b197df9eb075"
@@ -7742,8 +7834,8 @@
         "z": "28627559bebdc324",
         "g": "76417db2b472ef4f",
         "name": "",
-        "group": "06dde4be9a9a6b27",
-        "order": 5,
+        "group": "7866c2aa313ab8b9",
+        "order": 4,
         "width": 0,
         "height": 0,
         "label": "SQLite TimedSpeedCounts.counts (5-min) for last 60-min",
@@ -7775,8 +7867,8 @@
         "outputs": 1,
         "useDifferentColor": false,
         "className": "",
-        "x": 770,
-        "y": 1240,
+        "x": 1250,
+        "y": 820,
         "wires": [
             []
         ]
@@ -7787,8 +7879,8 @@
         "z": "28627559bebdc324",
         "g": "76417db2b472ef4f",
         "name": "",
-        "group": "06dde4be9a9a6b27",
-        "order": 6,
+        "group": "7866c2aa313ab8b9",
+        "order": 5,
         "width": 0,
         "height": 0,
         "label": "SQLite TimedSpeedCounts.speed_average (5-min) for last 60-min",
@@ -7820,8 +7912,8 @@
         "outputs": 1,
         "useDifferentColor": false,
         "className": "",
-        "x": 800,
-        "y": 1320,
+        "x": 1280,
+        "y": 900,
         "wires": [
             []
         ]
@@ -7834,9 +7926,9 @@
         "name": "",
         "label": "",
         "tooltip": "",
-        "place": "Select sensor to report cumulative daily object counts",
+        "place": "Select camera",
         "group": "202181a361213d6d",
-        "order": 7,
+        "order": 1,
         "width": 0,
         "height": 0,
         "passthru": true,
@@ -7852,7 +7944,7 @@
         "topic": "topic",
         "topicType": "msg",
         "className": "",
-        "x": 240,
+        "x": 920,
         "y": 120,
         "wires": [
             [
@@ -7865,29 +7957,19 @@
         "type": "inject",
         "z": "28627559bebdc324",
         "g": "2df66c6bc991dbf4",
-        "name": "",
-        "props": [
-            {
-                "p": "payload"
-            },
-            {
-                "p": "options",
-                "v": "$keys($globalContext(\"config.sensors.cameras\"))\t",
-                "vt": "jsonata"
-            }
-        ],
+        "name": "trigger: sensor selections, after 5-secs",
+        "props": [],
         "repeat": "",
         "crontab": "",
         "once": true,
         "onceDelay": "5",
         "topic": "",
-        "payload": "$keys($globalContext(\"config.sensors.cameras\"))[0]\t",
-        "payloadType": "jsonata",
-        "x": 110,
+        "x": 210,
         "y": 120,
         "wires": [
             [
-                "bb08a223f0aaef0f"
+                "f50a7968e032532a",
+                "af02df2daa211e5b"
             ]
         ]
     },
@@ -7911,8 +7993,577 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 190,
+        "x": 1110,
+        "y": 120,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "ff783e21c3b96d4b",
+        "type": "change",
+        "z": "28627559bebdc324",
+        "g": "2df66c6bc991dbf4",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "radar_selection",
+                "pt": "flow",
+                "to": "payload",
+                "tot": "msg"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 1110,
         "y": 180,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "62c9240d45e9c8d6",
+        "type": "ui_dropdown",
+        "z": "28627559bebdc324",
+        "g": "2df66c6bc991dbf4",
+        "name": "",
+        "label": "",
+        "tooltip": "",
+        "place": "Select radar",
+        "group": "202181a361213d6d",
+        "order": 2,
+        "width": 0,
+        "height": 0,
+        "passthru": true,
+        "multiple": false,
+        "options": [
+            {
+                "label": "",
+                "value": "",
+                "type": "str"
+            }
+        ],
+        "payload": "",
+        "topic": "topic",
+        "topicType": "msg",
+        "className": "",
+        "x": 920,
+        "y": 180,
+        "wires": [
+            [
+                "ff783e21c3b96d4b"
+            ]
+        ]
+    },
+    {
+        "id": "59d0c8b142295eee",
+        "type": "change",
+        "z": "28627559bebdc324",
+        "g": "2df66c6bc991dbf4",
+        "name": "set radars, default to camera_radar",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "$globalContext(\"config.sensors.cameras.\" & payload & \".camera_radar\")",
+                "tot": "jsonata"
+            },
+            {
+                "t": "set",
+                "p": "options",
+                "pt": "msg",
+                "to": "$keys($globalContext(\"config.sensors.radars\"))",
+                "tot": "jsonata"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 640,
+        "y": 180,
+        "wires": [
+            [
+                "62c9240d45e9c8d6"
+            ]
+        ]
+    },
+    {
+        "id": "f50a7968e032532a",
+        "type": "change",
+        "z": "28627559bebdc324",
+        "g": "2df66c6bc991dbf4",
+        "name": "set cameras, default to index 0",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "$keys($globalContext(\"config.sensors.cameras\"))[0]",
+                "tot": "jsonata"
+            },
+            {
+                "t": "set",
+                "p": "options",
+                "pt": "msg",
+                "to": "$keys($globalContext(\"config.sensors.cameras\"))",
+                "tot": "jsonata"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 590,
+        "y": 120,
+        "wires": [
+            [
+                "bb08a223f0aaef0f",
+                "59d0c8b142295eee"
+            ]
+        ]
+    },
+    {
+        "id": "af02df2daa211e5b",
+        "type": "change",
+        "z": "28627559bebdc324",
+        "g": "2df66c6bc991dbf4",
+        "name": "set airquality_monitors, default to index 0",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "$keys($globalContext(\"config.sensors.airquality_monitors\"))[0]",
+                "tot": "jsonata"
+            },
+            {
+                "t": "set",
+                "p": "options",
+                "pt": "msg",
+                "to": "$keys($globalContext(\"config.sensors.airquality_monitors\"))",
+                "tot": "jsonata"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 620,
+        "y": 240,
+        "wires": [
+            [
+                "1feaed96b954867a"
+            ]
+        ]
+    },
+    {
+        "id": "1feaed96b954867a",
+        "type": "ui_dropdown",
+        "z": "28627559bebdc324",
+        "g": "2df66c6bc991dbf4",
+        "name": "",
+        "label": "",
+        "tooltip": "",
+        "place": "Select aq_monitor",
+        "group": "202181a361213d6d",
+        "order": 3,
+        "width": 0,
+        "height": 0,
+        "passthru": true,
+        "multiple": false,
+        "options": [
+            {
+                "label": "",
+                "value": "",
+                "type": "str"
+            }
+        ],
+        "payload": "",
+        "topic": "topic",
+        "topicType": "msg",
+        "className": "",
+        "x": 920,
+        "y": 240,
+        "wires": [
+            [
+                "946c6bc353743bc4"
+            ]
+        ]
+    },
+    {
+        "id": "946c6bc353743bc4",
+        "type": "change",
+        "z": "28627559bebdc324",
+        "g": "2df66c6bc991dbf4",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "aq_selection",
+                "pt": "flow",
+                "to": "payload",
+                "tot": "msg"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 1100,
+        "y": 240,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "a3672e4c4c84d721",
+        "type": "inject",
+        "z": "28627559bebdc324",
+        "g": "7c19b3698bb02613",
+        "name": "trigger Event query every 5-min",
+        "props": [
+            {
+                "p": "payload"
+            },
+            {
+                "p": "topic",
+                "vt": "str"
+            }
+        ],
+        "repeat": "300",
+        "crontab": "",
+        "once": true,
+        "onceDelay": "5",
+        "topic": "query",
+        "payload": "",
+        "payloadType": "date",
+        "x": 200,
+        "y": 1940,
+        "wires": [
+            [
+                "441e03047af79373",
+                "9573839489d3567f"
+            ]
+        ]
+    },
+    {
+        "id": "e5ed08571761bd2c",
+        "type": "ui_chart",
+        "z": "28627559bebdc324",
+        "g": "7c19b3698bb02613",
+        "name": "aq gas last 24-hours",
+        "group": "62cdf198fe42de7e",
+        "order": 1,
+        "width": 6,
+        "height": 7,
+        "label": "aq gas PPM, every 5-min (or based on settings) for last 24-hours",
+        "chartType": "line",
+        "legend": "true",
+        "xformat": "HH:mm",
+        "interpolate": "linear",
+        "nodata": "",
+        "dot": false,
+        "ymin": "",
+        "ymax": "",
+        "removeOlder": "24",
+        "removeOlderPoints": "10000",
+        "removeOlderUnit": "3600",
+        "cutout": 0,
+        "useOneColor": false,
+        "useUTC": false,
+        "colors": [
+            "#1f77b4",
+            "#aec7e8",
+            "#ff7f0e",
+            "#2ca02c",
+            "#98df8a",
+            "#d62728",
+            "#ff9896",
+            "#9467bd",
+            "#c5b0d5"
+        ],
+        "outputs": 1,
+        "useDifferentColor": false,
+        "className": "",
+        "x": 1200,
+        "y": 1980,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "441e03047af79373",
+        "type": "function",
+        "z": "28627559bebdc324",
+        "g": "7c19b3698bb02613",
+        "name": "query, airquality for every entry",
+        "func": "//entryDateTime is already in seconds\n\nconst query = `\nSELECT\n    strftime('%Y-%m-%d %H:%M:00', datetime(entryDateTime, 'unixepoch', 'localtime'), '+0 minutes') AS datetime,\n    gas_red, \n    gas_oxi, \n    gas_nh3\nFROM\n    airquality\nWHERE\n    entryDateTime > (unixepoch('now') - (86400 * 1))\n    AND sensorName = '${flow.get(\"aq_selection\")}'\nORDER BY\n    entryDateTime;\n`;\n\nmsg.topic = query;\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 530,
+        "y": 1940,
+        "wires": [
+            [
+                "9d1978d68c96feb9"
+            ]
+        ]
+    },
+    {
+        "id": "9d1978d68c96feb9",
+        "type": "sqlite",
+        "z": "28627559bebdc324",
+        "g": "7c19b3698bb02613",
+        "mydb": "2f60c1ab30a6fc8f",
+        "sqlquery": "msg.topic",
+        "sql": "",
+        "name": "",
+        "x": 820,
+        "y": 1940,
+        "wires": [
+            [
+                "2227d1c8d929c91d"
+            ]
+        ]
+    },
+    {
+        "id": "2227d1c8d929c91d",
+        "type": "function",
+        "z": "28627559bebdc324",
+        "g": "7c19b3698bb02613",
+        "name": "structure daily summary payload",
+        "func": "//https://github.com/node-red/node-red-dashboard/blob/master/Charts.md\n//Array of Object with keys of series, data=x:ts,y:count, labels\n\nconst result = [{\n    \"series\": [\"gas_red\", \"gas_oxi\", \"gas_nh3\"],\n    \"data\": [\n        msg.payload.map(item => ({ \"x\": new Date(item.datetime), \"y\": item.gas_red })),\n        msg.payload.map(item => ({ \"x\": new Date(item.datetime), \"y\": item.gas_oxi })),\n        msg.payload.map(item => ({ \"x\": new Date(item.datetime), \"y\": item.gas_nh3 }))\n    ],\n    \"labels\": [\"\"]\n}];\n\nmsg.payload = result;\n\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 1150,
+        "y": 1940,
+        "wires": [
+            [
+                "e5ed08571761bd2c"
+            ]
+        ]
+    },
+    {
+        "id": "bd1b7f16edeb4ed3",
+        "type": "ui_chart",
+        "z": "28627559bebdc324",
+        "g": "83eedcc325ccc21d",
+        "name": "aq PM last 24-hours",
+        "group": "62cdf198fe42de7e",
+        "order": 3,
+        "width": 6,
+        "height": 7,
+        "label": "aq PM ug/m3, every 5-min (or based on settings) for last 24-hours",
+        "chartType": "line",
+        "legend": "true",
+        "xformat": "HH:mm",
+        "interpolate": "linear",
+        "nodata": "",
+        "dot": false,
+        "ymin": "",
+        "ymax": "",
+        "removeOlder": "24",
+        "removeOlderPoints": "10000",
+        "removeOlderUnit": "3600",
+        "cutout": 0,
+        "useOneColor": false,
+        "useUTC": false,
+        "colors": [
+            "#1f77b4",
+            "#aec7e8",
+            "#ff7f0e",
+            "#2ca02c",
+            "#98df8a",
+            "#d62728",
+            "#ff9896",
+            "#9467bd",
+            "#c5b0d5"
+        ],
+        "outputs": 1,
+        "useDifferentColor": false,
+        "className": "",
+        "x": 1160,
+        "y": 2260,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "bf4e488edf28469b",
+        "type": "function",
+        "z": "28627559bebdc324",
+        "g": "83eedcc325ccc21d",
+        "name": "query, airquality for every entry",
+        "func": "//entryDateTime is already in seconds\n\nconst query = `\nSELECT\n    strftime('%Y-%m-%d %H:%M:00', datetime(entryDateTime, 'unixepoch', 'localtime'), '+0 minutes') AS datetime,\n    pm01, \n    pm025, \n    pm10\nFROM\n    airquality\nWHERE\n    entryDateTime > (unixepoch('now') - (86400 * 1))\n    AND sensorName = '${flow.get(\"aq_selection\")}'\nORDER BY\n    entryDateTime;\n`;\n\nmsg.topic = query;\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 390,
+        "y": 2220,
+        "wires": [
+            [
+                "0d4ff80748d1c876"
+            ]
+        ]
+    },
+    {
+        "id": "0d4ff80748d1c876",
+        "type": "sqlite",
+        "z": "28627559bebdc324",
+        "g": "83eedcc325ccc21d",
+        "mydb": "2f60c1ab30a6fc8f",
+        "sqlquery": "msg.topic",
+        "sql": "",
+        "name": "",
+        "x": 820,
+        "y": 2220,
+        "wires": [
+            [
+                "56bbbcd2844a4c13"
+            ]
+        ]
+    },
+    {
+        "id": "56bbbcd2844a4c13",
+        "type": "function",
+        "z": "28627559bebdc324",
+        "g": "83eedcc325ccc21d",
+        "name": "structure daily summary payload",
+        "func": "//https://github.com/node-red/node-red-dashboard/blob/master/Charts.md\n//Array of Object with keys of series, data=x:ts,y:count, labels\n\nconst result = [{\n    \"series\": [\"pm01\", \"pm025\", \"pm10\"],\n    \"data\": [\n        msg.payload.map(item => ({ \"x\": new Date(item.datetime), \"y\": item.pm01 })),\n        msg.payload.map(item => ({ \"x\": new Date(item.datetime), \"y\": item.pm025 })),\n        msg.payload.map(item => ({ \"x\": new Date(item.datetime), \"y\": item.pm10 }))\n    ],\n    \"labels\": [\"\"]\n}];\n\nmsg.payload = result;\n\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 1110,
+        "y": 2220,
+        "wires": [
+            [
+                "bd1b7f16edeb4ed3"
+            ]
+        ]
+    },
+    {
+        "id": "12df4fdffa628238",
+        "type": "function",
+        "z": "28627559bebdc324",
+        "g": "d16177f416c9a0ef",
+        "name": "query, events 30-min bins last 24-h in zone_capture",
+        "func": "//frame_time is already in seconds\n//frame_time as 5-minute intervals, rounded up\n\nconst query = `\nSELECT\n    strftime('%Y-%m-%d %H:%M:00', (frame_time + 1799), 'unixepoch', '-' || ((frame_time + 1799) % 1800) || ' seconds', 'localtime') AS bin_time,\n    label,\n    COUNT(*) as count\nFROM\n    events\nWHERE\n    frame_time > (unixepoch('now') - (86400 * 1))\n    AND camera = '${flow.get(\"camera_selection\")}'\n    AND entered_zones LIKE '%zone_capture%'\n    AND label IN ('car')\nGROUP BY\n    strftime('%Y-%m-%d %H:%M:00', (frame_time + 1799), 'unixepoch', '-' || ((frame_time + 1799) % 1800) || ' seconds', 'localtime'), label\nORDER BY\n    label, bin_time;\n`;\n\nmsg.topic = query;\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 450,
+        "y": 2080,
+        "wires": [
+            [
+                "6a292f3905fe5405"
+            ]
+        ]
+    },
+    {
+        "id": "6a292f3905fe5405",
+        "type": "sqlite",
+        "z": "28627559bebdc324",
+        "g": "d16177f416c9a0ef",
+        "mydb": "2f60c1ab30a6fc8f",
+        "sqlquery": "msg.topic",
+        "sql": "",
+        "name": "",
+        "x": 820,
+        "y": 2080,
+        "wires": [
+            [
+                "76e813b1b7a4b63e"
+            ]
+        ]
+    },
+    {
+        "id": "76e813b1b7a4b63e",
+        "type": "function",
+        "z": "28627559bebdc324",
+        "g": "d16177f416c9a0ef",
+        "name": "structure bin_counts for last day",
+        "func": "const series = {};\nconst labels = [];\n\nmsg.payload.forEach((item) => {\n    const timestamp = new Date(item.bin_time);\n    if (!series[item.label]) {\n        series[item.label] = [];\n    }\n    series[item.label].push({ x: timestamp, y: item.count });\n    if (!labels.includes(item.label)) {\n        labels.push(item.label);\n    }\n});\n\nconst result = [{\n    series: labels,\n    data: Object.values(series),\n    labels: [\"\"]\n}];\n\nmsg.payload = result;\n\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 1110,
+        "y": 2080,
+        "wires": [
+            [
+                "5cf61952cb6823de"
+            ]
+        ]
+    },
+    {
+        "id": "5cf61952cb6823de",
+        "type": "ui_chart",
+        "z": "28627559bebdc324",
+        "g": "d16177f416c9a0ef",
+        "name": "events (30-min) last 24-hours",
+        "group": "62cdf198fe42de7e",
+        "order": 2,
+        "width": 6,
+        "height": 7,
+        "label": "events by label, every 30-min for last 24-hours",
+        "chartType": "line",
+        "legend": "true",
+        "xformat": "HH:mm",
+        "interpolate": "linear",
+        "nodata": "",
+        "dot": false,
+        "ymin": "",
+        "ymax": "",
+        "removeOlder": "24",
+        "removeOlderPoints": "10000",
+        "removeOlderUnit": "3600",
+        "cutout": 0,
+        "useOneColor": false,
+        "useUTC": false,
+        "colors": [
+            "#1f77b4",
+            "#aec7e8",
+            "#ff7f0e",
+            "#2ca02c",
+            "#98df8a",
+            "#d62728",
+            "#ff9896",
+            "#9467bd",
+            "#c5b0d5"
+        ],
+        "outputs": 1,
+        "useDifferentColor": false,
+        "className": "",
+        "x": 1180,
+        "y": 2120,
         "wires": [
             []
         ]

--- a/node-red-project/flows.json
+++ b/node-red-project/flows.json
@@ -851,8 +851,26 @@
         ],
         "x": 54,
         "y": 439,
-        "w": 2272,
+        "w": 2512,
         "h": 162
+    },
+    {
+        "id": "2df66c6bc991dbf4",
+        "type": "group",
+        "z": "28627559bebdc324",
+        "name": "camera selection",
+        "style": {
+            "label": true
+        },
+        "nodes": [
+            "bb08a223f0aaef0f",
+            "e3b795e05d7650b2",
+            "c7f00f59861cd00f"
+        ],
+        "x": 14,
+        "y": 79,
+        "w": 312,
+        "h": 142
     },
     {
         "id": "b334a2375eb8cb42",
@@ -1230,24 +1248,6 @@
         "y": 859,
         "w": 932,
         "h": 162
-    },
-    {
-        "id": "2df66c6bc991dbf4",
-        "type": "group",
-        "z": "28627559bebdc324",
-        "name": "camera selection",
-        "style": {
-            "label": true
-        },
-        "nodes": [
-            "bb08a223f0aaef0f",
-            "e3b795e05d7650b2",
-            "c7f00f59861cd00f"
-        ],
-        "x": 14,
-        "y": 79,
-        "w": 312,
-        "h": 142
     },
     {
         "id": "05a58d9ee463c696",
@@ -4267,7 +4267,7 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 2160,
+        "x": 2400,
         "y": 560,
         "wires": [
             []
@@ -4283,7 +4283,7 @@
         "links": [
             "66bace5cf805a4fb"
         ],
-        "x": 2285,
+        "x": 2275,
         "y": 520,
         "wires": []
     },
@@ -5842,7 +5842,7 @@
         "z": "f7932be9acc7391c",
         "g": "99dfff63ac837bc8",
         "name": "format system metrics payload",
-        "func": "// format the payload with a timestamp\nlet values = {\n    ...msg.payload,\n}\n//ts in milliseconds\nmsg.payload = {\n    ts: values.time_ms_utc,\n    values: {\n        system_metrics: values\n    }\n}\n\nreturn msg;",
+        "func": "const newPayload = {\n    ts: msg.payload.time_ms_utc,\n    values: {\n        system_metrics: msg.payload\n    }\n}\n\nmsg.payload = newPayload;\n\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
         "noerr": 0,
@@ -6308,7 +6308,7 @@
         "z": "f7932be9acc7391c",
         "g": "f034ca2ecdf9a2f6",
         "name": "format radar info client-side attributes",
-        "func": "const newPayload = {\n    radarInfo: msg.payload,\n}\n\nmsg.payload = newPayload;\n\nreturn msg;",
+        "func": "const newPayload = {\n    radarinfo: msg.payload,\n}\n\nmsg.payload = newPayload;\n\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
         "noerr": 0,
@@ -6706,7 +6706,7 @@
         "z": "28627559bebdc324",
         "g": "9b9e4fc50b744fc3",
         "name": "debug: event payload in",
-        "active": true,
+        "active": false,
         "tosidebar": true,
         "console": false,
         "tostatus": false,
@@ -11667,7 +11667,7 @@
         "useparts": false,
         "accumulate": false,
         "timeout": "",
-        "count": "8",
+        "count": "9",
         "reduceRight": false,
         "reduceExp": "",
         "reduceInit": "",
@@ -11912,7 +11912,7 @@
         "type": "function",
         "z": "f410f6aac9d1a3fc",
         "name": "Hardware",
-        "func": "msg.payload = JSON.parse(msg.payload);\nmsg.topic = \"metrics_Hardware\";\nreturn msg;",
+        "func": "msg.payload = JSON.parse(msg.payload);\nmsg.topic = \"tm/system_metrics\";\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
         "noerr": 0,

--- a/node-red-project/flows.json
+++ b/node-red-project/flows.json
@@ -1066,6 +1066,48 @@
         "h": 622
     },
     {
+        "id": "672f3b07194c5dd5",
+        "type": "group",
+        "z": "b1fde507a4b80c79",
+        "name": "set up airquality database table",
+        "style": {
+            "label": true
+        },
+        "nodes": [
+            "35d0362b1f8a5e1a",
+            "ad3b1bd4bcdd6731",
+            "e063e562cca50f31",
+            "9ec2c67401c5aebc",
+            "d61da5053d3a100e",
+            "e13414feb4f512b8"
+        ],
+        "x": 74,
+        "y": 539,
+        "w": 1042,
+        "h": 122
+    },
+    {
+        "id": "efdb589a1b6e0c2f",
+        "type": "group",
+        "z": "b1fde507a4b80c79",
+        "name": "capture airquality messages, assign properties, format message, save and send",
+        "style": {
+            "label": true
+        },
+        "nodes": [
+            "8cae4cba37aecc0d",
+            "99bfb6c2ced810ec",
+            "014464d29b72fa53",
+            "24ae834ea737eac6",
+            "a40ef3730c08bfce",
+            "ef6ffe823574c1d1"
+        ],
+        "x": 234,
+        "y": 159,
+        "w": 872,
+        "h": 302
+    },
+    {
         "id": "05a58d9ee463c696",
         "type": "junction",
         "z": "1c71c8f26f5b7b19",
@@ -4716,7 +4758,7 @@
         "z": "9269520ddb532b00",
         "g": "0a5faeac9fbd6d55",
         "name": "append config, deployment properties",
-        "func": "// attach radarName, deployment_id, if applicable\n\nconst sensor = global.get(`config.sensors.cameras.${msg.frigate_event.camera}`, 'config');\n\nmsg.radarEnabled = false;\n\nif (sensor.hasOwnProperty('camera_radar')) {\n    //get radar settings\n    const radar = global.get(`config.sensors.radars.${msg.frigate_event.camera}`, 'config');\n    if (radar.hasOwnProperty('enabled')) {\n        if (radar.enabled === true) {\n            msg.frigate_event.radarName = sensor.camera_radar;\n            msg.radarEnabled = true;\n        }\n    }\n}\n\nif (sensor.hasOwnProperty('deployment')) {\n    msg.frigate_event.deployment_id = sensor.deployment.id;\n}\n//indicate if camera is enabled in TM for capture (may still be on in Frigate)\nif (sensor.hasOwnProperty('enabled')) {\n    msg.enabled = sensor.enabled;\n}\n\nreturn msg;",
+        "func": "// attach radarName, deployment_id, if applicable\n\nconst sensor = global.get(`config.sensors.cameras.${msg.frigate_event.camera}`);\n\nmsg.radarEnabled = false;\n\nif (sensor.hasOwnProperty('camera_radar')) {\n    //get radar settings\n    const radar = global.get(`config.sensors.radars.${msg.frigate_event.camera}`);\n    if (radar.hasOwnProperty('enabled')) {\n        if (radar.enabled === true) {\n            msg.frigate_event.radarName = sensor.camera_radar;\n            msg.radarEnabled = true;\n        }\n    }\n}\n\nif (sensor.hasOwnProperty('deployment')) {\n    msg.frigate_event.deployment_id = sensor.deployment.id;\n}\n//indicate if camera is enabled in TM for capture (may still be on in Frigate)\nif (sensor.hasOwnProperty('enabled')) {\n    msg.enabled = sensor.enabled;\n}\n\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
         "noerr": 0,
@@ -11190,10 +11232,11 @@
         "rh": 0,
         "inputs": 0,
         "x": 110,
-        "y": 60,
+        "y": 100,
         "wires": [
             [
-                "3da49a479e99f3b5"
+                "3da49a479e99f3b5",
+                "a40ef3730c08bfce"
             ]
         ]
     },
@@ -11201,7 +11244,7 @@
         "id": "3da49a479e99f3b5",
         "type": "debug",
         "z": "b1fde507a4b80c79",
-        "name": "debug 1",
+        "name": "debug: published airquality messages",
         "active": true,
         "tosidebar": true,
         "console": false,
@@ -11210,38 +11253,267 @@
         "targetType": "full",
         "statusVal": "",
         "statusType": "auto",
-        "x": 330,
-        "y": 60,
+        "x": 450,
+        "y": 100,
         "wires": []
     },
     {
-        "id": "5afaf6995a6bb8cf",
-        "type": "comment",
+        "id": "35d0362b1f8a5e1a",
+        "type": "sqlite",
         "z": "b1fde507a4b80c79",
-        "name": "attach timestamp, entryDateTime",
-        "info": "",
-        "x": 390,
+        "g": "672f3b07194c5dd5",
+        "mydb": "2f60c1ab30a6fc8f",
+        "sqlquery": "msg.topic",
+        "sql": "",
+        "name": "",
+        "x": 920,
+        "y": 580,
+        "wires": [
+            [
+                "9ec2c67401c5aebc"
+            ]
+        ]
+    },
+    {
+        "id": "ad3b1bd4bcdd6731",
+        "type": "inject",
+        "z": "b1fde507a4b80c79",
+        "g": "672f3b07194c5dd5",
+        "name": "inject after 0.1 sec",
+        "props": [],
+        "repeat": "",
+        "crontab": "",
+        "once": true,
+        "onceDelay": 0.1,
+        "topic": "",
+        "x": 210,
+        "y": 580,
+        "wires": [
+            [
+                "d61da5053d3a100e"
+            ]
+        ]
+    },
+    {
+        "id": "e063e562cca50f31",
+        "type": "inject",
+        "z": "b1fde507a4b80c79",
+        "g": "672f3b07194c5dd5",
+        "name": "inject manually",
+        "props": [],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "x": 200,
+        "y": 620,
+        "wires": [
+            [
+                "e13414feb4f512b8"
+            ]
+        ]
+    },
+    {
+        "id": "9ec2c67401c5aebc",
+        "type": "debug",
+        "z": "b1fde507a4b80c79",
+        "g": "672f3b07194c5dd5",
+        "name": "debug: last 5 rows airquality",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "payload",
+        "targetType": "msg",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 950,
+        "y": 620,
+        "wires": []
+    },
+    {
+        "id": "8cae4cba37aecc0d",
+        "type": "sqlite",
+        "z": "b1fde507a4b80c79",
+        "g": "efdb589a1b6e0c2f",
+        "mydb": "2f60c1ab30a6fc8f",
+        "sqlquery": "prepared",
+        "sql": "INSERT INTO airquality (entryDateTime, gas_calibrated, temp, bar, hum, dew, temp_raw, bar_raw, hum_raw, pm01, pm025, pm10, gas_red, gas_oxi, gas_nh3, gas_red_raw, gas_oxi_raw, gas_nh3_raw, lux, lux_raw, proximity, noise_level, sensorName, deployment_id)\nVALUES ($entryDateTime, $gas_calibrated, $temp, $bar, $hum, $dew, $temp_raw, $bar_raw, $hum_raw, $pm01, $pm025, $pm10, $gas_red, $gas_oxi, $gas_nh3, $gas_red_raw, $gas_oxi_raw, $gas_nh3_raw, $lux, $lux_raw, $proximity, $noise_level, $sensorName, $deployment_id);\n",
+        "name": "",
+        "x": 940,
+        "y": 360,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "99bfb6c2ced810ec",
+        "type": "function",
+        "z": "b1fde507a4b80c79",
+        "g": "efdb589a1b6e0c2f",
+        "name": "write params for airquality insert",
+        "func": "//format for SQLITE Insert Prepared Statement\n\nconst obj = msg.payload;\n\nconst keyedObj = Object.keys(obj).reduce((acc, key) => {\n    acc[`$${key}`] = obj[key];\n    return acc;\n}, {});\n\nmsg.params = keyedObj;\n\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 890,
+        "y": 320,
+        "wires": [
+            [
+                "8cae4cba37aecc0d"
+            ]
+        ]
+    },
+    {
+        "id": "d61da5053d3a100e",
+        "type": "template",
+        "z": "b1fde507a4b80c79",
+        "g": "672f3b07194c5dd5",
+        "name": "create airquality table",
+        "field": "topic",
+        "fieldType": "msg",
+        "format": "sql",
+        "syntax": "mustache",
+        "template": "CREATE TABLE IF NOT EXISTS airquality (\n    entryDateTime REAL\n    gas_calibrated INTEGER\n    temp REAL\n    bar REAL\n    hum REAL\n    dew REAL\n    temp_raw REAL\n    bar_raw REAL\n    hum_raw REAL\n    pm01 REAL\n    pm025 REAL\n    pm10 REAL\n    gas_red REAL\n    gas_oxi REAL\n    gas_nh3 REAL\n    gas_red_raw REAL\n    gas_oxi_raw REAL\n    gas_nh3_raw REAL\n    lux REAL\n    lux_raw REAL\n    proximity REAL\n    noise_level REAL\n    sensorName TEXT\n    deployment_id TEXT\n    );",
+        "output": "str",
+        "x": 600,
+        "y": 580,
+        "wires": [
+            [
+                "35d0362b1f8a5e1a"
+            ]
+        ]
+    },
+    {
+        "id": "e13414feb4f512b8",
+        "type": "template",
+        "z": "b1fde507a4b80c79",
+        "g": "672f3b07194c5dd5",
+        "name": "select latest 5 rows from airquality",
+        "field": "topic",
+        "fieldType": "msg",
+        "format": "sql",
+        "syntax": "mustache",
+        "template": "SELECT * \nFROM airquality \nORDER BY entryDateTime DESC \nLIMIT 5;",
+        "output": "str",
+        "x": 560,
+        "y": 620,
+        "wires": [
+            [
+                "35d0362b1f8a5e1a"
+            ]
+        ]
+    },
+    {
+        "id": "014464d29b72fa53",
+        "type": "switch",
+        "z": "b1fde507a4b80c79",
+        "g": "efdb589a1b6e0c2f",
+        "name": "enabled?",
+        "property": "sensor.enabled",
+        "propertyType": "msg",
+        "rules": [
+            {
+                "t": "true"
+            }
+        ],
+        "checkall": "true",
+        "repair": false,
+        "outputs": 1,
+        "x": 500,
+        "y": 240,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "24ae834ea737eac6",
+        "type": "template",
+        "z": "b1fde507a4b80c79",
+        "g": "efdb589a1b6e0c2f",
+        "name": "format mqtt for sqlite",
+        "field": "payload",
+        "fieldType": "msg",
+        "format": "handlebars",
+        "syntax": "mustache",
+        "template": "{\n    \"entryDateTime\": {{payload.current_time}},\n    \"gas_calibrated\": {{#payload.Gas Calibrated}}1{{/payload.Gas Calibrated}}{{^payload.Gas Calibrated}}0{{/payload.Gas Calibrated}},\n    \"temp\": {{payload.Temp}},\n    \"bar\": {{#payload}}{{#Bar}}{{.[0]}}{{/Bar}}{{/payload}},\n    \"hum\": {{#payload}}{{#Hum}}{{.[0]}}{{/Hum}}{{/payload}},\n    \"dew\": {{payload.Dew}},\n    \"temp_raw\": {{payload.temp_raw}},\n    \"bar_raw\": {{payload.bar_raw}},\n    \"hum_raw\": {{payload.hum_raw}},\n    \"pm01\": {{payload.P1}},\n    \"pm025\": {{payload.P2.5}},\n    \"pm10\": {{payload.P10}},\n    \"gas_red\": {{payload.Red}},\n    \"gas_oxi\": {{payload.Oxi}},\n    \"gas_nh3\": {{payload.NH3}},\n    \"gas_red_raw\": {{payload.gas_red_raw}},\n    \"gas_oxi_raw\": {{payload.gas_oxi_raw}},\n    \"gas_nh3_raw\": {{payload.gas_nh3_raw}},\n    \"lux\": {{payload.lux}},\n    \"lux_raw\": {{payload.lux_raw}},\n    \"proximity\": {{payload.proximity}},\n    \"noise_level\": \"\",\n    \"sensorName\": {{sensor.name}},\n    \"deployment_id\": {{sensor.deployment_id}}\n}",
+        "output": "json",
+        "x": 600,
+        "y": 320,
+        "wires": [
+            [
+                "99bfb6c2ced810ec",
+                "ef6ffe823574c1d1"
+            ]
+        ]
+    },
+    {
+        "id": "a40ef3730c08bfce",
+        "type": "function",
+        "z": "b1fde507a4b80c79",
+        "g": "efdb589a1b6e0c2f",
+        "name": "append config, deployment properties",
+        "func": "// attach deployment_id, if applicable\nmsg.sensor = {}\n\n//pull the airquality_monitor name, will be second element in mqtt topic; e.g. aq/sensorname01/readings\nconst sensor = global.get(`config.sensors.airquality_monitors.${msg.topic.split('/')[1]}`);\nmsg.sensor.name = msg.topic.split('/')[1];\n\n//indicate if sensor is enabled in TM for capture\nif (sensor.hasOwnProperty('enabled')) {\n    msg.sensor.enabled = sensor.enabled;\n}\n\n//attach deployment_id to message\nif (sensor.hasOwnProperty('deployment')) {\n    msg.sensor.deployment_id = sensor.deployment.id;\n}\n\n//attach mqtt topic to message\nif (sensor.hasOwnProperty('mqtt_topic_incoming')) {\n    msg.sensor.mqtt_topic_incoming = sensor.mqtt_topic_incoming;\n}\n\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 410,
         "y": 200,
+        "wires": [
+            [
+                "014464d29b72fa53"
+            ]
+        ]
+    },
+    {
+        "id": "ef6ffe823574c1d1",
+        "type": "link out",
+        "z": "b1fde507a4b80c79",
+        "g": "efdb589a1b6e0c2f",
+        "name": "airquality link out",
+        "mode": "link",
+        "links": [],
+        "x": 775,
+        "y": 420,
         "wires": []
     },
     {
-        "id": "3d42c2ee8cdbb69e",
-        "type": "comment",
+        "id": "78fe0447b9a69129",
+        "type": "catch",
         "z": "b1fde507a4b80c79",
-        "name": "check if enabled",
-        "info": "",
-        "x": 180,
-        "y": 140,
-        "wires": []
+        "name": "catch - airquality flow",
+        "scope": null,
+        "uncaught": false,
+        "x": 160,
+        "y": 40,
+        "wires": [
+            [
+                "86c57166ac231b3c"
+            ]
+        ]
     },
     {
-        "id": "d00238beae2aadd7",
-        "type": "comment",
+        "id": "86c57166ac231b3c",
+        "type": "debug",
         "z": "b1fde507a4b80c79",
-        "name": "create table airquality",
-        "info": "",
-        "x": 420,
-        "y": 460,
+        "name": "catch - airquality flow",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "true",
+        "targetType": "full",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 400,
+        "y": 40,
         "wires": []
     }
 ]

--- a/node-red-project/flows.json
+++ b/node-red-project/flows.json
@@ -566,7 +566,7 @@
         "x": 108,
         "y": 999,
         "w": 1198,
-        "h": 368
+        "h": 408
     },
     {
         "id": "9e0b1edd49eb4244",
@@ -610,7 +610,7 @@
             "463b64006f270db3"
         ],
         "x": 354,
-        "y": 799,
+        "y": 1039,
         "w": 1222,
         "h": 282
     },
@@ -638,7 +638,7 @@
             "dd88a80a3a79aa0b"
         ],
         "x": 354,
-        "y": 499,
+        "y": 739,
         "w": 1122,
         "h": 282
     },
@@ -666,7 +666,7 @@
             "2aac5b4f344a86e8"
         ],
         "x": 354,
-        "y": 1079,
+        "y": 1339,
         "w": 1242,
         "h": 282
     },
@@ -693,37 +693,9 @@
             "a18940845d6c5a2e"
         ],
         "x": 414,
-        "y": 1379,
+        "y": 1639,
         "w": 1242,
         "h": 302
-    },
-    {
-        "id": "da1c8c74261a93a4",
-        "type": "group",
-        "z": "1c71c8f26f5b7b19",
-        "name": "OC - payload, object summary+vehicle length",
-        "style": {
-            "label": true
-        },
-        "nodes": [
-            "ca4ed8761a4ded27",
-            "fbde266909bc0ca7",
-            "09369d5e4816364f",
-            "4ffa919935494b14",
-            "45801cdcc5094abc",
-            "6e30f911242c5595",
-            "edcc237df962c31a",
-            "59a9c9a7ba535641",
-            "0ba6c9b3eb3d521d",
-            "fb89305143faab57",
-            "45cdb2f02dfb2009",
-            "07d558da50af5ae4",
-            "1bdec3d0b912f792"
-        ],
-        "x": 354,
-        "y": 1699,
-        "w": 1192,
-        "h": 282
     },
     {
         "id": "23636f4163fa6e3b",
@@ -835,6 +807,61 @@
         "h": 188
     },
     {
+        "id": "da1c8c74261a93a4",
+        "type": "group",
+        "z": "1c71c8f26f5b7b19",
+        "name": "OC - payload, object summary+vehicle length",
+        "style": {
+            "label": true
+        },
+        "nodes": [
+            "ca4ed8761a4ded27",
+            "fbde266909bc0ca7",
+            "09369d5e4816364f",
+            "4ffa919935494b14",
+            "45801cdcc5094abc",
+            "6e30f911242c5595",
+            "edcc237df962c31a",
+            "59a9c9a7ba535641",
+            "fb89305143faab57",
+            "45cdb2f02dfb2009",
+            "07d558da50af5ae4",
+            "1bdec3d0b912f792",
+            "14ec91d93285b0fb",
+            "9b57af73505cbb61",
+            "8e8edd5176fc9a71"
+        ],
+        "x": 414,
+        "y": 1959,
+        "w": 1132,
+        "h": 362
+    },
+    {
+        "id": "805c5feafbb3610b",
+        "type": "group",
+        "z": "1c71c8f26f5b7b19",
+        "name": "collect radarInfo, initialize",
+        "style": {
+            "label": true
+        },
+        "nodes": [
+            "6a21bd2e9204bac0",
+            "c113788ccfa879b4",
+            "ae11d5c9948bf4e1",
+            "c4a024def66c8499",
+            "0abd83310c35db9a",
+            "59d61701c38da429",
+            "9e95f569494a21dc",
+            "50c56047654010ea",
+            "8c434de19f88fefc",
+            "7eb7b4b61d38b789"
+        ],
+        "x": 34,
+        "y": 439,
+        "w": 2292,
+        "h": 162
+    },
+    {
         "id": "b334a2375eb8cb42",
         "type": "group",
         "z": "f7932be9acc7391c",
@@ -877,9 +904,7 @@
             "4796b517d7d045a7",
             "9a894f4bd304f5a9",
             "5d3596375bd695c0",
-            "f29975eb207b5b8d",
-            "1711871384d75e10",
-            "6c582e93dfb3d6fa"
+            "f29975eb207b5b8d"
         ],
         "x": 134,
         "y": 219,
@@ -1119,7 +1144,7 @@
             "9b0f7197fe82bbfa"
         ],
         "x": 134,
-        "y": 1259,
+        "y": 1299,
         "w": 492,
         "h": 82
     },
@@ -1137,12 +1162,14 @@
             "d367cb76b239682f",
             "e507fdc9cbf67095",
             "0b62cae60d488c85",
-            "4af0d78e8bc39647"
+            "4af0d78e8bc39647",
+            "66bace5cf805a4fb",
+            "22f397ac5c294b6e"
         ],
         "x": 134,
         "y": 1079,
         "w": 472,
-        "h": 142
+        "h": 202
     },
     {
         "id": "b7398c4e0bc743e5",
@@ -1216,7 +1243,7 @@
         "id": "05a58d9ee463c696",
         "type": "junction",
         "z": "1c71c8f26f5b7b19",
-        "x": 440,
+        "x": 500,
         "y": 120,
         "wires": [
             [
@@ -1233,7 +1260,7 @@
         "z": "1c71c8f26f5b7b19",
         "g": "1eebfe6a2eca8ad4",
         "x": 380,
-        "y": 580,
+        "y": 820,
         "wires": [
             [
                 "7139490bca7e56ca",
@@ -1248,7 +1275,7 @@
         "z": "1c71c8f26f5b7b19",
         "g": "dea1b8828f8e501f",
         "x": 380,
-        "y": 840,
+        "y": 1080,
         "wires": [
             [
                 "4094c101f6b59d95",
@@ -1263,7 +1290,7 @@
         "z": "1c71c8f26f5b7b19",
         "g": "047f05d7650ba3cc",
         "x": 380,
-        "y": 1120,
+        "y": 1380,
         "wires": [
             [
                 "080fd00489701aa1",
@@ -1274,30 +1301,16 @@
         ]
     },
     {
-        "id": "0ba6c9b3eb3d521d",
-        "type": "junction",
-        "z": "1c71c8f26f5b7b19",
-        "g": "da1c8c74261a93a4",
-        "x": 380,
-        "y": 1740,
-        "wires": [
-            [
-                "ca4ed8761a4ded27",
-                "59a9c9a7ba535641",
-                "edcc237df962c31a"
-            ]
-        ]
-    },
-    {
         "id": "05e485cfcada03a3",
         "type": "junction",
         "z": "1c71c8f26f5b7b19",
-        "x": 1740,
+        "x": 1780,
         "y": 360,
         "wires": [
             [
                 "314e74cc3f8d050c",
-                "7d83424b6bf3a7a7"
+                "7d83424b6bf3a7a7",
+                "0abd83310c35db9a"
             ]
         ]
     },
@@ -1325,6 +1338,21 @@
         "wires": [
             [
                 "221ddfedf40c108f"
+            ]
+        ]
+    },
+    {
+        "id": "14ec91d93285b0fb",
+        "type": "junction",
+        "z": "1c71c8f26f5b7b19",
+        "g": "da1c8c74261a93a4",
+        "x": 620,
+        "y": 2000,
+        "wires": [
+            [
+                "edcc237df962c31a",
+                "ca4ed8761a4ded27",
+                "59a9c9a7ba535641"
             ]
         ]
     },
@@ -2312,7 +2340,7 @@
         "property": "payload",
         "action": "",
         "pretty": false,
-        "x": 1350,
+        "x": 1390,
         "y": 120,
         "wires": [
             [
@@ -2333,7 +2361,7 @@
         "targetType": "msg",
         "statusVal": "",
         "statusType": "auto",
-        "x": 1900,
+        "x": 1940,
         "y": 360,
         "wires": []
     },
@@ -2352,7 +2380,7 @@
         "statusVal": "",
         "statusType": "auto",
         "x": 640,
-        "y": 840,
+        "y": 1080,
         "wires": []
     },
     {
@@ -2361,7 +2389,7 @@
         "z": "1c71c8f26f5b7b19",
         "name": "receive RADAR_00",
         "serial": "6739e78652771a41",
-        "x": 1050,
+        "x": 1090,
         "y": 120,
         "wires": [
             [
@@ -2375,7 +2403,7 @@
         "z": "1c71c8f26f5b7b19",
         "name": "send to RADAR_00",
         "serial": "6739e78652771a41",
-        "x": 850,
+        "x": 890,
         "y": 120,
         "wires": []
     },
@@ -2394,7 +2422,7 @@
         "statusVal": "",
         "statusType": "auto",
         "x": 620,
-        "y": 540,
+        "y": 780,
         "wires": []
     },
     {
@@ -2433,28 +2461,20 @@
         "id": "6a21bd2e9204bac0",
         "type": "inject",
         "z": "1c71c8f26f5b7b19",
-        "name": "query all settings, after 1.7",
-        "props": [
-            {
-                "p": "payload"
-            },
-            {
-                "p": "topic",
-                "vt": "str"
-            }
-        ],
+        "g": "805c5feafbb3610b",
+        "name": "query all settings, after 4; then active",
+        "props": [],
         "repeat": "",
         "crontab": "",
         "once": true,
-        "onceDelay": "1.7",
+        "onceDelay": "4",
         "topic": "",
-        "payload": "\"?P\" & \"?N\" & \"?V\" & \"?B\" & \"??\" & \"O?\" & \"?F\" & \"?s\"",
-        "payloadType": "jsonata",
-        "x": 200,
-        "y": 400,
+        "x": 230,
+        "y": 480,
         "wires": [
             [
-                "05a58d9ee463c696"
+                "c4a024def66c8499",
+                "8c434de19f88fefc"
             ]
         ]
     },
@@ -2535,7 +2555,7 @@
         "once": true,
         "onceDelay": "1.1",
         "topic": "",
-        "payload": "\"OJUSF2S2K+IGONO3OUOTOhOC\" & \"OMM>20\\n\" & \"OSR>5\\n\" & \"@O@|300\\n\" & \"A!\" ",
+        "payload": "\"OJUSF2S2K+IGONO3OUOTOhOc\" & \"OMM>20\\n\" & \"OSR>5\\n\" & \"@O@|300\\n\" & \"A!\" ",
         "payloadType": "jsonata",
         "x": 230,
         "y": 160,
@@ -2578,7 +2598,7 @@
         "id": "7c8d64d25c65f351",
         "type": "inject",
         "z": "1c71c8f26f5b7b19",
-        "name": "init: PA, active power mode after settings, after 2",
+        "name": "init: PA, active power mode, manual",
         "props": [
             {
                 "p": "payload"
@@ -2590,13 +2610,13 @@
         ],
         "repeat": "",
         "crontab": "",
-        "once": true,
-        "onceDelay": "2",
+        "once": false,
+        "onceDelay": "20",
         "topic": "",
         "payload": "\"PA\"",
         "payloadType": "jsonata",
-        "x": 260,
-        "y": 440,
+        "x": 220,
+        "y": 400,
         "wires": [
             [
                 "05a58d9ee463c696"
@@ -2657,15 +2677,20 @@
             },
             {
                 "t": "hask",
-                "v": "delta_time_msec",
+                "v": "dir",
+                "vt": "str"
+            },
+            {
+                "t": "hask",
+                "v": "classifier",
                 "vt": "str"
             }
         ],
         "checkall": "true",
         "repair": false,
-        "outputs": 4,
+        "outputs": 5,
         "x": 180,
-        "y": 540,
+        "y": 780,
         "wires": [
             [
                 "3faf0dcbc24ef11c"
@@ -2677,7 +2702,10 @@
                 "a489601d43802b82"
             ],
             [
-                "0ba6c9b3eb3d521d"
+                "9b57af73505cbb61"
+            ],
+            [
+                "8e8edd5176fc9a71"
             ]
         ]
     },
@@ -2696,25 +2724,7 @@
         "statusVal": "",
         "statusType": "auto",
         "x": 590,
-        "y": 1120,
-        "wires": []
-    },
-    {
-        "id": "ca4ed8761a4ded27",
-        "type": "debug",
-        "z": "1c71c8f26f5b7b19",
-        "g": "da1c8c74261a93a4",
-        "name": "radar_oc_payload",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "payload",
-        "targetType": "msg",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 550,
-        "y": 1740,
+        "y": 1380,
         "wires": []
     },
     {
@@ -2785,7 +2795,7 @@
         "sql": "",
         "name": "",
         "x": 1280,
-        "y": 620,
+        "y": 860,
         "wires": [
             [
                 "5514c5ab4bed552c"
@@ -2805,7 +2815,7 @@
         "onceDelay": 0.1,
         "topic": "",
         "x": 550,
-        "y": 620,
+        "y": 860,
         "wires": [
             [
                 "1ef2418fe536aad5"
@@ -2825,7 +2835,7 @@
         "onceDelay": 0.1,
         "topic": "",
         "x": 540,
-        "y": 660,
+        "y": 900,
         "wires": [
             [
                 "1db11b98d771c791"
@@ -2847,7 +2857,7 @@
         "statusVal": "",
         "statusType": "auto",
         "x": 1310,
-        "y": 660,
+        "y": 900,
         "wires": []
     },
     {
@@ -2860,7 +2870,7 @@
         "sql": "INSERT INTO radar_dov (time, unit, direction, velocity, radarName, deployment_id) \nVALUES ($time, $unit, $direction, $velocity, $radarName, $deployment_id);\n",
         "name": "",
         "x": 1280,
-        "y": 740,
+        "y": 980,
         "wires": [
             []
         ]
@@ -2879,7 +2889,7 @@
         "finalize": "",
         "libs": [],
         "x": 610,
-        "y": 740,
+        "y": 980,
         "wires": [
             [
                 "c6fcbfb9341f189b"
@@ -2896,7 +2906,7 @@
         "sql": "",
         "name": "",
         "x": 1280,
-        "y": 920,
+        "y": 1160,
         "wires": [
             [
                 "866e0c814ea2b4da"
@@ -2916,7 +2926,7 @@
         "onceDelay": 0.1,
         "topic": "",
         "x": 550,
-        "y": 920,
+        "y": 1160,
         "wires": [
             [
                 "f9a458c786e4bb84"
@@ -2936,7 +2946,7 @@
         "onceDelay": 0.1,
         "topic": "",
         "x": 540,
-        "y": 960,
+        "y": 1200,
         "wires": [
             [
                 "8ccadc734d8ab769"
@@ -2958,7 +2968,7 @@
         "statusVal": "",
         "statusType": "auto",
         "x": 1360,
-        "y": 960,
+        "y": 1200,
         "wires": []
     },
     {
@@ -2975,7 +2985,7 @@
         "finalize": "",
         "libs": [],
         "x": 640,
-        "y": 1040,
+        "y": 1280,
         "wires": [
             [
                 "22234193104332f6"
@@ -2992,7 +3002,7 @@
         "sql": "INSERT INTO radar_timed_speed_counts (time, direction, units, count, average, radarName, deployment_id)\nVALUES ($time, $direction, $units, $count, $average, $radarName, $deployment_id);\n",
         "name": "",
         "x": 1280,
-        "y": 1040,
+        "y": 1280,
         "wires": [
             []
         ]
@@ -3007,7 +3017,7 @@
         "sql": "",
         "name": "",
         "x": 1280,
-        "y": 1200,
+        "y": 1460,
         "wires": [
             [
                 "9de4885ad8ef8485"
@@ -3027,7 +3037,7 @@
         "onceDelay": 0.1,
         "topic": "",
         "x": 550,
-        "y": 1200,
+        "y": 1460,
         "wires": [
             [
                 "8d4953609399d75e"
@@ -3047,7 +3057,7 @@
         "onceDelay": 0.1,
         "topic": "",
         "x": 540,
-        "y": 1240,
+        "y": 1500,
         "wires": [
             [
                 "2aac5b4f344a86e8"
@@ -3069,7 +3079,7 @@
         "statusVal": "",
         "statusType": "auto",
         "x": 1370,
-        "y": 1240,
+        "y": 1500,
         "wires": []
     },
     {
@@ -3082,7 +3092,7 @@
         "sql": "INSERT INTO radar_raw_speed_magnitude (time, unit, magnitude, speed, radarName, deployment_id) \nVALUES ($time, $unit, $magnitude, $speed, $radarName, $deployment_id);",
         "name": "",
         "x": 1280,
-        "y": 1320,
+        "y": 1580,
         "wires": [
             []
         ]
@@ -3101,121 +3111,10 @@
         "finalize": "",
         "libs": [],
         "x": 660,
-        "y": 1320,
+        "y": 1580,
         "wires": [
             [
                 "81522ee190374834"
-            ]
-        ]
-    },
-    {
-        "id": "fbde266909bc0ca7",
-        "type": "inject",
-        "z": "1c71c8f26f5b7b19",
-        "g": "da1c8c74261a93a4",
-        "name": "inject after 0.1 sec",
-        "props": [],
-        "repeat": "",
-        "crontab": "",
-        "once": true,
-        "onceDelay": 0.1,
-        "topic": "",
-        "x": 550,
-        "y": 1820,
-        "wires": [
-            [
-                "1bdec3d0b912f792"
-            ]
-        ]
-    },
-    {
-        "id": "09369d5e4816364f",
-        "type": "sqlite",
-        "z": "1c71c8f26f5b7b19",
-        "g": "da1c8c74261a93a4",
-        "mydb": "2f60c1ab30a6fc8f",
-        "sqlquery": "msg.topic",
-        "sql": "INSERT INTO radar_oc_payload (end_time, start_time, delta_time_msec, dir, frames, max_mph, min_mph, max_mag, avg_mag, frames_per_mph, length_ft)\nVALUES ($end_time, $start_time, $delta_time_msec, $dir, $frames, $max_mph, $min_mph, $max_mag, $avg_mag, $frames_per_mph, $length_ft);",
-        "name": "",
-        "x": 1280,
-        "y": 1820,
-        "wires": [
-            [
-                "45801cdcc5094abc"
-            ]
-        ]
-    },
-    {
-        "id": "4ffa919935494b14",
-        "type": "inject",
-        "z": "1c71c8f26f5b7b19",
-        "g": "da1c8c74261a93a4",
-        "name": "inject manually",
-        "props": [],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "",
-        "x": 540,
-        "y": 1860,
-        "wires": [
-            [
-                "07d558da50af5ae4"
-            ]
-        ]
-    },
-    {
-        "id": "45801cdcc5094abc",
-        "type": "debug",
-        "z": "1c71c8f26f5b7b19",
-        "g": "da1c8c74261a93a4",
-        "name": "debug: last 5 rows radar_oc_payload",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "payload",
-        "targetType": "msg",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 1350,
-        "y": 1860,
-        "wires": []
-    },
-    {
-        "id": "6e30f911242c5595",
-        "type": "sqlite",
-        "z": "1c71c8f26f5b7b19",
-        "g": "da1c8c74261a93a4",
-        "mydb": "2f60c1ab30a6fc8f",
-        "sqlquery": "prepared",
-        "sql": "INSERT INTO radar_oc_payload (end_time, start_time, delta_time_msec, dir, frames, max_mph, min_mph, max_mag, avg_mag, frames_per_mph, length_ft, radarName, deployment_id)\nVALUES ($end_time, $start_time, $delta_time_msec, $dir, $frames, $max_mph, $min_mph, $max_mag, $avg_mag, $frames_per_mph, $length_ft, $radarName, $deployment_id);",
-        "name": "",
-        "x": 1280,
-        "y": 1940,
-        "wires": [
-            []
-        ]
-    },
-    {
-        "id": "edcc237df962c31a",
-        "type": "function",
-        "z": "1c71c8f26f5b7b19",
-        "g": "da1c8c74261a93a4",
-        "name": "write params for radar_oc_payload insert",
-        "func": "\nconst obj = msg.payload;\n\nconst keyedObj = Object.keys(obj).reduce((acc, key) => {\n    acc[`$${key}`] = obj[key];\n    return acc;\n}, {});\n\nmsg.params = keyedObj;\n\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 620,
-        "y": 1940,
-        "wires": [
-            [
-                "6e30f911242c5595"
             ]
         ]
     },
@@ -3229,7 +3128,7 @@
         "sql": "",
         "name": "",
         "x": 1280,
-        "y": 1420,
+        "y": 1680,
         "wires": [
             [
                 "cdc947bb9cd47c63"
@@ -3249,7 +3148,7 @@
         "onceDelay": 0.1,
         "topic": "",
         "x": 550,
-        "y": 1420,
+        "y": 1680,
         "wires": [
             [
                 "a18940845d6c5a2e"
@@ -3269,7 +3168,7 @@
         "onceDelay": 0.1,
         "topic": "",
         "x": 540,
-        "y": 1460,
+        "y": 1720,
         "wires": [
             [
                 "303ea9d25d718231"
@@ -3291,7 +3190,7 @@
         "statusVal": "",
         "statusType": "auto",
         "x": 1400,
-        "y": 1460,
+        "y": 1720,
         "wires": []
     },
     {
@@ -3304,7 +3203,7 @@
         "sql": "INSERT INTO radar_raw_speed_magnitude_single (time, unit, magnitude, speed, radarName, deployment_id) \nVALUES ($time, $unit, $magnitude, $speed, $radarName, $deployment_id);",
         "name": "",
         "x": 1280,
-        "y": 1600,
+        "y": 1860,
         "wires": [
             []
         ]
@@ -3323,7 +3222,7 @@
         "finalize": "",
         "libs": [],
         "x": 740,
-        "y": 1600,
+        "y": 1860,
         "wires": [
             [
                 "252e2f5b95aeb8da"
@@ -3355,21 +3254,7 @@
             "fee85b1886270ac6"
         ],
         "x": 475,
-        "y": 580,
-        "wires": []
-    },
-    {
-        "id": "59a9c9a7ba535641",
-        "type": "link out",
-        "z": "1c71c8f26f5b7b19",
-        "g": "da1c8c74261a93a4",
-        "name": "radar_oc_payload link out",
-        "mode": "link",
-        "links": [
-            "e05e91362c933e94"
-        ],
-        "x": 475,
-        "y": 1780,
+        "y": 820,
         "wires": []
     },
     {
@@ -3383,7 +3268,7 @@
             "0124afc74d86b533"
         ],
         "x": 485,
-        "y": 1640,
+        "y": 1900,
         "wires": []
     },
     {
@@ -3397,7 +3282,7 @@
             "fc5e2cd719fa680a"
         ],
         "x": 475,
-        "y": 1160,
+        "y": 1420,
         "wires": []
     },
     {
@@ -3411,7 +3296,7 @@
             "087588593911f398"
         ],
         "x": 475,
-        "y": 880,
+        "y": 1120,
         "wires": []
     },
     {
@@ -3428,7 +3313,7 @@
         "finalize": "",
         "libs": [],
         "x": 640,
-        "y": 1540,
+        "y": 1800,
         "wires": [
             [
                 "83065a55697cc160",
@@ -3462,7 +3347,7 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 1500,
+        "x": 1540,
         "y": 120,
         "wires": [
             [
@@ -3476,7 +3361,7 @@
         "z": "1c71c8f26f5b7b19",
         "name": "send to RADAR_01",
         "serial": "d4f8fcd8e734b75f",
-        "x": 850,
+        "x": 890,
         "y": 200,
         "wires": []
     },
@@ -3486,7 +3371,7 @@
         "z": "1c71c8f26f5b7b19",
         "name": "send to RADAR_02",
         "serial": "8fcc984759daf862",
-        "x": 850,
+        "x": 890,
         "y": 280,
         "wires": []
     },
@@ -3496,7 +3381,7 @@
         "z": "1c71c8f26f5b7b19",
         "name": "send to RADAR_03",
         "serial": "9436149d39191450",
-        "x": 850,
+        "x": 890,
         "y": 360,
         "wires": []
     },
@@ -3506,7 +3391,7 @@
         "z": "1c71c8f26f5b7b19",
         "name": "receive RADAR_01",
         "serial": "d4f8fcd8e734b75f",
-        "x": 1050,
+        "x": 1090,
         "y": 200,
         "wires": [
             [
@@ -3522,7 +3407,7 @@
         "property": "payload",
         "action": "",
         "pretty": false,
-        "x": 1350,
+        "x": 1390,
         "y": 200,
         "wires": [
             [
@@ -3556,7 +3441,7 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 1500,
+        "x": 1540,
         "y": 200,
         "wires": [
             [
@@ -3570,7 +3455,7 @@
         "z": "1c71c8f26f5b7b19",
         "name": "receive RADAR_02",
         "serial": "8fcc984759daf862",
-        "x": 1050,
+        "x": 1090,
         "y": 280,
         "wires": [
             [
@@ -3586,7 +3471,7 @@
         "property": "payload",
         "action": "",
         "pretty": false,
-        "x": 1350,
+        "x": 1390,
         "y": 280,
         "wires": [
             [
@@ -3620,7 +3505,7 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 1500,
+        "x": 1540,
         "y": 280,
         "wires": [
             [
@@ -3634,7 +3519,7 @@
         "z": "1c71c8f26f5b7b19",
         "name": "receive RADAR_03",
         "serial": "9436149d39191450",
-        "x": 1050,
+        "x": 1090,
         "y": 360,
         "wires": [
             [
@@ -3650,7 +3535,7 @@
         "property": "payload",
         "action": "",
         "pretty": false,
-        "x": 1350,
+        "x": 1390,
         "y": 360,
         "wires": [
             [
@@ -3684,7 +3569,7 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 1500,
+        "x": 1540,
         "y": 360,
         "wires": [
             [
@@ -3707,7 +3592,7 @@
         "checkall": "true",
         "repair": false,
         "outputs": 1,
-        "x": 1220,
+        "x": 1260,
         "y": 120,
         "wires": [
             [
@@ -3730,7 +3615,7 @@
         "checkall": "true",
         "repair": false,
         "outputs": 1,
-        "x": 1220,
+        "x": 1260,
         "y": 200,
         "wires": [
             [
@@ -3753,7 +3638,7 @@
         "checkall": "true",
         "repair": false,
         "outputs": 1,
-        "x": 1220,
+        "x": 1260,
         "y": 280,
         "wires": [
             [
@@ -3776,7 +3661,7 @@
         "checkall": "true",
         "repair": false,
         "outputs": 1,
-        "x": 1220,
+        "x": 1260,
         "y": 360,
         "wires": [
             [
@@ -3802,7 +3687,7 @@
         "checkall": "true",
         "repair": false,
         "outputs": 2,
-        "x": 560,
+        "x": 660,
         "y": 120,
         "wires": [
             [
@@ -3831,7 +3716,7 @@
         "checkall": "true",
         "repair": false,
         "outputs": 2,
-        "x": 560,
+        "x": 660,
         "y": 200,
         "wires": [
             [
@@ -3860,7 +3745,7 @@
         "checkall": "true",
         "repair": false,
         "outputs": 2,
-        "x": 560,
+        "x": 660,
         "y": 280,
         "wires": [
             [
@@ -3889,7 +3774,7 @@
         "checkall": "true",
         "repair": false,
         "outputs": 2,
-        "x": 560,
+        "x": 660,
         "y": 360,
         "wires": [
             [
@@ -3913,7 +3798,7 @@
         "onceDelay": 0.1,
         "topic": "",
         "x": 540,
-        "y": 700,
+        "y": 940,
         "wires": [
             [
                 "dd88a80a3a79aa0b"
@@ -3933,7 +3818,7 @@
         "onceDelay": 0.1,
         "topic": "",
         "x": 540,
-        "y": 1000,
+        "y": 1240,
         "wires": [
             [
                 "463b64006f270db3"
@@ -3953,7 +3838,7 @@
         "onceDelay": 0.1,
         "topic": "",
         "x": 540,
-        "y": 1280,
+        "y": 1540,
         "wires": [
             [
                 "d18b637f01871f23"
@@ -3973,30 +3858,10 @@
         "onceDelay": 0.1,
         "topic": "",
         "x": 540,
-        "y": 1500,
+        "y": 1760,
         "wires": [
             [
                 "4f072d31286f7667"
-            ]
-        ]
-    },
-    {
-        "id": "fb89305143faab57",
-        "type": "inject",
-        "z": "1c71c8f26f5b7b19",
-        "g": "da1c8c74261a93a4",
-        "name": "inject manually",
-        "props": [],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "",
-        "x": 540,
-        "y": 1900,
-        "wires": [
-            [
-                "45cdb2f02dfb2009"
             ]
         ]
     },
@@ -4019,7 +3884,7 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 590,
+        "x": 690,
         "y": 160,
         "wires": [
             [
@@ -4046,7 +3911,7 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 590,
+        "x": 690,
         "y": 240,
         "wires": [
             [
@@ -4073,7 +3938,7 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 590,
+        "x": 690,
         "y": 320,
         "wires": [
             [
@@ -4100,7 +3965,7 @@
         "from": "",
         "to": "",
         "reg": false,
-        "x": 590,
+        "x": 690,
         "y": 400,
         "wires": [
             [
@@ -4121,7 +3986,7 @@
         "template": "CREATE TABLE IF NOT EXISTS radar_dov (\n    time REAL, \n    unit TEXT, \n    direction TEXT, \n    velocity REAL, \n    radarName TEXT, \n    deployment_id TEXT\n    );",
         "output": "str",
         "x": 940,
-        "y": 620,
+        "y": 860,
         "wires": [
             [
                 "ca182659939320ce"
@@ -4141,7 +4006,7 @@
         "template": "SELECT * \nFROM radar_dov \nORDER BY time DESC \nLIMIT 5;",
         "output": "str",
         "x": 900,
-        "y": 660,
+        "y": 900,
         "wires": [
             [
                 "ca182659939320ce"
@@ -4161,7 +4026,7 @@
         "template": "",
         "output": "str",
         "x": 940,
-        "y": 700,
+        "y": 940,
         "wires": [
             [
                 "ca182659939320ce"
@@ -4181,7 +4046,7 @@
         "template": "CREATE TABLE IF NOT EXISTS radar_timed_speed_counts (\n    time REAL, \n    direction TEXT, \n    units TEXT, \n    count INTEGER, \n    average REAL, \n    radarName TEXT, \n    deployment_id TEXT\n);",
         "output": "str",
         "x": 890,
-        "y": 920,
+        "y": 1160,
         "wires": [
             [
                 "50dcead7cf35b74f"
@@ -4201,7 +4066,7 @@
         "template": "SELECT * \nFROM radar_timed_speed_counts \nORDER BY time DESC \nLIMIT 5;",
         "output": "str",
         "x": 850,
-        "y": 960,
+        "y": 1200,
         "wires": [
             [
                 "50dcead7cf35b74f"
@@ -4221,7 +4086,7 @@
         "template": "",
         "output": "str",
         "x": 900,
-        "y": 1000,
+        "y": 1240,
         "wires": [
             [
                 "50dcead7cf35b74f"
@@ -4241,7 +4106,7 @@
         "template": "CREATE TABLE IF NOT EXISTS radar_raw_speed_magnitude (\n    time REAL, \n    unit TEXT, \n    magnitude TEXT, \n    speed TEXT, \n    radarName TEXT, \n    deployment_id TEXT\n    );",
         "output": "str",
         "x": 880,
-        "y": 1200,
+        "y": 1460,
         "wires": [
             [
                 "a3dddf65b65ca371"
@@ -4261,7 +4126,7 @@
         "template": "",
         "output": "str",
         "x": 880,
-        "y": 1280,
+        "y": 1540,
         "wires": [
             [
                 "a3dddf65b65ca371"
@@ -4281,7 +4146,7 @@
         "template": "SELECT * \nFROM radar_raw_speed_magnitude \nORDER BY time DESC \nLIMIT 5;",
         "output": "str",
         "x": 840,
-        "y": 1240,
+        "y": 1500,
         "wires": [
             [
                 "a3dddf65b65ca371"
@@ -4301,7 +4166,7 @@
         "template": "",
         "output": "str",
         "x": 900,
-        "y": 1500,
+        "y": 1760,
         "wires": [
             [
                 "a3924864154eaefb"
@@ -4321,7 +4186,7 @@
         "template": "SELECT * \nFROM radar_raw_speed_magnitude_single \nORDER BY time DESC \nLIMIT 5;",
         "output": "str",
         "x": 860,
-        "y": 1460,
+        "y": 1720,
         "wires": [
             [
                 "a3924864154eaefb"
@@ -4341,10 +4206,173 @@
         "template": "CREATE TABLE IF NOT EXISTS radar_raw_speed_magnitude_single (\n    time REAL, \n    unit TEXT, \n    magnitude REAL, \n    speed REAL, \n    radarName TEXT, \n    deployment_id TEXT\n    );",
         "output": "str",
         "x": 890,
-        "y": 1420,
+        "y": 1680,
         "wires": [
             [
                 "a3924864154eaefb"
+            ]
+        ]
+    },
+    {
+        "id": "ca4ed8761a4ded27",
+        "type": "debug",
+        "z": "1c71c8f26f5b7b19",
+        "g": "da1c8c74261a93a4",
+        "name": "radar_oc_payload",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "payload",
+        "targetType": "msg",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 1230,
+        "y": 2100,
+        "wires": []
+    },
+    {
+        "id": "fbde266909bc0ca7",
+        "type": "inject",
+        "z": "1c71c8f26f5b7b19",
+        "g": "da1c8c74261a93a4",
+        "name": "inject after 0.1 sec",
+        "props": [],
+        "repeat": "",
+        "crontab": "",
+        "once": true,
+        "onceDelay": 0.1,
+        "topic": "",
+        "x": 550,
+        "y": 2200,
+        "wires": [
+            [
+                "1bdec3d0b912f792"
+            ]
+        ]
+    },
+    {
+        "id": "09369d5e4816364f",
+        "type": "sqlite",
+        "z": "1c71c8f26f5b7b19",
+        "g": "da1c8c74261a93a4",
+        "mydb": "2f60c1ab30a6fc8f",
+        "sqlquery": "msg.topic",
+        "sql": "INSERT INTO radar_oc_payload (end_time, start_time, delta_time_msec, dir, frames, max_mph, min_mph, max_mag, avg_mag, frames_per_mph, length_ft)\nVALUES ($end_time, $start_time, $delta_time_msec, $dir, $frames, $max_mph, $min_mph, $max_mag, $avg_mag, $frames_per_mph, $length_ft);",
+        "name": "",
+        "x": 1280,
+        "y": 2200,
+        "wires": [
+            [
+                "45801cdcc5094abc"
+            ]
+        ]
+    },
+    {
+        "id": "4ffa919935494b14",
+        "type": "inject",
+        "z": "1c71c8f26f5b7b19",
+        "g": "da1c8c74261a93a4",
+        "name": "inject manually",
+        "props": [],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "x": 540,
+        "y": 2240,
+        "wires": [
+            [
+                "07d558da50af5ae4"
+            ]
+        ]
+    },
+    {
+        "id": "45801cdcc5094abc",
+        "type": "debug",
+        "z": "1c71c8f26f5b7b19",
+        "g": "da1c8c74261a93a4",
+        "name": "debug: last 5 rows radar_oc_payload",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "payload",
+        "targetType": "msg",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 1350,
+        "y": 2240,
+        "wires": []
+    },
+    {
+        "id": "6e30f911242c5595",
+        "type": "sqlite",
+        "z": "1c71c8f26f5b7b19",
+        "g": "da1c8c74261a93a4",
+        "mydb": "2f60c1ab30a6fc8f",
+        "sqlquery": "prepared",
+        "sql": "INSERT INTO radar_oc_payload (end_time, start_time, delta_time_msec, dir, frames, max_mph, min_mph, max_mag, avg_mag, frames_per_mph, length_ft, radarName, deployment_id)\nVALUES ($end_time, $start_time, $delta_time_msec, $dir, $frames, $max_mph, $min_mph, $max_mag, $avg_mag, $frames_per_mph, $length_ft, $radarName, $deployment_id);",
+        "name": "",
+        "x": 1280,
+        "y": 2040,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "edcc237df962c31a",
+        "type": "function",
+        "z": "1c71c8f26f5b7b19",
+        "g": "da1c8c74261a93a4",
+        "name": "write params for radar_oc_payload insert",
+        "func": "\nconst obj = msg.payload;\n\nconst keyedObj = Object.keys(obj).reduce((acc, key) => {\n    acc[`$${key}`] = obj[key];\n    return acc;\n}, {});\n\nmsg.params = keyedObj;\n\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 1220,
+        "y": 2000,
+        "wires": [
+            [
+                "6e30f911242c5595"
+            ]
+        ]
+    },
+    {
+        "id": "59a9c9a7ba535641",
+        "type": "link out",
+        "z": "1c71c8f26f5b7b19",
+        "g": "da1c8c74261a93a4",
+        "name": "radar_oc_payload link out",
+        "mode": "link",
+        "links": [
+            "e05e91362c933e94"
+        ],
+        "x": 1155,
+        "y": 2140,
+        "wires": []
+    },
+    {
+        "id": "fb89305143faab57",
+        "type": "inject",
+        "z": "1c71c8f26f5b7b19",
+        "g": "da1c8c74261a93a4",
+        "name": "inject manually",
+        "props": [],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "x": 540,
+        "y": 2280,
+        "wires": [
+            [
+                "45cdb2f02dfb2009"
             ]
         ]
     },
@@ -4361,7 +4389,7 @@
         "template": "",
         "output": "str",
         "x": 920,
-        "y": 1900,
+        "y": 2280,
         "wires": [
             [
                 "09369d5e4816364f"
@@ -4381,7 +4409,7 @@
         "template": "SELECT * \nFROM radar_oc_payload \nORDER BY end_time DESC \nLIMIT 5;",
         "output": "str",
         "x": 870,
-        "y": 1860,
+        "y": 2240,
         "wires": [
             [
                 "09369d5e4816364f"
@@ -4401,10 +4429,285 @@
         "template": "CREATE TABLE IF NOT EXISTS radar_oc_payload (\n    end_time REAL,\n    start_time REAL,\n    delta_time_msec INTEGER,\n    dir TEXT,\n    frames INTEGER,\n    max_mph REAL,\n    min_mph REAL,\n    max_mag REAL,\n    avg_mag REAL,\n    frames_per_mph REAL,\n    length_ft REAL,\n    radarName TEXT,\n    deployment_id TEXT\n    );",
         "output": "str",
         "x": 910,
-        "y": 1820,
+        "y": 2200,
         "wires": [
             [
                 "09369d5e4816364f"
+            ]
+        ]
+    },
+    {
+        "id": "9b57af73505cbb61",
+        "type": "function",
+        "z": "1c71c8f26f5b7b19",
+        "g": "da1c8c74261a93a4",
+        "name": "dir",
+        "func": "\n// end_time\n// start_time\n// delta_time_msec\n// __dirnameframes\n// max_mph\n// min_mph\n// max_mag\n// avg_mag\n// frames_per_mph\n// length_ft\n\n// radarName\n// deployment_id\n\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 490,
+        "y": 2000,
+        "wires": [
+            [
+                "14ec91d93285b0fb"
+            ]
+        ]
+    },
+    {
+        "id": "8e8edd5176fc9a71",
+        "type": "function",
+        "z": "1c71c8f26f5b7b19",
+        "g": "da1c8c74261a93a4",
+        "name": "classifier",
+        "func": "\n\n// classifier\n// start_time\n// max_speed_mph\n// min_speed_mph\n// max_magnitude\n// avg_magnitude\n// total_frames\n// frames_per_mph\n// length_ft\n// delta_time_msec\n\n// radarName\n// deployment_id\n\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 500,
+        "y": 2040,
+        "wires": [
+            [
+                "14ec91d93285b0fb"
+            ]
+        ]
+    },
+    {
+        "id": "c113788ccfa879b4",
+        "type": "join",
+        "z": "1c71c8f26f5b7b19",
+        "g": "805c5feafbb3610b",
+        "name": "",
+        "mode": "custom",
+        "build": "array",
+        "property": "payload",
+        "propertyType": "msg",
+        "key": "payload.radarName",
+        "joiner": "\\n",
+        "joinerType": "str",
+        "useparts": false,
+        "accumulate": false,
+        "timeout": "",
+        "count": "",
+        "reduceRight": false,
+        "reduceExp": "",
+        "reduceInit": "",
+        "reduceInitType": "",
+        "reduceFixup": "",
+        "x": 1930,
+        "y": 520,
+        "wires": [
+            [
+                "59d61701c38da429"
+            ]
+        ]
+    },
+    {
+        "id": "ae11d5c9948bf4e1",
+        "type": "change",
+        "z": "1c71c8f26f5b7b19",
+        "g": "805c5feafbb3610b",
+        "name": "set flow.radarCollectInfo = false, complete",
+        "rules": [
+            {
+                "t": "set",
+                "p": "radarCollectInfo",
+                "pt": "flow",
+                "to": "false",
+                "tot": "bool"
+            },
+            {
+                "t": "set",
+                "p": "complete",
+                "pt": "msg",
+                "to": "true",
+                "tot": "bool"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 960,
+        "y": 520,
+        "wires": [
+            [
+                "c113788ccfa879b4"
+            ]
+        ]
+    },
+    {
+        "id": "c4a024def66c8499",
+        "type": "change",
+        "z": "1c71c8f26f5b7b19",
+        "g": "805c5feafbb3610b",
+        "name": "set flow.radarCollectInfo = true, reset",
+        "rules": [
+            {
+                "t": "set",
+                "p": "radarCollectInfo",
+                "pt": "flow",
+                "to": "true",
+                "tot": "bool"
+            },
+            {
+                "t": "set",
+                "p": "reset",
+                "pt": "msg",
+                "to": "true",
+                "tot": "bool"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 290,
+        "y": 520,
+        "wires": [
+            [
+                "05a58d9ee463c696",
+                "c113788ccfa879b4"
+            ]
+        ]
+    },
+    {
+        "id": "0abd83310c35db9a",
+        "type": "switch",
+        "z": "1c71c8f26f5b7b19",
+        "g": "805c5feafbb3610b",
+        "name": "radarCollectInfo?",
+        "property": "radarCollectInfo",
+        "propertyType": "flow",
+        "rules": [
+            {
+                "t": "true"
+            }
+        ],
+        "checkall": "true",
+        "repair": false,
+        "outputs": 1,
+        "x": 1870,
+        "y": 480,
+        "wires": [
+            [
+                "c113788ccfa879b4"
+            ]
+        ]
+    },
+    {
+        "id": "59d61701c38da429",
+        "type": "function",
+        "z": "1c71c8f26f5b7b19",
+        "g": "805c5feafbb3610b",
+        "name": "create radarInfo payload",
+        "func": "//iterate through array\n// top-level key radarName, list of key:values\n\nconst result = msg.payload.reduce((acc, current) => {\n    const radarName = current.radarName;\n    delete current.radarName;\n    if (!acc[radarName]) {\n        acc[radarName] = current;\n    }\n    Object.assign(acc[radarName], current);\n    return acc;\n}, {});\n\nmsg.payload = result;\n\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 2110,
+        "y": 520,
+        "wires": [
+            [
+                "9e95f569494a21dc",
+                "50c56047654010ea"
+            ]
+        ]
+    },
+    {
+        "id": "9e95f569494a21dc",
+        "type": "change",
+        "z": "1c71c8f26f5b7b19",
+        "g": "805c5feafbb3610b",
+        "name": "",
+        "rules": [
+            {
+                "t": "set",
+                "p": "deviceAttributes.radarInfo",
+                "pt": "global",
+                "to": "payload",
+                "tot": "msg"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 2160,
+        "y": 560,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "50c56047654010ea",
+        "type": "link out",
+        "z": "1c71c8f26f5b7b19",
+        "g": "805c5feafbb3610b",
+        "name": "radarInfo link out",
+        "mode": "link",
+        "links": [
+            "66bace5cf805a4fb"
+        ],
+        "x": 2285,
+        "y": 520,
+        "wires": []
+    },
+    {
+        "id": "8c434de19f88fefc",
+        "type": "function",
+        "z": "1c71c8f26f5b7b19",
+        "g": "805c5feafbb3610b",
+        "name": "query each setting, and clear buffer, takes ~9.0-sec",
+        "func": "//send parameters to query, start with PI (idle) and end with PA (active)\n// required as a long string of these commands will sometimes not report back\nconst attribute_array = [\"PI\", \"?P\", \"?N\", \"?D\", \"?V\", \"?B\", \"??\", \"U?\", \"u?\", \"F?\", \"O?\", \"?F\", \"t?\", \"s?\", \"PA\"]\n\n// send each, clear it with ctr+c which is hex code 0x03\nconst hexCode = '\\x03'; // 0x03 hex code\nconst delay = 500; // 500 ms delay\nconst delay_short = 100;\n//500+100 = 600 ms per attribute\n\nnode.send({payload:hexCode});\nawait new Promise(resolve => setTimeout(resolve, delay_short));\n\nfor (let i = 0; i < attribute_array.length; i++) {\n    node.send({payload:attribute_array[i]});\n    await new Promise(resolve => setTimeout(resolve, delay));\n    node.send({payload:hexCode});\n    await new Promise(resolve => setTimeout(resolve, delay_short));\n}\n\nmsg.complete = true;\nnode.done();\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 330,
+        "y": 560,
+        "wires": [
+            [
+                "05a58d9ee463c696",
+                "7eb7b4b61d38b789"
+            ]
+        ]
+    },
+    {
+        "id": "7eb7b4b61d38b789",
+        "type": "switch",
+        "z": "1c71c8f26f5b7b19",
+        "g": "805c5feafbb3610b",
+        "name": "complete?",
+        "property": "complete",
+        "propertyType": "msg",
+        "rules": [
+            {
+                "t": "true"
+            }
+        ],
+        "checkall": "true",
+        "repair": false,
+        "outputs": 1,
+        "x": 690,
+        "y": 520,
+        "wires": [
+            [
+                "ae11d5c9948bf4e1"
             ]
         ]
     },
@@ -5099,7 +5402,7 @@
         "z": "b1fde507a4b80c79",
         "g": "672f3b07194c5dd5",
         "name": "debug: airquality query",
-        "active": true,
+        "active": false,
         "tosidebar": true,
         "console": false,
         "tostatus": false,
@@ -5658,7 +5961,7 @@
         "joinerType": "str",
         "useparts": false,
         "accumulate": false,
-        "timeout": "",
+        "timeout": "60",
         "count": "",
         "reduceRight": false,
         "reduceExp": "",
@@ -5669,7 +5972,6 @@
         "y": 360,
         "wires": [
             [
-                "1711871384d75e10",
                 "221ddfedf40c108f"
             ]
         ]
@@ -5830,7 +6132,7 @@
             "1ba33a74f2d3a680"
         ],
         "x": 175,
-        "y": 1300,
+        "y": 1340,
         "wires": [
             [
                 "9b0f7197fe82bbfa"
@@ -6112,7 +6414,7 @@
         "template": "{\n    \"deployments\": {\n        {{#payload.currentDeployment}}\n        \"{{sensorName}}\": {\n            \"sensorType\": \"{{sensorType}}\",\n            \"lat\": {{lat}},\n            \"lon\": {{lon}},\n            \"bearing\": \"{{bearing}}\",\n            \"id\": \"{{id}}\"\n        },\n        {{/payload.currentDeployment}}\n        \"deploymentTopLevel\": {\n            \"lat\": {{global.config.deployment.lat}},\n            \"lon\": {{global.config.deployment.lon}},\n            \"bearing\": \"{{global.config.deployment.bearing}}\"\n        }\n    }\n}",
         "output": "json",
         "x": 430,
-        "y": 1300,
+        "y": 1340,
         "wires": [
             [
                 "75f7976086cc9838"
@@ -6157,44 +6459,9 @@
         "y": 260,
         "wires": [
             [
-                "221ddfedf40c108f",
-                "6c582e93dfb3d6fa"
+                "221ddfedf40c108f"
             ]
         ]
-    },
-    {
-        "id": "1711871384d75e10",
-        "type": "debug",
-        "z": "f7932be9acc7391c",
-        "g": "1819134eccdf2660",
-        "name": "debug 4",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "false",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 900,
-        "y": 400,
-        "wires": []
-    },
-    {
-        "id": "6c582e93dfb3d6fa",
-        "type": "debug",
-        "z": "f7932be9acc7391c",
-        "g": "1819134eccdf2660",
-        "name": "debug 2",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "false",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 730,
-        "y": 260,
-        "wires": []
     },
     {
         "id": "e507fdc9cbf67095",
@@ -6265,6 +6532,44 @@
         "x": 320,
         "y": 1040,
         "wires": []
+    },
+    {
+        "id": "66bace5cf805a4fb",
+        "type": "link in",
+        "z": "f7932be9acc7391c",
+        "g": "f034ca2ecdf9a2f6",
+        "name": "radarInfo device attributes link in",
+        "links": [
+            "50c56047654010ea"
+        ],
+        "x": 175,
+        "y": 1240,
+        "wires": [
+            [
+                "22f397ac5c294b6e"
+            ]
+        ]
+    },
+    {
+        "id": "22f397ac5c294b6e",
+        "type": "function",
+        "z": "f7932be9acc7391c",
+        "g": "f034ca2ecdf9a2f6",
+        "name": "format radar info client-side attributes",
+        "func": "const newPayload = {\n    radarInfo: msg.payload,\n}\n\nmsg.payload = newPayload;\n\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 410,
+        "y": 1240,
+        "wires": [
+            [
+                "75f7976086cc9838"
+            ]
+        ]
     },
     {
         "id": "3985037239b671c5",

--- a/node-red-project/flows.json
+++ b/node-red-project/flows.json
@@ -87,8 +87,8 @@
             "ec7a0e0b1c62e91d"
         ],
         "x": 14,
-        "y": 459,
-        "w": 1372,
+        "y": 559,
+        "w": 1172,
         "h": 122
     },
     {
@@ -106,7 +106,7 @@
             "eb140f61419c6a08"
         ],
         "x": 14,
-        "y": 319,
+        "y": 419,
         "w": 1092,
         "h": 122
     },
@@ -126,8 +126,8 @@
             "4f84bcb60e4be762"
         ],
         "x": 14,
-        "y": 599,
-        "w": 1452,
+        "y": 699,
+        "w": 1212,
         "h": 122
     },
     {
@@ -149,63 +149,9 @@
             "7db4b197df9eb075"
         ],
         "x": 14,
-        "y": 739,
-        "w": 1532,
+        "y": 839,
+        "w": 1372,
         "h": 348
-    },
-    {
-        "id": "9b9e4fc50b744fc3",
-        "type": "group",
-        "z": "28627559bebdc324",
-        "g": "91096cd6c9c741e2",
-        "name": "last N events, radar",
-        "style": {
-            "label": true
-        },
-        "nodes": [
-            "d66541089b01306e",
-            "2e680914d7da5c94",
-            "c788d632f5e93a73",
-            "e5391514131a2b5a",
-            "5ec2d3ba52f944f5",
-            "c36c71706e494b5e",
-            "82bc0c11adb825f8",
-            "736d1e21a49f446b",
-            "5b307e65106f3540",
-            "4c087723a1d698e9",
-            "0f65ceafe3f7c069",
-            "f5d2d92d50d18ce2",
-            "c2270f3050bf35ab"
-        ],
-        "x": 194,
-        "y": 1279,
-        "w": 1292,
-        "h": 362
-    },
-    {
-        "id": "453513c49e4b1b60",
-        "type": "group",
-        "z": "28627559bebdc324",
-        "g": "91096cd6c9c741e2",
-        "name": "cumulative events today by object",
-        "style": {
-            "label": true
-        },
-        "nodes": [
-            "6d738ed81fefbedc",
-            "d856c68660eb2202",
-            "f57e08e6fb9c0d09",
-            "d23be15251ed6d73",
-            "4760bed60a7f392a",
-            "170ddffb726db9e0",
-            "befe91e6862c72db",
-            "13a061996f9322f3",
-            "98571c77b9801a83"
-        ],
-        "x": 194,
-        "y": 1659,
-        "w": 1592,
-        "h": 182
     },
     {
         "id": "1bd1f21fa0390c69",
@@ -223,8 +169,8 @@
             "6d81c8e3c89b68f6"
         ],
         "x": 14,
-        "y": 1099,
-        "w": 1492,
+        "y": 1199,
+        "w": 1292,
         "h": 122
     },
     {
@@ -859,7 +805,7 @@
         "id": "2df66c6bc991dbf4",
         "type": "group",
         "z": "28627559bebdc324",
-        "name": "camera selection",
+        "name": "sensor selection",
         "style": {
             "label": true
         },
@@ -873,11 +819,115 @@
             "f50a7968e032532a",
             "af02df2daa211e5b",
             "1feaed96b954867a",
-            "946c6bc353743bc4"
+            "946c6bc353743bc4",
+            "04c77d4233fbffd3"
         ],
         "x": 14,
         "y": 79,
-        "w": 1232,
+        "w": 1332,
+        "h": 202
+    },
+    {
+        "id": "7c19b3698bb02613",
+        "type": "group",
+        "z": "28627559bebdc324",
+        "name": "airquality_monitor",
+        "style": {
+            "label": true
+        },
+        "nodes": [
+            "a3672e4c4c84d721",
+            "e5ed08571761bd2c",
+            "441e03047af79373",
+            "9d1978d68c96feb9",
+            "2227d1c8d929c91d",
+            "f920233df1bbb23f",
+            "149757a20cc50973",
+            "b8342af470189c50",
+            "95871652f30bc9ce",
+            "8a82204bdfcdddb9",
+            "7d5875326501443c",
+            "d16177f416c9a0ef",
+            "34361a18f847df07",
+            "c1adf5e2bd669713",
+            "c13f03809fbd9809"
+        ],
+        "x": 14,
+        "y": 1999,
+        "w": 1278,
+        "h": 408
+    },
+    {
+        "id": "91096cd6c9c741e2",
+        "type": "group",
+        "z": "28627559bebdc324",
+        "name": "event-based ui",
+        "style": {
+            "label": true
+        },
+        "nodes": [
+            "c249329109ac17d5",
+            "9b9e4fc50b744fc3",
+            "453513c49e4b1b60",
+            "ca3c18fa88ded42a"
+        ],
+        "x": 94,
+        "y": 1353,
+        "w": 1398,
+        "h": 634
+    },
+    {
+        "id": "9b9e4fc50b744fc3",
+        "type": "group",
+        "z": "28627559bebdc324",
+        "g": "91096cd6c9c741e2",
+        "name": "last N events, radar",
+        "style": {
+            "label": true
+        },
+        "nodes": [
+            "d66541089b01306e",
+            "2e680914d7da5c94",
+            "c788d632f5e93a73",
+            "e5391514131a2b5a",
+            "5ec2d3ba52f944f5",
+            "c36c71706e494b5e",
+            "82bc0c11adb825f8",
+            "736d1e21a49f446b",
+            "5b307e65106f3540",
+            "4c087723a1d698e9",
+            "0f65ceafe3f7c069",
+            "f5d2d92d50d18ce2",
+            "c2270f3050bf35ab"
+        ],
+        "x": 194,
+        "y": 1379,
+        "w": 1252,
+        "h": 362
+    },
+    {
+        "id": "453513c49e4b1b60",
+        "type": "group",
+        "z": "28627559bebdc324",
+        "g": "91096cd6c9c741e2",
+        "name": "cumulative events today by object",
+        "style": {
+            "label": true
+        },
+        "nodes": [
+            "6d738ed81fefbedc",
+            "d856c68660eb2202",
+            "f57e08e6fb9c0d09",
+            "d23be15251ed6d73",
+            "4760bed60a7f392a",
+            "170ddffb726db9e0",
+            "befe91e6862c72db",
+            "13a061996f9322f3",
+            "98571c77b9801a83"
+        ],
+        "x": 194,
+        "y": 1759,
+        "w": 1272,
         "h": 202
     },
     {
@@ -984,28 +1034,8 @@
             "57fa6ca2b7d290e3"
         ],
         "x": 334,
-        "y": 939,
-        "w": 1152,
-        "h": 122
-    },
-    {
-        "id": "f5d2d92d50d18ce2",
-        "type": "group",
-        "z": "28627559bebdc324",
-        "g": "9b9e4fc50b744fc3",
-        "name": "frigate event api for thumbnail",
-        "style": {
-            "label": true
-        },
-        "nodes": [
-            "09f99c931e5535bf",
-            "08121a31488784bc",
-            "9226865e3385eb56",
-            "aa0afb5180297e2b"
-        ],
-        "x": 594,
-        "y": 1319,
-        "w": 612,
+        "y": 1039,
+        "w": 972,
         "h": 122
     },
     {
@@ -1237,6 +1267,46 @@
         "h": 122
     },
     {
+        "id": "d16177f416c9a0ef",
+        "type": "group",
+        "z": "28627559bebdc324",
+        "g": "7c19b3698bb02613",
+        "name": "event; object counts/speeds individually last 24-hours",
+        "style": {
+            "label": true
+        },
+        "nodes": [
+            "12df4fdffa628238",
+            "6a292f3905fe5405",
+            "76e813b1b7a4b63e",
+            "5cf61952cb6823de"
+        ],
+        "x": 394,
+        "y": 2259,
+        "w": 872,
+        "h": 122
+    },
+    {
+        "id": "f5d2d92d50d18ce2",
+        "type": "group",
+        "z": "28627559bebdc324",
+        "g": "9b9e4fc50b744fc3",
+        "name": "frigate event api for thumbnail",
+        "style": {
+            "label": true
+        },
+        "nodes": [
+            "09f99c931e5535bf",
+            "08121a31488784bc",
+            "9226865e3385eb56",
+            "aa0afb5180297e2b"
+        ],
+        "x": 594,
+        "y": 1419,
+        "w": 612,
+        "h": 122
+    },
+    {
         "id": "a2b2e69319628779",
         "type": "group",
         "z": "3dae026ab340962a",
@@ -1259,83 +1329,6 @@
         "y": 859,
         "w": 932,
         "h": 162
-    },
-    {
-        "id": "7c19b3698bb02613",
-        "type": "group",
-        "z": "28627559bebdc324",
-        "name": "aq; gas",
-        "style": {
-            "label": true
-        },
-        "nodes": [
-            "a3672e4c4c84d721",
-            "e5ed08571761bd2c",
-            "441e03047af79373",
-            "9d1978d68c96feb9",
-            "2227d1c8d929c91d",
-            "9573839489d3567f"
-        ],
-        "x": 14,
-        "y": 1899,
-        "w": 1312,
-        "h": 127
-    },
-    {
-        "id": "91096cd6c9c741e2",
-        "type": "group",
-        "z": "28627559bebdc324",
-        "name": "event-based ui",
-        "style": {
-            "label": true
-        },
-        "nodes": [
-            "c249329109ac17d5",
-            "9b9e4fc50b744fc3",
-            "453513c49e4b1b60"
-        ],
-        "x": 94,
-        "y": 1253,
-        "w": 1718,
-        "h": 614
-    },
-    {
-        "id": "83eedcc325ccc21d",
-        "type": "group",
-        "z": "28627559bebdc324",
-        "name": "aq, particulate matter (PM)",
-        "style": {
-            "label": true
-        },
-        "nodes": [
-            "bd1b7f16edeb4ed3",
-            "bf4e488edf28469b",
-            "0d4ff80748d1c876",
-            "56bbbcd2844a4c13"
-        ],
-        "x": 234,
-        "y": 2179,
-        "w": 1052,
-        "h": 122
-    },
-    {
-        "id": "d16177f416c9a0ef",
-        "type": "group",
-        "z": "28627559bebdc324",
-        "name": "event; object counts/speeds individually last 24-hours",
-        "style": {
-            "label": true
-        },
-        "nodes": [
-            "12df4fdffa628238",
-            "6a292f3905fe5405",
-            "76e813b1b7a4b63e",
-            "5cf61952cb6823de"
-        ],
-        "x": 234,
-        "y": 2039,
-        "w": 1092,
-        "h": 122
     },
     {
         "id": "05a58d9ee463c696",
@@ -1483,16 +1476,64 @@
         ]
     },
     {
-        "id": "9573839489d3567f",
+        "id": "04c77d4233fbffd3",
+        "type": "junction",
+        "z": "28627559bebdc324",
+        "g": "2df66c6bc991dbf4",
+        "x": 1320,
+        "y": 240,
+        "wires": [
+            [
+                "a20d5f859bf5c14d"
+            ]
+        ]
+    },
+    {
+        "id": "ca3c18fa88ded42a",
+        "type": "junction",
+        "z": "28627559bebdc324",
+        "g": "91096cd6c9c741e2",
+        "x": 180,
+        "y": 1420,
+        "wires": [
+            [
+                "82bc0c11adb825f8",
+                "f57e08e6fb9c0d09",
+                "736d1e21a49f446b",
+                "5ec2d3ba52f944f5"
+            ]
+        ]
+    },
+    {
+        "id": "34361a18f847df07",
         "type": "junction",
         "z": "28627559bebdc324",
         "g": "7c19b3698bb02613",
-        "x": 140,
-        "y": 2000,
+        "x": 360,
+        "y": 2040,
         "wires": [
             [
-                "bf4e488edf28469b",
-                "12df4fdffa628238"
+                "12df4fdffa628238",
+                "441e03047af79373"
+            ]
+        ]
+    },
+    {
+        "id": "a20d5f859bf5c14d",
+        "type": "junction",
+        "z": "28627559bebdc324",
+        "x": 100,
+        "y": 360,
+        "wires": [
+            [
+                "34361a18f847df07",
+                "158e6edae533bfdc",
+                "79900a566af02159",
+                "928b71f25ce6e7b6",
+                "5f3716d2176c3ab4",
+                "b241a0ef89fd7ce4",
+                "584504e6c8935eaf",
+                "f57e08e6fb9c0d09"
             ]
         ]
     },
@@ -1543,7 +1584,7 @@
         "tab": "665d947f9a312a33",
         "order": 2,
         "disp": true,
-        "width": "12",
+        "width": 8,
         "collapse": false,
         "className": ""
     },
@@ -1852,7 +1893,7 @@
         "tab": "665d947f9a312a33",
         "order": 1,
         "disp": true,
-        "width": 3,
+        "width": 6,
         "collapse": false,
         "className": ""
     },
@@ -6513,7 +6554,7 @@
         "payload": "",
         "payloadType": "date",
         "x": 200,
-        "y": 640,
+        "y": 740,
         "wires": [
             [
                 "928b71f25ce6e7b6"
@@ -6528,8 +6569,8 @@
         "name": "frigate summary daily, objects",
         "group": "06dde4be9a9a6b27",
         "order": 4,
-        "width": 6,
-        "height": 7,
+        "width": 0,
+        "height": 0,
         "label": "frigate api/events/summary daily object count for the last 10-days",
         "chartType": "line",
         "legend": "true",
@@ -6560,7 +6601,7 @@
         "useDifferentColor": false,
         "className": "",
         "x": 950,
-        "y": 400,
+        "y": 500,
         "wires": [
             []
         ]
@@ -6583,7 +6624,7 @@
         "senderr": false,
         "headers": [],
         "x": 590,
-        "y": 360,
+        "y": 460,
         "wires": [
             [
                 "eb140f61419c6a08"
@@ -6604,7 +6645,7 @@
         "onceDelay": "5",
         "topic": "",
         "x": 230,
-        "y": 360,
+        "y": 460,
         "wires": [
             [
                 "b241a0ef89fd7ce4"
@@ -6625,7 +6666,7 @@
         "finalize": "",
         "libs": [],
         "x": 900,
-        "y": 360,
+        "y": 460,
         "wires": [
             [
                 "08d030ffc3fe6adb"
@@ -6655,7 +6696,7 @@
         "payload": "",
         "payloadType": "date",
         "x": 200,
-        "y": 500,
+        "y": 600,
         "wires": [
             [
                 "5f3716d2176c3ab4"
@@ -6670,8 +6711,8 @@
         "name": "events summary daily, objects",
         "group": "06dde4be9a9a6b27",
         "order": 5,
-        "width": 6,
-        "height": 7,
+        "width": 0,
+        "height": 0,
         "label": "events daily object count for the last 10-days",
         "chartType": "line",
         "legend": "true",
@@ -6701,8 +6742,8 @@
         "outputs": 1,
         "useDifferentColor": false,
         "className": "",
-        "x": 1230,
-        "y": 540,
+        "x": 1030,
+        "y": 640,
         "wires": [
             []
         ]
@@ -6717,13 +6758,10 @@
             "274f87c31437c2d7"
         ],
         "x": 135,
-        "y": 1320,
+        "y": 1420,
         "wires": [
             [
-                "5ec2d3ba52f944f5",
-                "82bc0c11adb825f8",
-                "736d1e21a49f446b",
-                "f57e08e6fb9c0d09"
+                "ca3c18fa88ded42a"
             ]
         ]
     },
@@ -6746,7 +6784,7 @@
         "repair": false,
         "outputs": 1,
         "x": 1020,
-        "y": 1520,
+        "y": 1620,
         "wires": [
             [
                 "c788d632f5e93a73"
@@ -6772,7 +6810,7 @@
         "repair": false,
         "outputs": 1,
         "x": 360,
-        "y": 1400,
+        "y": 1500,
         "wires": [
             [
                 "c2270f3050bf35ab"
@@ -6793,7 +6831,7 @@
         "finalize": "",
         "libs": [],
         "x": 1050,
-        "y": 1560,
+        "y": 1660,
         "wires": [
             [
                 "4c087723a1d698e9"
@@ -6814,7 +6852,7 @@
         "finalize": "",
         "libs": [],
         "x": 1030,
-        "y": 1480,
+        "y": 1580,
         "wires": [
             [
                 "c36c71706e494b5e"
@@ -6838,7 +6876,7 @@
         "repair": false,
         "outputs": 1,
         "x": 330,
-        "y": 1360,
+        "y": 1460,
         "wires": [
             [
                 "2e680914d7da5c94"
@@ -6853,16 +6891,16 @@
         "group": "06dde4be9a9a6b27",
         "name": "last N radar events",
         "order": 2,
-        "width": 0,
-        "height": 0,
+        "width": 8,
+        "height": 19,
         "format": "<p class=\"label nr-dashboard-chart-title nr-dashboard-chart-titlel\">last N zone_radar events for radar_camera</p>\n<table class=\"table\">\n    <tr ng-repeat=\"payload in msg.payload\">\n        <td><img src=\"data:image/jpg;base64, {{payload.thumbnail_base64jpg}}\" alt=\"thumbnail\" /></td>\n        <td>\n            id: {{payload.id}} <br /> \n            label: {{payload.label}} <br />\n            top_score: {{payload.top_score}} <br />\n            frame_time: {{payload.frame_time_datestring}} <br />\n            direction: {{payload.direction_calc}} <br />\n            speed: {{payload.speed_calc}}\n        </td>\n    </tr>\n</table>",
         "storeOutMessages": true,
         "fwdInMessages": true,
         "resendOnRefresh": true,
         "templateScope": "local",
         "className": "",
-        "x": 1310,
-        "y": 1480,
+        "x": 1270,
+        "y": 1580,
         "wires": [
             []
         ]
@@ -6882,7 +6920,7 @@
         "statusVal": "",
         "statusType": "auto",
         "x": 330,
-        "y": 1320,
+        "y": 1420,
         "wires": []
     },
     {
@@ -6956,8 +6994,8 @@
         "outputs": 1,
         "useDifferentColor": false,
         "className": "",
-        "x": 1280,
-        "y": 680,
+        "x": 1040,
+        "y": 780,
         "wires": [
             []
         ]
@@ -6985,7 +7023,7 @@
         "payload": "",
         "payloadType": "date",
         "x": 200,
-        "y": 780,
+        "y": 880,
         "wires": [
             [
                 "158e6edae533bfdc",
@@ -7007,7 +7045,7 @@
         "finalize": "",
         "libs": [],
         "x": 470,
-        "y": 1600,
+        "y": 1700,
         "wires": [
             [
                 "5b307e65106f3540"
@@ -7021,8 +7059,8 @@
         "g": "9b9e4fc50b744fc3",
         "group": "7866c2aa313ab8b9",
         "order": 6,
-        "width": 0,
-        "height": 0,
+        "width": 6,
+        "height": 7,
         "name": "",
         "label": "last N events, text output",
         "format": "{{msg.payload}}",
@@ -7032,8 +7070,8 @@
         "font": "Courier,monospace",
         "fontSize": "10",
         "color": "#000000",
-        "x": 1330,
-        "y": 1600,
+        "x": 1290,
+        "y": 1700,
         "wires": []
     },
     {
@@ -7044,16 +7082,16 @@
         "group": "06dde4be9a9a6b27",
         "name": "last N radar speeding events",
         "order": 3,
-        "width": 0,
-        "height": 0,
+        "width": 8,
+        "height": 12,
         "format": "<p class=\"label nr-dashboard-chart-title nr-dashboard-chart-titlel\">last N zone_radar speeding events for radar_camera (>20-mph)</p>\n<table class=\"table\">\n    <tr ng-repeat=\"payload in msg.payload\">\n        <td><img src=\"data:image/jpg;base64, {{payload.thumbnail_base64jpg}}\" alt=\"thumbnail\" /></td>\n        <td>\n            id: {{payload.id}} <br /> \n            label: {{payload.label}} <br />\n            top_score: {{payload.top_score}} <br />\n            frame_time: {{payload.frame_time_datestring}} <br />\n            direction: {{payload.direction_calc}} <br />\n            speed: {{payload.speed_calc}}\n        </td>\n    </tr>\n</table>",
         "storeOutMessages": true,
         "fwdInMessages": true,
         "resendOnRefresh": true,
         "templateScope": "local",
         "className": "",
-        "x": 1340,
-        "y": 1560,
+        "x": 1300,
+        "y": 1660,
         "wires": [
             []
         ]
@@ -7097,8 +7135,8 @@
         "outputs": 1,
         "useDifferentColor": false,
         "className": "",
-        "x": 1290,
-        "y": 1020,
+        "x": 1110,
+        "y": 1120,
         "wires": [
             []
         ]
@@ -7142,8 +7180,8 @@
         "outputs": 1,
         "useDifferentColor": false,
         "className": "",
-        "x": 1600,
-        "y": 1760,
+        "x": 1280,
+        "y": 1840,
         "wires": [
             []
         ]
@@ -7163,8 +7201,8 @@
         "correl": "",
         "expiry": "",
         "broker": "a5d65dd0e3566daa",
-        "x": 1500,
-        "y": 1800,
+        "x": 1360,
+        "y": 1920,
         "wires": []
     },
     {
@@ -7181,7 +7219,7 @@
         "finalize": "",
         "libs": [],
         "x": 740,
-        "y": 1480,
+        "y": 1580,
         "wires": [
             [
                 "e5391514131a2b5a",
@@ -7212,7 +7250,7 @@
         "payload": "",
         "payloadType": "date",
         "x": 200,
-        "y": 1140,
+        "y": 1240,
         "wires": [
             [
                 "584504e6c8935eaf"
@@ -7227,16 +7265,16 @@
         "group": "7866c2aa313ab8b9",
         "name": "car speed stats for today, since 0400",
         "order": 2,
-        "width": 0,
-        "height": 0,
+        "width": 6,
+        "height": 7,
         "format": "<p class=\"label nr-dashboard-chart-title nr-dashboard-chart-titlel\">car speed stats for today, since 0400</p>\n<table class=\"table\">\n    <tr ng-repeat=\"payload in msg.payload\">\n        <td ng-repeat =\"(key,value) in payload\">{{key}}: </td>\n        <td ng-repeat =\"(key,value) in payload\">{{value}}</td>\n    </tr>\n</table>",
         "storeOutMessages": true,
         "fwdInMessages": true,
         "resendOnRefresh": true,
         "templateScope": "local",
         "className": "",
-        "x": 1330,
-        "y": 1180,
+        "x": 1130,
+        "y": 1280,
         "wires": [
             []
         ]
@@ -7260,7 +7298,7 @@
         "repair": false,
         "outputs": 1,
         "x": 320,
-        "y": 1700,
+        "y": 1800,
         "wires": [
             [
                 "d23be15251ed6d73"
@@ -7288,7 +7326,7 @@
         "to": "",
         "reg": false,
         "x": 380,
-        "y": 1740,
+        "y": 1840,
         "wires": [
             [
                 "170ddffb726db9e0"
@@ -7308,7 +7346,7 @@
         "onceDelay": 0.1,
         "topic": "",
         "x": 430,
-        "y": 1800,
+        "y": 1900,
         "wires": [
             [
                 "170ddffb726db9e0"
@@ -7333,7 +7371,7 @@
         "senderr": false,
         "headers": [],
         "x": 740,
-        "y": 1360,
+        "y": 1460,
         "wires": [
             [
                 "9226865e3385eb56",
@@ -7362,7 +7400,7 @@
         "to": "",
         "reg": false,
         "x": 1050,
-        "y": 1400,
+        "y": 1500,
         "wires": [
             [
                 "0f65ceafe3f7c069"
@@ -7383,7 +7421,7 @@
         "pass": false,
         "outputs": 0,
         "x": 1000,
-        "y": 1360,
+        "y": 1460,
         "wires": []
     },
     {
@@ -7395,7 +7433,7 @@
         "action": "",
         "property": "payload",
         "x": 840,
-        "y": 1400,
+        "y": 1500,
         "wires": [
             [
                 "08121a31488784bc"
@@ -7423,7 +7461,7 @@
         "to": "",
         "reg": false,
         "x": 410,
-        "y": 1440,
+        "y": 1540,
         "wires": [
             [
                 "09f99c931e5535bf"
@@ -7435,7 +7473,7 @@
         "type": "function",
         "z": "28627559bebdc324",
         "g": "0a6e123f5e53c029",
-        "name": "query, daily summary last 10 days in zone_capture",
+        "name": "query events, daily summary last 10 days in zone_capture",
         "func": "//frame_time is already in seconds\n\nconst query = `\nSELECT\n    date(frame_time, 'unixepoch') as day,\n    label,\n    camera,\n    COUNT(*) as count\nFROM\n    events\nWHERE\n    frame_time > (unixepoch('now') - (86400 * 10))\n    AND camera = '${flow.get(\"camera_selection\")}'\n    AND entered_zones LIKE '%zone_capture%'\nGROUP BY\n    label, date(frame_time, 'unixepoch'), camera\nORDER BY\n    label, day, camera;\n`;\n\nmsg.topic = query;\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
@@ -7443,8 +7481,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 550,
-        "y": 500,
+        "x": 570,
+        "y": 600,
         "wires": [
             [
                 "bdb4b259d648b1f0"
@@ -7460,8 +7498,8 @@
         "sqlquery": "msg.topic",
         "sql": "",
         "name": "",
-        "x": 900,
-        "y": 500,
+        "x": 680,
+        "y": 640,
         "wires": [
             [
                 "ec7a0e0b1c62e91d"
@@ -7481,8 +7519,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 1190,
-        "y": 500,
+        "x": 990,
+        "y": 600,
         "wires": [
             [
                 "b65e1877b1e04881"
@@ -7494,7 +7532,7 @@
         "type": "function",
         "z": "28627559bebdc324",
         "g": "5173f4b3ac03407a",
-        "name": "query, 1-h counts last 24-h in zone_capture",
+        "name": "query events, 1-h counts last 24-h in zone_capture",
         "func": "//frame_time is already in seconds\n\nconst query = `\nSELECT\n    strftime('%FT%H:00:00.000Z', frame_time, 'unixepoch') as hour,\n    label,\n    camera,\n    COUNT(*) as count\nFROM\n    events\nWHERE\n    frame_time > (unixepoch('now') - (86400 * 1))\n    AND camera = '${flow.get(\"camera_selection\")}'\n    AND entered_zones LIKE '%zone_capture%'\nGROUP BY\n    label, strftime('%F %H', frame_time, 'unixepoch'), camera\nORDER BY\n    label, hour, camera;\n`;\n\nmsg.topic = query;\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
@@ -7502,8 +7540,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 530,
-        "y": 640,
+        "x": 550,
+        "y": 740,
         "wires": [
             [
                 "c03516d1eb65598d"
@@ -7519,8 +7557,8 @@
         "sqlquery": "msg.topic",
         "sql": "",
         "name": "",
-        "x": 940,
-        "y": 640,
+        "x": 640,
+        "y": 780,
         "wires": [
             [
                 "4f84bcb60e4be762"
@@ -7540,8 +7578,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 1230,
-        "y": 640,
+        "x": 990,
+        "y": 740,
         "wires": [
             [
                 "02469f2425072f7b"
@@ -7553,7 +7591,7 @@
         "type": "function",
         "z": "28627559bebdc324",
         "g": "0e1614cf2e5f9942",
-        "name": "query, 5-min event speed counts for last 1-h in zone_radar",
+        "name": "query events, 5-min event speed counts for last 1-h in zone_radar",
         "func": "//frame_time is already in seconds\n//frame_time as 5-minute intervals, rounded up\n\nconst query = `\nSELECT\n    strftime('%Y-%m-%d %H:%M:00', (frame_time + 299), 'unixepoch', '-' || ((frame_time + 299) % 300) || ' seconds', 'localtime') AS bin_time,\n    label,\n    camera,\n    COUNT(*) as count\nFROM\n    events\nWHERE\n    frame_time > (unixepoch('now') - (3600))\n    AND camera = '${flow.get(\"camera_selection\")}'\n    AND entered_zones LIKE '%zone_radar%'\nGROUP BY\n    label, strftime('%Y-%m-%d %H:%M:00', (frame_time + 299), 'unixepoch', '-' || ((frame_time + 299) % 300) || ' seconds', 'localtime'), camera\nORDER BY\n    label, bin_time, camera;\n`;\n\nmsg.topic = query;\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
@@ -7561,8 +7599,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 570,
-        "y": 980,
+        "x": 600,
+        "y": 1080,
         "wires": [
             [
                 "eff2193c8246a9d2"
@@ -7578,8 +7616,8 @@
         "sqlquery": "msg.topic",
         "sql": "",
         "name": "",
-        "x": 940,
-        "y": 980,
+        "x": 740,
+        "y": 1120,
         "wires": [
             [
                 "57fa6ca2b7d290e3"
@@ -7599,8 +7637,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 1230,
-        "y": 980,
+        "x": 1050,
+        "y": 1080,
         "wires": [
             [
                 "11fa2826769befc7"
@@ -7612,7 +7650,7 @@
         "type": "function",
         "z": "28627559bebdc324",
         "g": "453513c49e4b1b60",
-        "name": "create sqlite query, daily cumulative counts in zone_capture",
+        "name": "query events, daily cumulative counts in zone_capture",
         "func": "//frame_time is already in seconds\n\nconst query = `\nSELECT\n    label,\n    COUNT(*) as count\nFROM\n    events\nWHERE\n    frame_time >= unixepoch(strftime('%Y-%m-%dT04:00','now', 'localtime'),'utc')\n    AND camera = '${flow.get(\"camera_selection\")}'\n    AND entered_zones LIKE '%zone_capture%'\nGROUP BY \n    label\nORDER BY\n    label;\n`;\n\nmsg.topic = query;\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
@@ -7620,8 +7658,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 760,
-        "y": 1700,
+        "x": 740,
+        "y": 1800,
         "wires": [
             [
                 "befe91e6862c72db"
@@ -7637,8 +7675,8 @@
         "sqlquery": "msg.topic",
         "sql": "",
         "name": "",
-        "x": 1140,
-        "y": 1700,
+        "x": 860,
+        "y": 1840,
         "wires": [
             [
                 "13a061996f9322f3",
@@ -7660,7 +7698,7 @@
         "finalize": "",
         "libs": [],
         "x": 1230,
-        "y": 1760,
+        "y": 1800,
         "wires": [
             [
                 "6d738ed81fefbedc"
@@ -7681,7 +7719,7 @@
         "finalize": "",
         "libs": [],
         "x": 1240,
-        "y": 1800,
+        "y": 1880,
         "wires": [
             [
                 "d856c68660eb2202"
@@ -7693,7 +7731,7 @@
         "type": "function",
         "z": "28627559bebdc324",
         "g": "1bd1f21fa0390c69",
-        "name": "query, daily cum car counts in zone_radar with speed_calc",
+        "name": "query events, daily cum car counts in zone_radar with speed_calc",
         "func": "//frame_time is already in seconds\n//cars with speeds in zone_radar AND zone_capture since 0400 today\n\nconst query = `\nWITH results AS (\n  SELECT \n    COUNT(*) AS count,\n    AVG(ABS(speed_calc)) AS mean_speed,\n    MAX(CASE WHEN ntile = 5 THEN ABS(speed_calc) ELSE NULL END) AS p25_speed,\n    MAX(CASE WHEN ntile = 10 THEN ABS(speed_calc) ELSE NULL END) AS p50_speed,\n    MAX(CASE WHEN ntile = 15 THEN ABS(speed_calc) ELSE NULL END) AS p75_speed,\n    MAX(CASE WHEN ntile = 17 THEN ABS(speed_calc) ELSE NULL END) AS p85_speed,\n    MAX(ABS(speed_calc)) AS max_speed,\n    SUM(CASE WHEN ABS(speed_calc) > 25 THEN 1 ELSE 0 END) AS count_over_25,\n    JSON_GROUP_ARRAY(speed_calc) AS speeds\n  FROM \n    (SELECT \n       ABS(speed_calc) as speed_calc,\n       NTILE(20) OVER (ORDER BY ABS(speed_calc)) AS ntile\n     FROM \n       events\n     WHERE \n       frame_time >= unixepoch(strftime('%Y-%m-%dT04:00','now', 'localtime'),'utc') AND\n       label = 'car' AND\n       entered_zones LIKE '%zone_radar%' AND\n       entered_zones LIKE '%zone_capture%' AND\n       ABS(speed_calc) NOT NULL AND\n       camera = '${flow.get(\"camera_selection\")}'\n    )\n)\nSELECT \n  *, \n  p75_speed + 1.5 * (p75_speed - p25_speed) AS iqr_upper,\n  (SELECT COUNT(*) FROM json_each(results.speeds) WHERE json_each.value > p75_speed + 1.5 * (p75_speed - p25_speed)) AS iqr_upper_freq\nFROM \n  results;\n`;\n\nmsg.topic = query;\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
@@ -7701,8 +7739,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 590,
-        "y": 1140,
+        "x": 620,
+        "y": 1240,
         "wires": [
             [
                 "9cf49f0891d25df1"
@@ -7718,8 +7756,8 @@
         "sqlquery": "msg.topic",
         "sql": "",
         "name": "",
-        "x": 960,
-        "y": 1140,
+        "x": 760,
+        "y": 1280,
         "wires": [
             [
                 "6d81c8e3c89b68f6"
@@ -7739,8 +7777,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 1280,
-        "y": 1140,
+        "x": 1080,
+        "y": 1240,
         "wires": [
             [
                 "5417aae0d14fa661"
@@ -7756,8 +7794,8 @@
         "sqlquery": "msg.topic",
         "sql": "",
         "name": "",
-        "x": 840,
-        "y": 780,
+        "x": 620,
+        "y": 920,
         "wires": [
             [
                 "39d895a16ca6f6f1",
@@ -7779,7 +7817,7 @@
         "finalize": "",
         "libs": [],
         "x": 520,
-        "y": 780,
+        "y": 880,
         "wires": [
             [
                 "7cc031e5a7d773a4"
@@ -7799,8 +7837,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 1190,
-        "y": 780,
+        "x": 1030,
+        "y": 880,
         "wires": [
             [
                 "cbb3b02ca505a55b"
@@ -7820,8 +7858,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 1210,
-        "y": 860,
+        "x": 1050,
+        "y": 960,
         "wires": [
             [
                 "7db4b197df9eb075"
@@ -7867,8 +7905,8 @@
         "outputs": 1,
         "useDifferentColor": false,
         "className": "",
-        "x": 1250,
-        "y": 820,
+        "x": 1090,
+        "y": 920,
         "wires": [
             []
         ]
@@ -7912,8 +7950,8 @@
         "outputs": 1,
         "useDifferentColor": false,
         "className": "",
-        "x": 1280,
-        "y": 900,
+        "x": 1120,
+        "y": 1000,
         "wires": [
             []
         ]
@@ -7996,7 +8034,9 @@
         "x": 1110,
         "y": 120,
         "wires": [
-            []
+            [
+                "04c77d4233fbffd3"
+            ]
         ]
     },
     {
@@ -8022,7 +8062,9 @@
         "x": 1110,
         "y": 180,
         "wires": [
-            []
+            [
+                "04c77d4233fbffd3"
+            ]
         ]
     },
     {
@@ -8222,7 +8264,9 @@
         "x": 1100,
         "y": 240,
         "wires": [
-            []
+            [
+                "04c77d4233fbffd3"
+            ]
         ]
     },
     {
@@ -8248,11 +8292,10 @@
         "payload": "",
         "payloadType": "date",
         "x": 200,
-        "y": 1940,
+        "y": 2040,
         "wires": [
             [
-                "441e03047af79373",
-                "9573839489d3567f"
+                "34361a18f847df07"
             ]
         ]
     },
@@ -8295,8 +8338,8 @@
         "outputs": 1,
         "useDifferentColor": false,
         "className": "",
-        "x": 1200,
-        "y": 1980,
+        "x": 1120,
+        "y": 2040,
         "wires": [
             []
         ]
@@ -8306,8 +8349,8 @@
         "type": "function",
         "z": "28627559bebdc324",
         "g": "7c19b3698bb02613",
-        "name": "query, airquality for every entry",
-        "func": "//entryDateTime is already in seconds\n\nconst query = `\nSELECT\n    strftime('%Y-%m-%d %H:%M:00', datetime(entryDateTime, 'unixepoch', 'localtime'), '+0 minutes') AS datetime,\n    gas_red, \n    gas_oxi, \n    gas_nh3\nFROM\n    airquality\nWHERE\n    entryDateTime > (unixepoch('now') - (86400 * 1))\n    AND sensorName = '${flow.get(\"aq_selection\")}'\nORDER BY\n    entryDateTime;\n`;\n\nmsg.topic = query;\nreturn msg;",
+        "name": "query airquality, for every entry",
+        "func": "//entryDateTime is already in seconds\n\nconst query = `\nSELECT\n    strftime('%Y-%m-%d %H:%M:00', datetime(entryDateTime, 'unixepoch', 'localtime'), '+0 minutes') AS datetime,\n    gas_red, \n    gas_oxi, \n    gas_nh3,\n    pm01, \n    pm025, \n    pm10,\n    temp,\n    bar,\n    hum,\n    dew\nFROM\n    airquality\nWHERE\n    entryDateTime > (unixepoch('now') - (86400 * 1))\n    AND sensorName = '${flow.get(\"aq_selection\")}'\nORDER BY\n    entryDateTime;\n`;\n\nmsg.topic = query;\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
         "noerr": 0,
@@ -8315,7 +8358,7 @@
         "finalize": "",
         "libs": [],
         "x": 530,
-        "y": 1940,
+        "y": 2040,
         "wires": [
             [
                 "9d1978d68c96feb9"
@@ -8331,11 +8374,15 @@
         "sqlquery": "msg.topic",
         "sql": "",
         "name": "",
-        "x": 820,
-        "y": 1940,
+        "x": 560,
+        "y": 2080,
         "wires": [
             [
-                "2227d1c8d929c91d"
+                "2227d1c8d929c91d",
+                "149757a20cc50973",
+                "95871652f30bc9ce",
+                "7d5875326501443c",
+                "c13f03809fbd9809"
             ]
         ]
     },
@@ -8344,7 +8391,7 @@
         "type": "function",
         "z": "28627559bebdc324",
         "g": "7c19b3698bb02613",
-        "name": "structure daily summary payload",
+        "name": "structure payload, gas",
         "func": "//https://github.com/node-red/node-red-dashboard/blob/master/Charts.md\n//Array of Object with keys of series, data=x:ts,y:count, labels\n\nconst result = [{\n    \"series\": [\"gas_red\", \"gas_oxi\", \"gas_nh3\"],\n    \"data\": [\n        msg.payload.map(item => ({ \"x\": new Date(item.datetime), \"y\": item.gas_red })),\n        msg.payload.map(item => ({ \"x\": new Date(item.datetime), \"y\": item.gas_oxi })),\n        msg.payload.map(item => ({ \"x\": new Date(item.datetime), \"y\": item.gas_nh3 }))\n    ],\n    \"labels\": [\"\"]\n}];\n\nmsg.payload = result;\n\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
@@ -8352,115 +8399,11 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 1150,
-        "y": 1940,
+        "x": 860,
+        "y": 2040,
         "wires": [
             [
                 "e5ed08571761bd2c"
-            ]
-        ]
-    },
-    {
-        "id": "bd1b7f16edeb4ed3",
-        "type": "ui_chart",
-        "z": "28627559bebdc324",
-        "g": "83eedcc325ccc21d",
-        "name": "aq PM last 24-hours",
-        "group": "62cdf198fe42de7e",
-        "order": 3,
-        "width": 6,
-        "height": 7,
-        "label": "aq PM ug/m3, every 5-min (or based on settings) for last 24-hours",
-        "chartType": "line",
-        "legend": "true",
-        "xformat": "HH:mm",
-        "interpolate": "linear",
-        "nodata": "",
-        "dot": false,
-        "ymin": "",
-        "ymax": "",
-        "removeOlder": "24",
-        "removeOlderPoints": "10000",
-        "removeOlderUnit": "3600",
-        "cutout": 0,
-        "useOneColor": false,
-        "useUTC": false,
-        "colors": [
-            "#1f77b4",
-            "#aec7e8",
-            "#ff7f0e",
-            "#2ca02c",
-            "#98df8a",
-            "#d62728",
-            "#ff9896",
-            "#9467bd",
-            "#c5b0d5"
-        ],
-        "outputs": 1,
-        "useDifferentColor": false,
-        "className": "",
-        "x": 1160,
-        "y": 2260,
-        "wires": [
-            []
-        ]
-    },
-    {
-        "id": "bf4e488edf28469b",
-        "type": "function",
-        "z": "28627559bebdc324",
-        "g": "83eedcc325ccc21d",
-        "name": "query, airquality for every entry",
-        "func": "//entryDateTime is already in seconds\n\nconst query = `\nSELECT\n    strftime('%Y-%m-%d %H:%M:00', datetime(entryDateTime, 'unixepoch', 'localtime'), '+0 minutes') AS datetime,\n    pm01, \n    pm025, \n    pm10\nFROM\n    airquality\nWHERE\n    entryDateTime > (unixepoch('now') - (86400 * 1))\n    AND sensorName = '${flow.get(\"aq_selection\")}'\nORDER BY\n    entryDateTime;\n`;\n\nmsg.topic = query;\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 390,
-        "y": 2220,
-        "wires": [
-            [
-                "0d4ff80748d1c876"
-            ]
-        ]
-    },
-    {
-        "id": "0d4ff80748d1c876",
-        "type": "sqlite",
-        "z": "28627559bebdc324",
-        "g": "83eedcc325ccc21d",
-        "mydb": "2f60c1ab30a6fc8f",
-        "sqlquery": "msg.topic",
-        "sql": "",
-        "name": "",
-        "x": 820,
-        "y": 2220,
-        "wires": [
-            [
-                "56bbbcd2844a4c13"
-            ]
-        ]
-    },
-    {
-        "id": "56bbbcd2844a4c13",
-        "type": "function",
-        "z": "28627559bebdc324",
-        "g": "83eedcc325ccc21d",
-        "name": "structure daily summary payload",
-        "func": "//https://github.com/node-red/node-red-dashboard/blob/master/Charts.md\n//Array of Object with keys of series, data=x:ts,y:count, labels\n\nconst result = [{\n    \"series\": [\"pm01\", \"pm025\", \"pm10\"],\n    \"data\": [\n        msg.payload.map(item => ({ \"x\": new Date(item.datetime), \"y\": item.pm01 })),\n        msg.payload.map(item => ({ \"x\": new Date(item.datetime), \"y\": item.pm025 })),\n        msg.payload.map(item => ({ \"x\": new Date(item.datetime), \"y\": item.pm10 }))\n    ],\n    \"labels\": [\"\"]\n}];\n\nmsg.payload = result;\n\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 1110,
-        "y": 2220,
-        "wires": [
-            [
-                "bd1b7f16edeb4ed3"
             ]
         ]
     },
@@ -8469,7 +8412,7 @@
         "type": "function",
         "z": "28627559bebdc324",
         "g": "d16177f416c9a0ef",
-        "name": "query, events 30-min bins last 24-h in zone_capture",
+        "name": "query events, 30-min bins last 24-h in zone_capture",
         "func": "//frame_time is already in seconds\n//frame_time as 5-minute intervals, rounded up\n\nconst query = `\nSELECT\n    strftime('%Y-%m-%d %H:%M:00', (frame_time + 1799), 'unixepoch', '-' || ((frame_time + 1799) % 1800) || ' seconds', 'localtime') AS bin_time,\n    label,\n    COUNT(*) as count\nFROM\n    events\nWHERE\n    frame_time > (unixepoch('now') - (86400 * 1))\n    AND camera = '${flow.get(\"camera_selection\")}'\n    AND entered_zones LIKE '%zone_capture%'\n    AND label IN ('car')\nGROUP BY\n    strftime('%Y-%m-%d %H:%M:00', (frame_time + 1799), 'unixepoch', '-' || ((frame_time + 1799) % 1800) || ' seconds', 'localtime'), label\nORDER BY\n    label, bin_time;\n`;\n\nmsg.topic = query;\nreturn msg;",
         "outputs": 1,
         "timeout": 0,
@@ -8477,8 +8420,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 450,
-        "y": 2080,
+        "x": 610,
+        "y": 2300,
         "wires": [
             [
                 "6a292f3905fe5405"
@@ -8494,8 +8437,8 @@
         "sqlquery": "msg.topic",
         "sql": "",
         "name": "",
-        "x": 820,
-        "y": 2080,
+        "x": 680,
+        "y": 2340,
         "wires": [
             [
                 "76e813b1b7a4b63e"
@@ -8515,8 +8458,8 @@
         "initialize": "",
         "finalize": "",
         "libs": [],
-        "x": 1110,
-        "y": 2080,
+        "x": 1050,
+        "y": 2300,
         "wires": [
             [
                 "5cf61952cb6823de"
@@ -8562,10 +8505,274 @@
         "outputs": 1,
         "useDifferentColor": false,
         "className": "",
-        "x": 1180,
+        "x": 1120,
+        "y": 2340,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "f920233df1bbb23f",
+        "type": "ui_chart",
+        "z": "28627559bebdc324",
+        "g": "7c19b3698bb02613",
+        "name": "aq PM last 24-hours",
+        "group": "62cdf198fe42de7e",
+        "order": 3,
+        "width": 6,
+        "height": 7,
+        "label": "aq PM ug/m3, every 5-min (or based on settings) for last 24-hours",
+        "chartType": "line",
+        "legend": "true",
+        "xformat": "HH:mm",
+        "interpolate": "linear",
+        "nodata": "",
+        "dot": false,
+        "ymin": "",
+        "ymax": "",
+        "removeOlder": "24",
+        "removeOlderPoints": "10000",
+        "removeOlderUnit": "3600",
+        "cutout": 0,
+        "useOneColor": false,
+        "useUTC": false,
+        "colors": [
+            "#1f77b4",
+            "#aec7e8",
+            "#ff7f0e",
+            "#2ca02c",
+            "#98df8a",
+            "#d62728",
+            "#ff9896",
+            "#9467bd",
+            "#c5b0d5"
+        ],
+        "outputs": 1,
+        "useDifferentColor": false,
+        "className": "",
+        "x": 1120,
+        "y": 2080,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "149757a20cc50973",
+        "type": "function",
+        "z": "28627559bebdc324",
+        "g": "7c19b3698bb02613",
+        "name": "structure payload, PM",
+        "func": "//https://github.com/node-red/node-red-dashboard/blob/master/Charts.md\n//Array of Object with keys of series, data=x:ts,y:count, labels\n\nconst result = [{\n    \"series\": [\"pm01\", \"pm025\", \"pm10\"],\n    \"data\": [\n        msg.payload.map(item => ({ \"x\": new Date(item.datetime), \"y\": item.pm01 })),\n        msg.payload.map(item => ({ \"x\": new Date(item.datetime), \"y\": item.pm025 })),\n        msg.payload.map(item => ({ \"x\": new Date(item.datetime), \"y\": item.pm10 }))\n    ],\n    \"labels\": [\"\"]\n}];\n\nmsg.payload = result;\n\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 860,
+        "y": 2080,
+        "wires": [
+            [
+                "f920233df1bbb23f"
+            ]
+        ]
+    },
+    {
+        "id": "b8342af470189c50",
+        "type": "ui_chart",
+        "z": "28627559bebdc324",
+        "g": "7c19b3698bb02613",
+        "name": "aq TEMP, DEW last 24-hours",
+        "group": "62cdf198fe42de7e",
+        "order": 4,
+        "width": 6,
+        "height": 7,
+        "label": "aq TEMP, DEW, every 5-min (or based on settings) for last 24-hours",
+        "chartType": "line",
+        "legend": "true",
+        "xformat": "HH:mm",
+        "interpolate": "linear",
+        "nodata": "",
+        "dot": false,
+        "ymin": "",
+        "ymax": "",
+        "removeOlder": "24",
+        "removeOlderPoints": "10000",
+        "removeOlderUnit": "3600",
+        "cutout": 0,
+        "useOneColor": false,
+        "useUTC": false,
+        "colors": [
+            "#1f77b4",
+            "#aec7e8",
+            "#ff7f0e",
+            "#2ca02c",
+            "#98df8a",
+            "#d62728",
+            "#ff9896",
+            "#9467bd",
+            "#c5b0d5"
+        ],
+        "outputs": 1,
+        "useDifferentColor": false,
+        "className": "",
+        "x": 1140,
         "y": 2120,
         "wires": [
             []
+        ]
+    },
+    {
+        "id": "95871652f30bc9ce",
+        "type": "function",
+        "z": "28627559bebdc324",
+        "g": "7c19b3698bb02613",
+        "name": "structure payload, temp, dew",
+        "func": "//https://github.com/node-red/node-red-dashboard/blob/master/Charts.md\n//Array of Object with keys of series, data=x:ts,y:count, labels\n\nconst result = [{\n    \"series\": [\"temp\", \"dew\"],\n    \"data\": [\n        msg.payload.map(item => ({ \"x\": new Date(item.datetime), \"y\": item.temp })),\n        msg.payload.map(item => ({ \"x\": new Date(item.datetime), \"y\": item.dew }))\n    ],\n    \"labels\": [\"\"]\n}];\n\nmsg.payload = result;\n\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 880,
+        "y": 2120,
+        "wires": [
+            [
+                "b8342af470189c50"
+            ]
+        ]
+    },
+    {
+        "id": "8a82204bdfcdddb9",
+        "type": "ui_chart",
+        "z": "28627559bebdc324",
+        "g": "7c19b3698bb02613",
+        "name": "aq HUM last 24-hours",
+        "group": "62cdf198fe42de7e",
+        "order": 5,
+        "width": 6,
+        "height": 7,
+        "label": "aq HUM, every 5-min (or based on settings) for last 24-hours",
+        "chartType": "line",
+        "legend": "true",
+        "xformat": "HH:mm",
+        "interpolate": "linear",
+        "nodata": "",
+        "dot": false,
+        "ymin": "",
+        "ymax": "",
+        "removeOlder": "24",
+        "removeOlderPoints": "10000",
+        "removeOlderUnit": "3600",
+        "cutout": 0,
+        "useOneColor": false,
+        "useUTC": false,
+        "colors": [
+            "#1f77b4",
+            "#aec7e8",
+            "#ff7f0e",
+            "#2ca02c",
+            "#98df8a",
+            "#d62728",
+            "#ff9896",
+            "#9467bd",
+            "#c5b0d5"
+        ],
+        "outputs": 1,
+        "useDifferentColor": false,
+        "className": "",
+        "x": 1120,
+        "y": 2160,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "7d5875326501443c",
+        "type": "function",
+        "z": "28627559bebdc324",
+        "g": "7c19b3698bb02613",
+        "name": "structure payload, hum",
+        "func": "//https://github.com/node-red/node-red-dashboard/blob/master/Charts.md\n//Array of Object with keys of series, data=x:ts,y:count, labels\n\nconst result = [{\n    \"series\": [\"hum\"],\n    \"data\": [\n        msg.payload.map(item => ({ \"x\": new Date(item.datetime), \"y\": item.hum })),\n    ],\n    \"labels\": [\"\"]\n}];\n\nmsg.payload = result;\n\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 860,
+        "y": 2160,
+        "wires": [
+            [
+                "8a82204bdfcdddb9"
+            ]
+        ]
+    },
+    {
+        "id": "c1adf5e2bd669713",
+        "type": "ui_chart",
+        "z": "28627559bebdc324",
+        "g": "7c19b3698bb02613",
+        "name": "aq BAR last 24-hours",
+        "group": "62cdf198fe42de7e",
+        "order": 6,
+        "width": 6,
+        "height": 7,
+        "label": "aq BAR, every 5-min (or based on settings) for last 24-hours",
+        "chartType": "line",
+        "legend": "true",
+        "xformat": "HH:mm",
+        "interpolate": "linear",
+        "nodata": "",
+        "dot": false,
+        "ymin": "",
+        "ymax": "",
+        "removeOlder": "24",
+        "removeOlderPoints": "10000",
+        "removeOlderUnit": "3600",
+        "cutout": 0,
+        "useOneColor": false,
+        "useUTC": false,
+        "colors": [
+            "#1f77b4",
+            "#aec7e8",
+            "#ff7f0e",
+            "#2ca02c",
+            "#98df8a",
+            "#d62728",
+            "#ff9896",
+            "#9467bd",
+            "#c5b0d5"
+        ],
+        "outputs": 1,
+        "useDifferentColor": false,
+        "className": "",
+        "x": 1120,
+        "y": 2200,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "c13f03809fbd9809",
+        "type": "function",
+        "z": "28627559bebdc324",
+        "g": "7c19b3698bb02613",
+        "name": "structure payload, bar",
+        "func": "//https://github.com/node-red/node-red-dashboard/blob/master/Charts.md\n//Array of Object with keys of series, data=x:ts,y:count, labels\n\nconst result = [{\n    \"series\": [\"bar\"],\n    \"data\": [\n        msg.payload.map(item => ({ \"x\": new Date(item.datetime), \"y\": item.bar })),\n    ],\n    \"labels\": [\"\"]\n}];\n\nmsg.payload = result;\n\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 860,
+        "y": 2200,
+        "wires": [
+            [
+                "c1adf5e2bd669713"
+            ]
         ]
     },
     {


### PR DESCRIPTION
Created Node-RED flows for Air Quality sensors ([greendormer/enviroplus-monitor](https://github.com/greendormer/enviroplus-monitor)):
- Entirely new flow called `capture-aq` 
- AQ flow listens for MQTT messages from python script, saves to tmdb.sqlite
- Added ThingsBoard telemetry send of aq readings
- Added aq sensor documentation