### PR TITLE
Fix setup script, copy frigate.env

### DIFF
--- a/script/setup
+++ b/script/setup
@@ -18,6 +18,7 @@ mkdir -p ~/code/frigate  #for files
 mkdir -p ~/code/frigate/config  #for frigate configuration file
 mkdir -p ~/code/frigate/storage  #for media
 cp docker-frigate/docker-compose-frigate.yaml ~/code/frigate/docker-compose-frigate.yml
+cp docker-frigate/frigate.env ~/code/frigate/frigate.env
 
 #create config file, with hostname for rpi for streaming using go2rtc
 #cp docker-frigate/frigate-config.yaml ~/code/frigate/config/config.yml


### PR DESCRIPTION
Added line to fix setup script so it copies frigate.env into the working directory.