### PR TITLE
Bug Fix for issue 111

### DIFF
--- a/script/ansible/roles/tmsetup/tasks/wifi_setup.yml
+++ b/script/ansible/roles/tmsetup/tasks/wifi_setup.yml
@@ -10,12 +10,21 @@
     mode: '0644'
   notify: Restart NetworkManager service
 
+- name: TMSetup - WiFi Setup - Add sudoers entry to allow tmadmin to restart NetworkManager
+  become: true
+  community.general.sudoers:
+    user: "{{ tmsetup_codeowner }}"
+    name: "{{ tmsetup_codeowner }}"
+    commands: /usr/bin/systemctl restart NetworkManager.service
+    nopassword: true
+    state: present
+
 - name: TMSetup - WiFi Setup - Setup crontab
   become: true
   ansible.builtin.cron:
     name: Traffic Monitor Wifi Check
-    user: '{{ tmsetup_codeowner }}'
+    user: "{{ tmsetup_codeowner }}"
     minute: '*/5'
-    job: '/usr/bin/sudo /bin/bash {{ tmsetup_codedir }}/utils/wlan_check.sh -q'
+    job: '/bin/bash {{ tmsetup_codedir }}/utils/wlan_check.sh -q'
     state: present
 ...

--- a/utils/wlan_check.sh
+++ b/utils/wlan_check.sh
@@ -17,7 +17,7 @@ while getopts "q" opt; do
 done
 
 ERROR=false
-NETRESTARTCMD="systemctl restart NetworkManager"
+NETRESTARTCMD="sudo /usr/bin/systemctl restart NetworkManager.service"
 
 
 _logallways() {


### PR DESCRIPTION
Bug fix for issue #111.  Updated wlan_check.sh to use sudo for the network restart command and changed crontab entry to run it not using sudo.  Added passwordless sudoers entry to allow codeowner to run network restart command.