### PR TITLE
Adding new functionality to allow REMOTE deployments using tmsetup!

### DIFF
--- a/script/ansible/roles/tmsetup/defaults/main.yml
+++ b/script/ansible/roles/tmsetup/defaults/main.yml
@@ -20,6 +20,7 @@ tmsetup_latitude: ''
 tmsetup_longitude: ''
 tmsetup_bearing: ''
 
+tmsetup_perform_apt_upgrade: false
 tmsetup_force_configs: false
 tmsetup_reboot_touch_file: ~/tm-reboot-required
 

--- a/script/ansible/roles/tmsetup/tasks/apt_upgrade.yml
+++ b/script/ansible/roles/tmsetup/tasks/apt_upgrade.yml
@@ -1,0 +1,7 @@
+---
+- name: TMSetup - Run apt full-upgrade on remote hosts (Warning this can take a while)
+  ansible.builtin.apt:
+    update_cache: true
+    upgrade: full
+
+...

--- a/script/ansible/roles/tmsetup/tasks/base_setup.yml
+++ b/script/ansible/roles/tmsetup/tasks/base_setup.yml
@@ -7,13 +7,6 @@
     groups: sudo
     name: '{{ tmsetup_codeowner }}'
 
-- name: TMSetup - Base Setup - Check if reboot needed
-  ansible.builtin.stat:
-    path: /var/run/reboot-required
-  register: tmsetup_reboot_required_stat_register
-  changed_when: tmsetup_reboot_required_stat_register.stat.exists
-  notify: TMSetup - Flag for reboot
-
 - name: TMSetup - Base Setup - Create code owner
   become: true
   ansible.builtin.user:
@@ -44,6 +37,13 @@
     owner: '{{ tmsetup_codeowner }}'
     path: '{{ item }}'
     state: directory
+
+- name: TMSetup - Base Setup - Install aptitude for better package management
+  become: true
+  ansible.builtin.apt:
+    name: aptitude
+    state: present
+    update_cache: true
 
 - name: TMSetup - Base Setup - Remove conflicting packages
   become: true

--- a/script/ansible/roles/tmsetup/tasks/main.yml
+++ b/script/ansible/roles/tmsetup/tasks/main.yml
@@ -20,6 +20,11 @@
   ansible.builtin.import_tasks:
     file: base_setup.yml
 
+- name: TMSetup - Main - Apt Full Upgrade (for remote hosts)
+  when: tmsetup_perform_apt_upgrade | bool
+  ansible.builtin.import_tasks:
+    file: apt_upgrade.yml
+
 - name: TMSetup - Main - Setup go2rtc driver
   tags:
     - go2rtc
@@ -73,4 +78,12 @@
     - go2rtc
   ansible.builtin.import_tasks:
     file: start_services.yml
+
+- name: TMSetup - Base Setup - Check if reboot needed
+  ansible.builtin.stat:
+    path: /var/run/reboot-required
+  register: tmsetup_reboot_required_stat_register
+  changed_when: tmsetup_reboot_required_stat_register.stat.exists
+  notify: TMSetup - Flag for reboot
+
 ...

--- a/script/ansible/roles/tmsetup/vars/main.yml
+++ b/script/ansible/roles/tmsetup/vars/main.yml
@@ -8,6 +8,7 @@ tmsetup_remove_packages:
   - rpicam-apps-lite
 
 tmsetup_packages:
+  - aptitude
   - ca-certificates
   - host
   - screen

--- a/script/ansible/setup_remote_hosts.yml
+++ b/script/ansible/setup_remote_hosts.yml
@@ -1,0 +1,13 @@
+---
+- name: Traffic Monitor Setup remote hosts
+  hosts: all
+## User configurable variables. Defaults are defined here.
+#  vars:
+#    tmsetup_codeowner: 'tmadmin'
+#    tmsetup_codedir: '/opt/traffic-monitor'
+#    tmsetup_force_configs: false
+  tasks:
+    - name: Run tmsetup role
+      ansible.builtin.import_role:
+        name: tmsetup
+...

--- a/script/tmsetup.sh
+++ b/script/tmsetup.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 # Setup ansible for install
 
-# User defined variables:
-VENV_DIR=~/tm_venv
-REBOOT_TOUCH_FILE=~/tm-reboot-required
+# TUNEABLE VARIABLES
+TM_TMP_DIR=~/.tmsetup
+VENV_DIR="${TM_TMP_DIR}/tm_venv"
+REBOOT_TOUCH_FILE="${TM_TMP_DIR}/reboot-required"
+TMP_INVENTORY_PATH="${TM_TMP_DIR}/inventory"
 
-
-# Set Internal Variables
+# INTERNAL VARIABLES
 _THIS_SCRIPT=$0
 _SCRIPT_DIR=$(dirname "$_THIS_SCRIPT")
 _START_DIR=$(pwd)
@@ -18,12 +19,14 @@ _FORCE=false
 _CONFIRM=false
 _LOGFILE=~/tmsetup-$(date +%Y%m%d-%H%M).log
 _MIN_ANSIBLE_VERSION=10.7.0
+_REMOTE_HOSTS=''
 declare _VALID_TAGS=("base" "wifi" "docker" "frigate" "nodered" "go2rtc")
 
-
+## FUNCTIONS
 _pline() { # Print line function
   printf '============================================================\n'
 }
+
 _usage() { # Print usage function
 printf "%s [-d PATH][-o USER][-z TIMEZONE][-f|h|y] \n" "${_THIS_SCRIPT}"
 printf "Install Traffic Monitor software for Raspberry Pi\n\n"
@@ -32,7 +35,10 @@ printf "  %-20s%s\n" \
   "-f" "FORCE to overwrite any existing configs with fresh copies from template" \
   "-g GROUP" "Set the GROUP owner of traffic-monitor files an processes (default tmadmin)" \
   "-h" "Show this usage output" \
-  "-l PATH" "PATH to log file for output of installer (default ${_LOGFILE})" \
+  "-H HOSTNAME" "HOSTNAME for remote host execution.  Can be comma-seperated list of mulitiple" \
+  "-l USERNAME" "LOGIN to for remote host execution" \
+  "-L PATH" "PATH to LOGFILE file for output of installer (default ${_LOGFILE})" \
+  "-k" "Prompt for password for remote host execution." \
   "-o USER" "Set the OWNER of traffic-monitor files and processes (default tmadmin)" \
   "-t TAG" "TAG the ansible-playbook command to only run a subset of plays" \
   "-T" "Get a list of available tags and exit" \
@@ -43,26 +49,26 @@ printf "  %-20s%s\n" \
 # "-R" "REMOVE Traffic Monitor software" # Future addition
 }
 
-_add_arg(){
+_add_arg(){ # add an arg to ansible-playbook command
   local arg=$1
   _EXTRA_ARGS="${_EXTRA_ARGS} $arg"
   return 0
 }
 
-_add_var(){
+_add_var(){ # add a extra-var to ansible-playbook command
   local key=$1
   local val=$2
   _add_arg "--extra-vars $key=$val"
   return 0
 }
 
-_apt_upgrade(){
+_apt_upgrade(){ # perform full upgrade on local installs
   sudo apt update || return 1
-  sudo apt upgrade || return 1
+  sudo apt full-upgrade || return 1
   return 0
 }
 
-_install_ansible() { # Check if python installed or install
+_install_ansible() { # check and install python3-venv and setup venv
 local venv_dir=$1
 dpkg -S python3-venv || ( sudo apt update && sudo apt install python3-venv )
 while ! . "${venv_dir}/bin/activate" ;do 
@@ -92,14 +98,29 @@ fi
 return 0
 }
 
-if [[ -n ${REBOOT_TOUCH_FILE} ]] ;then
-  _add_var tmsetup_reboot_touch_file "${REBOOT_TOUCH_FILE}"
-  touch ${REBOOT_TOUCH_FILE} || exit 1
-  printf '0' > ${REBOOT_TOUCH_FILE} || exit 1
-fi
+_init_reboot_touchfile() { # Initialize the reboot touchfile 
+  if [[ -n ${REBOOT_TOUCH_FILE} ]] ;then
+  _ add_var tmsetup_reboot_touch_file "${REBOOT_TOUCH_FILE}"
+    touch ${REBOOT_TOUCH_FILE} || return 1
+    printf '0' > ${REBOOT_TOUCH_FILE} || return 1
+  fi
+  return 0
+}
+
+_set_tmp_ansible_inv() { # Setup ansible inventory for remote hosts
+  local _remote_hosts=$1
+  local _tmp_inventory=$2
+  if [[ -n "${_remote_hosts}" ]];then
+    IFS=',' read -r -a _hosts_array <<< ${_remote_hosts}
+    printf "[all]\n" > "${_tmp_inventory}"
+    printf "%s\n" ${_hosts_array[@]} >> "${_tmp_inventory}"
+  fi
+}
+
+### Start of MAIN
 
 # Collect command-line options
-while getopts ":fhTuvyd:g:l:o:t:z:" opt
+while getopts ":fhkTuvyd:g:H:l:L:o:t:z:" opt
 do
   case ${opt} in
     d) # Set PATH for install
@@ -111,15 +132,27 @@ do
     g) # Set code GROUP
       _add_var tmsetup_codegroup "${OPTARG}"
       ;;
-    l) # Log output to file
+    H) # Set remote HOST execution
+      if [[ -n "${_REMOTE_HOSTS}" ]];then
+        _REMOTE_HOSTS="${OPTARG}"
+      else
+        _REMOTE_HOSTS="${_REMOTE_HOSTS},${OPTARG}"
+      fi
+      ;;
+    l) # LOGIN for remote host execution
+      _add_arg "-u ${OPTARG}"
+      ;;
+    L) # Log output to file
       _LOGFILE="${OPTARG}"
       ;;
+    k) # Prompt for password for login for remote host execution
+      _add_arg "-k"
+      ;;
     o) # Set Code OWNER
-      _EXTRA_ARGS="${_EXTRA_ARGS} -e tmsetup_codeowner=${OPTARG}"
       _add_var tmsetup_codeowner "${OPTARG}"
       ;;
     t) # Set playbook TAG
-      if [[ " ${_VALID_TAGS[*]} " =~ [[:space:]]${OPTARG}[[:space:]] ]] ;then
+      if [[ " ${_VALID_TAGS[*]} " =~ "[[:space:]]${OPTARG}[[:space:]]" ]] ;then
         _add_arg "--tags ${OPTARG}"
       else
         printf "Invalid Tag: %s\nExitting.\n\n" "${OPTARG}"
@@ -160,13 +193,27 @@ do
   esac
 done
 
-_log_check "${_LOGFILE}" || exit 1
+mkdir -p "${TM_TMP_DIR}" || exit
+printf "This directory %s is just a tmp directory for traffic-monitor tmsetup.sh script.\n Everything in here can be safely deleted but future tmsetup.sh runs will take a bit longer.\n\nThank you,\n-The TM Team\n" "${TM_TMP_DIR}" > "${TM_TMP_DIR}/README.txt"
+
+_log_check "${_LOGFILE}" || exit
 
 # Log all further output to logfile
 exec > >(tee -i "${_LOGFILE}")
 exec 2>&1
 
-[[ "${_APT_UPGRADE}" == "true" ]] && _apt_upgrade
+if [[ -n "${_REMOTE_HOSTS}" ]];then
+  _set_tmp_ansible_inv "${_REMOTE_HOSTS}" "${TMP_INVENTORY_PATH}"
+fi
+_init_reboot_touchfile || exit $?
+
+if [[ "${_APT_UPGRADE}" == "true" ]];then
+  if [[ -z "${_REMOTE_HOSTS}" ]];then
+    _apt_upgrade
+  else
+    _add_var tmsetup_perform_apt_upgrade true
+  fi
+fi
 
 _install_ansible "${VENV_DIR}"
 if [ "${_FORCE}" = true ]
@@ -182,32 +229,36 @@ fi
 _pline
 printf "Running Ansible playbook to setup Traffic Monitor\n"
 _pline
-cd "${_SCRIPT_DIR}/ansible" || exit 1
-. "${VENV_DIR}/bin/activate" || exit 1
+cd "${_SCRIPT_DIR}/ansible" || exit
+. "${VENV_DIR}/bin/activate" || exit
 
-ANSIBLE_CMD="ansible-playbook -i localhost setup.yml ${_EXTRA_ARGS}"
+if [[ -z "${_REMOTE_HOSTS}" ]];then
+  ANSIBLE_CMD="ansible-playbook -i localhost setup.yml ${_EXTRA_ARGS}"
+else
+  ANSIBLE_CMD="ansible-playbook -i "${TMP_INVENTORY_PATH}" setup_remote_hosts.yml ${_EXTRA_ARGS}"
+fi
+
 printf "%s\n" "${ANSIBLE_CMD}"
 ${ANSIBLE_CMD}
 
 # Notify and exit on error
-[[ "${PIPESTATUS[0]}" -eq 0 ]] || _EXIT_STATUS=1
+_EXIT_STATUS="${PIPESTATUS[0]}"
 
-cd "${_START_DIR}" || exit "${_EXIT_STATUS}"
+cd "${_START_DIR}" || exit
 
 printf "\n\n\n"
 _pline
 if [[ "${_EXIT_STATUS}" -eq 0 ]]
 then
-  printf "Setup completed succesfully!\n"
+  printf "Setup completed SUCCESFULLY!\n"
 else
-  printf "Setup completed with errors.  Review logs at: %s\n" "${_LOGFILE}"
+  printf "Setup completed with ERRORS!!\n"
 fi
 printf "Full output logged to: %s\n" "${_LOGFILE}"
 _pline
 
-
 # Ask to reboot if not bypassed
-if [[ "$(<"${REBOOT_TOUCH_FILE}")" -ne 0 ]] ;then
+if [[ "$(<"${REBOOT_TOUCH_FILE}")" -ne 0 ]] && [[ -z "${_REMOTE_HOSTS}" ]] ;then
   _pline
   printf "Reboot is required to complete the installation.\n"
   if _confirm_cont "Would you like to reboot now? [yN] "


### PR DESCRIPTION
Adding new functionality to _tmsetup.sh_ and the _tmsetup_ ansible role so that they can be used to deploy an base-imaged pi over SSH:
```
  "-H HOSTNAME" "HOSTNAME for remote host execution.  Can be comma-seperated list of mulitiple" \
  "-l USERNAME" "LOGIN to for remote host execution" \
  "-L PATH" "PATH to LOGFILE file for output of installer (default ${_LOGFILE})" \
  "-k" "Prompt for password for remote host execution." \
  ```
  Changed **LOGFILE** option to `-L` to free up `-l` to stay in line with ansible-playbook switches for **LOGIN**.
  Added `-H` switch to specify a **HOST** or list of **HOSTS** comma-seperated
  Added `-k` switch to prompt for a **PASSWORD** for the specified **LOGIN** again this is in keeping with Ansible's switches.  If not provided, will try ssh using keys and fail if unable to login.
 
 This was my real end goal with the ansible setup refactor all along.   No more cloning the git repo to every TM you image!