### PR TITLE
copy rpi5-node-red-telemetry to runtime folder and execute it from there

### DIFF
--- a/node-red-project/flows.json
+++ b/node-red-project/flows.json
@@ -12802,7 +12802,7 @@
         "id": "c0078fa5b3946c05",
         "type": "exec",
         "z": "f410f6aac9d1a3fc",
-        "command": "python3 .node-red/projects/traffic-monitor/utils/rpi5-nodered-telemetry.py",
+        "command": "python3 code/utils/rpi5-nodered-telemetry.py",
         "addpay": "",
         "append": "",
         "useSpawn": "true",

--- a/script/setup
+++ b/script/setup
@@ -92,5 +92,8 @@ mkdir -p ~/code/utils
 cp -p utils/wlan_check.sh ~/code/utils
 chmod +x ~/code/utils/wlan_check.sh
 
+##-- set up script that grabs hardware metrics for reporting to Thingsboard
+cp -p utils/rpi5-nodered-telemetry.py ~/code/utils
+
 # Setup cronjob to regularly run wlan_check script
 crontab script/crontab.jobs


### PR DESCRIPTION
Fix issue 65 by copying rpi5-node-red-telemetry.py to the `code` runtime folder and executing it from there.