### PR TITLE
Feature/setup make apt upgrade optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.backup
+.vscode

--- a/script/ansible/roles/tmsetup/tasks/base_setup.yml
+++ b/script/ansible/roles/tmsetup/tasks/base_setup.yml
@@ -7,24 +7,24 @@
     groups: sudo
     name: '{{ tmsetup_codeowner }}'
 
-- name: TMSetup - Base Setup - Run full update
-  become: true
-  async: 3600
-  poll: 0
-  ansible.builtin.apt:
-    update_cache: true
-    upgrade: full
-  register: tmsetup_apt_update_register
-  changed_when: false
-  
-- name: TMSetup - Base Setup - Monitor update job for results
-  become: true
-  ansible.builtin.async_status:
-    jid: "{{ tmsetup_apt_update_register.ansible_job_id }}"
-  register: tmsetup_apt_upate_job_register
-  until: tmsetup_apt_upate_job_register.finished
-  retries: 360
-  delay: 10
+# - name: TMSetup - Base Setup - Run full update
+#   become: true
+#   async: 3600
+#   poll: 0
+#   ansible.builtin.apt:
+#     update_cache: true
+#     upgrade: full
+#   register: tmsetup_apt_update_register
+#   changed_when: false
+
+# - name: TMSetup - Base Setup - Monitor update job for results
+#   become: true
+#   ansible.builtin.async_status:
+#     jid: "{{ tmsetup_apt_update_register.ansible_job_id }}"
+#   register: tmsetup_apt_upate_job_register
+#   until: tmsetup_apt_upate_job_register.finished
+#   retries: 360
+#   delay: 10
 
 - name: TMSetup - Base Setup - Check if reboot needed
   ansible.builtin.stat:

--- a/script/ansible/roles/tmsetup/tasks/base_setup.yml
+++ b/script/ansible/roles/tmsetup/tasks/base_setup.yml
@@ -7,25 +7,6 @@
     groups: sudo
     name: '{{ tmsetup_codeowner }}'
 
-# - name: TMSetup - Base Setup - Run full update
-#   become: true
-#   async: 3600
-#   poll: 0
-#   ansible.builtin.apt:
-#     update_cache: true
-#     upgrade: full
-#   register: tmsetup_apt_update_register
-#   changed_when: false
-
-# - name: TMSetup - Base Setup - Monitor update job for results
-#   become: true
-#   ansible.builtin.async_status:
-#     jid: "{{ tmsetup_apt_update_register.ansible_job_id }}"
-#   register: tmsetup_apt_upate_job_register
-#   until: tmsetup_apt_upate_job_register.finished
-#   retries: 360
-#   delay: 10
-
 - name: TMSetup - Base Setup - Check if reboot needed
   ansible.builtin.stat:
     path: /var/run/reboot-required

--- a/script/ansible/roles/tmsetup/tasks/coraltpu_pci_setup.yml
+++ b/script/ansible/roles/tmsetup/tasks/coraltpu_pci_setup.yml
@@ -40,14 +40,14 @@
         chdir: /tmp
         cmd: docker build -f gasket-builder.Dockerfile --output . .
         creates: /tmp/gasket-dkms_1.0-18_all.deb
-    
+
     - name: TMSetup - Coral TPU PCI Setup - Install gasket-dkms from .deb
       become: true
       ansible.builtin.apt:
         deb: /tmp/gasket-dkms_1.0-18_all.deb
         state: present
       notify: TMSetup - Flag for reboot
-        
+
 - name: TMSetup - Coral TPU PCI Setup - Create apex udev rules to manage device permissions
   become: true
   ansible.builtin.copy:

--- a/script/tmsetup.sh
+++ b/script/tmsetup.sh
@@ -16,7 +16,7 @@ _EXIT_STATUS=0
 _EXTRA_ARGS=""
 _FORCE=false
 _CONFIRM=false
-_LOGFILE=~/tmsetup-$(date +%Y%m%d).log
+_LOGFILE=~/tmsetup-$(date +%Y%m%d-%H%M).log
 _MIN_ANSIBLE_VERSION=10.7.0
 declare _VALID_TAGS=("base" "wifi" "docker" "frigate" "nodered" "go2rtc")
 
@@ -200,6 +200,7 @@ then
 else
   printf "Setup completed with errors.  Review logs at: %s\n" "${_LOGFILE}"
 fi
+printf "Full output logged to: %s\n" "${_LOGFILE}"
 _pline
 
 

--- a/script/tmsetup.sh
+++ b/script/tmsetup.sh
@@ -164,7 +164,7 @@ _log_check "${_LOGFILE}" || exit 1
 exec > >(tee -i "${_LOGFILE}")
 exec 2>&1
 
-[[ "${_APT_UPGRADE}" == "true" ]] && _apt_upgrade || exit 1
+[[ "${_APT_UPGRADE}" == "true" ]] && _apt_upgrade
 
 _install_ansible "${VENV_DIR}"
 if [ "${_FORCE}" = true ]

--- a/script/tmsetup.sh
+++ b/script/tmsetup.sh
@@ -40,7 +40,7 @@ printf "  %-20s%s\n" \
   "-v" "Verbose ansible-playbook output. Call multiple times for increased verbosity" \
   "-y" "Assume YES to all prompts including reboot" \
   "-z TIMEZONE" "Set TIMEZONE (default America/Los_Angeles)"
-# "-e" "ERASE Traffic Monitor software" # Future addition
+# "-R" "REMOVE Traffic Monitor software" # Future addition
 }
 
 _add_arg(){


### PR DESCRIPTION
Removed the tasks for apt upgrade from the `tmsetup` ansible role and made it a function in the `tmsetup.sh` shell script instead.  This can be called by the `-u` flag on `tmsetup.sh` but is optional now.  Confirmed shows output and logs to the tmsetup log file.