### PR TITLE
Bug/tmsetup install ansible

### DIFF
--- a/script/tmsetup.sh
+++ b/script/tmsetup.sh
@@ -56,8 +56,10 @@ _add_var(){
 
 _install_ansible() { # Check if python installed or install
 local venv_dir=$1
-which python3 || sudo apt install python3 || return 1
-. "${venv_dir}/bin/activate" > /dev/null || ( python3 -m venv "${venv_dir}"  && . "${venv_dir}/bin/activate" ) || return 1
+dpkg -S python3.10-venv || ( sudo apt update && sudo apt install python3.10-venv )
+while ! . "${venv_dir}/bin/activate" ;do 
+  python3 -m venv "${venv_dir}"  || return 1
+done
 pip3 install -r "${_SCRIPT_DIR}/requirements" || return 1
 return 0
 }

--- a/script/tmsetup.sh
+++ b/script/tmsetup.sh
@@ -56,7 +56,7 @@ _add_var(){
 
 _install_ansible() { # Check if python installed or install
 local venv_dir=$1
-dpkg -S python3.10-venv || ( sudo apt update && sudo apt install python3.10-venv )
+dpkg -S python3-venv || ( sudo apt update && sudo apt install python3-venv )
 while ! . "${venv_dir}/bin/activate" ;do 
   python3 -m venv "${venv_dir}"  || return 1
 done


### PR DESCRIPTION
… on OS-lite

`tmsetup.sh` fails in `_install_ansible` function when python3-venv not installed.  Adding commands to install if not found.