### PR TITLE
Add pytest testing framework for SQLite schema and payload validation

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,27 @@
+name: pytest
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          pip install pytest pytest-cov
+
+      - name: Run tests
+        run: |
+          pytest tests/ -v --tb=short

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,9 +2,9 @@ name: pytest
 
 on:
   push:
-    branches: [main]
+    branches: [dev, main]
   pull_request:
-    branches: [main]
+    branches: [dev]
 
 jobs:
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 *.backup
 .vscode
+
+__pycache__/
+*.pyc
+.pytest_cache/
+.coverage

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,7 +71,7 @@ def db():
 @pytest.fixture
 def db_with_deployment(db):
     db.execute(
-        "INSERT INTO deployment (id, lable, bearing, created_at) VALUES (?,?,?,?)",
+        "INSERT INTO deployment (id, label, bearing, created_at) VALUES (?,?,?,?)",
         ("deploy-001", "Front Street North", 0.0, int(time.time())),
     )
     db.commit()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,120 @@
+"""
+Shared pytest fixtures for traffic-monitor test suite.
+
+All fixtures use in-memory SQLite so no device or real DB is required.
+Schema mirrors tmdb.events.sqlite as documented at:
+  https://docs.trafficmonitor.ai/sensor-payloads/events-payload
+  https://docs.trafficmonitor.ai/sensor-payloads/radar-payload
+"""
+
+import json
+import sqlite3
+import time
+import pytest
+
+# Schema DDL
+# Derived from documented payload fields. Update if upstream schema changes.
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS deployment (
+    id          TEXT PRIMARY KEY,
+    label       TEXT,
+    bearing     REAL,
+    created_at  INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS events (
+    id              TEXT PRIMARY KEY,
+    camera          TEXT NOT NULL,
+    label           TEXT NOT NULL,
+    sub_label       TEXT,
+    score           REAL,
+    best_timestamp  INTEGER,
+    start_timestamp INTEGER NOT NULL,
+    end_timestamp   INTEGER NOT NULL,
+    zones           TEXT,
+    deployment_id   TEXT,
+    created_at      INTEGER,
+    FOREIGN KEY (deployment_id) REFERENCES deployment(id)
+);
+
+CREATE TABLE IF NOT EXISTS radar (
+    id              TEXT PRIMARY KEY,
+    sensor          TEXT NOT NULL,
+    direction       TEXT,
+    max_speed       REAL,
+    avg_speed       REAL,
+    dov_count       INTEGER,
+    speeds          TEXT,
+    duration_ms     INTEGER,
+    frame_count     INTEGER,
+    delta_speed     REAL,
+    est_length      REAL,
+    units           TEXT,
+    classification  TEXT,
+    start_time      INTEGER,
+    end_time        INTEGER,
+    deployment_id   TEXT,
+    created_at      INTEGER,
+    FOREIGN KEY (deployment_id) REFERENCES deployment(id)
+);
+"""
+@pytest.fixture
+def db():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(SCHEMA_SQL)
+    conn.execute("PRAGMA foreign_keys = ON")
+    yield conn
+    conn.close()
+
+@pytest.fixture
+def db_with_deployment(db):
+    db.execute(
+        "INSERT INTO deployment (id, lable, bearing, created_at) VALUES (?,?,?,?)",
+        ("deploy-001", "Front Street North", 0.0, int(time.time())),
+    )
+    db.commit()
+    return db
+
+def make_event_payload(**overrides):
+    now = int(time.time())
+    base = {
+        "id": "avt-abc123",
+        "camera": "front_cam",
+        "label": "car",
+        "sub_label": None,
+        "score": 0.87,
+        "best_timestamp": now,
+        "start_timestamp": now - 3,
+        "end_timestamp": now,
+        "zones": json.dumps(["zone_road"]),
+        "deployment_id": "deploy-001",
+        "created_at": now,
+    }
+    base.update(overrides)
+    return base
+
+def make_radar_payload(**overrides):
+    now = int(time.time())
+    base = {
+        "id": "rad-xyz789",
+        "sensor": "radar_front",
+        "direction": "inbound",
+        "max_speed": 28.5,
+        "avg_speed": 26.1,
+        "dov_count": 3,
+        "speeds": json.dumps([28.5, 27.2, 26.1]),
+        "duration_ms": 1400,
+        "frame_count": 28,
+        "delta_speed": 2.4,
+        "est_length": 4.3,
+        "units": "mph",
+        "classification": json.dumps({"car": 0.86, "bike": 0.05}),
+        "start_time": now - 2,
+        "end_time": now,
+        "deployment_id": "deploy-001",
+        "created_at": now,
+    }
+    base.update(overrides)
+    return base

--- a/tests/test_data_integrity.py
+++ b/tests/test_data_integrity.py
@@ -1,0 +1,156 @@
+"""
+test_data_integrity.py
+
+Tests for cross-table data integrity:
+- Foreign key enforcement (deployment_id references)
+- Orphan record detection
+- Multi-table query correctness
+
+These tests are valuable because the project has had repeated breaking
+schema changes between releases. A passing integrity suite means any
+migration script can be validated before deployment.
+"""
+
+import json
+import time
+import pytest
+from conftest import make_event_payload, make_radar_payload
+
+def insert_event(db, payload):
+    db.execute(
+        """INSERT INTO events
+           (id, camera, label, sub_label, score, best_timestamp,
+            start_timestamp, end_timestamp, zones, deployment_id, created_at)
+           VALUES
+           (:id, :camera, :label, :sub_label, :score, :best_timestamp,
+            :start_timestamp, :end_timestamp, :zones, :deployment_id, :created_at)""",
+        payload,
+    )
+    db.commit()
+
+
+def insert_radar(db, payload):
+    db.execute(
+        """INSERT INTO radar
+           (id, sensor, direction, max_speed, avg_speed, dov_count,
+            speeds, duration_ms, frame_count, delta_speed, est_length,
+            units, classification, start_time, end_time, deployment_id, created_at)
+           VALUES
+           (:id, :sensor, :direction, :max_speed, :avg_speed, :dov_count,
+            :speeds, :duration_ms, :frame_count, :delta_speed, :est_length,
+            :units, :classification, :start_time, :end_time, :deployment_id, :created_at)""",
+        payload,
+    )
+    db.commit()
+
+class TestForeignKeys:
+    def test_event_fk_requires_valid_deployment(self, db_with_deployment):
+        payload = make_event_payload(deployment_id="deploy-001")
+        insert_event(db_with_deployment, payload)
+        row = db_with_deployment.execute(
+            "SELECT * FROM events WHERE id=?", (payload["id"],)
+        ).fetchone()
+        assert row is not None
+
+    def test_event_invalid_deployment_id_raises(self, db_with_deployment):
+        payload = make_event_payload(deployment_id="does-not-exist")
+        with pytest.raises(Exception):
+            insert_event(db_with_deployment, payload)
+
+    def test_radar_fk_requires_valid_deployment(self, db_with_deployment):
+        payload = make_radar_payload(deployment_id="deploy-001")
+        insert_radar(db_with_deployment, payload)
+        row = db_with_deployment.execute(
+            "SELECT * FROM radar WHERE id=?", (payload["id"],)
+        ).fetchone()
+        assert row is not None
+
+    def test_radar_invalid_deployment_id_raises(self, db_with_deployment):
+        payload = make_radar_payload(deployment_id="does-not-exist")
+        with pytest.raises(Exception):
+            insert_radar(db_with_deployment, payload)
+
+class TestDeploymentTable:
+    def test_deployment_id_is_primary_key(self, db):
+        db.execute(
+            "INSERT INTO deployment (id, label, bearing, created_at) VALUES (?,?,?,?)",
+            ("dep-1", "North Street", 0.0, int(time.time())),
+        )
+        db.commit()
+        with pytest.raises(Exception):
+            db.execute(
+                "INSERT INTO deployment (id, label, bearing, created_at) VALUES (?,?,?,?)",
+                ("dep-1", "Duplicate", 180.0, int(time.time())),
+            )
+
+    def test_multiple_deployments_allowed(self, db):
+        for i in range(3):
+            db.execute(
+                "INSERT INTO deployment (id, label, bearing, created_at) VALUES (?,?,?,?)",
+                (f"dep-{i}", f"Location {i}", float(i * 90), int(time.time())),
+            )
+        db.commit()
+        count = db.execute("SELECT COUNT(*) FROM deployment").fetchone()[0]
+        assert count == 3
+
+class TestCrossTableQueries:
+    def test_events_joined_to_deployment(self, db_with_deployment):
+        payload = make_event_payload(deployment_id="deploy-001")
+        insert_event(db_with_deployment, payload)
+
+        row = db_with_deployment.execute(
+            """
+            SELECT e.label, d.label as location
+            FROM events e
+            JOIN deployment d ON e.deployment_id = d.id
+            WHERE e.id = ?
+            """,
+            (payload["id"],),
+        ).fetchone()
+
+        assert row["label"] == "car"
+        assert row["location"] == "Front Street North"
+
+    def test_radar_joined_to_deployment(self, db_with_deployment):
+        payload = make_radar_payload(deployment_id="deploy-001")
+        insert_radar(db_with_deployment, payload)
+
+        row = db_with_deployment.execute(
+            """
+            SELECT r.max_speed, d.label as location
+            FROM radar r
+            JOIN deployment d ON r.deployment_id = d.id
+            WHERE r.id = ?
+            """,
+            (payload["id"],),
+        ).fetchone()
+
+        assert row["location"] == "Front Street North"
+        assert row["max_speed"] > 0
+
+    def test_count_events_per_label(self, db_with_deployment):
+        labels = ["car", "car", "bicycle", "person", "car"]
+        for i, label in enumerate(labels):
+            p = make_event_payload(id=f"evt-{i}", label=label)
+            insert_event(db_with_deployment, p)
+
+        rows = db_with_deployment.execute(
+            "SELECT label, COUNT(*) as cnt FROM events GROUP BY label ORDER BY cnt DESC"
+        ).fetchall()
+
+        counts = {row["label"]: row["cnt"] for row in rows}
+        assert counts["car"] == 3
+        assert counts["bicycle"] == 1
+        assert counts["person"] == 1
+
+    def test_avg_speed_query_across_radar_readings(self, db_with_deployment):
+        speeds = [25.0, 30.0, 35.0]
+        for i, spd in enumerate(speeds):
+            p = make_radar_payload(id=f"rad-{i}", max_speed=spd, avg_speed=spd)
+            insert_radar(db_with_deployment, p)
+
+        result = db_with_deployment.execute(
+            "SELECT AVG(max_speed) as fleet_avg FROM radar"
+        ).fetchone()
+
+        assert abs(result["fleet_avg"] - 30.0) < 0.01

--- a/tests/test_db_schema.py
+++ b/tests/test_db_schema.py
@@ -1,0 +1,61 @@
+"""
+test_db_schema.py
+
+Validates that the in-memory DB has the tables and columns documented at:
+    https://docs.trafficmonitor.ai/sensor-payloads/events-payload
+    https://docs.trafficmonitor.ai/sensor-payloads/radar-payload
+    
+These tests fail if the schema changes without tests being updated.
+"""
+
+import pytest
+
+def get_columns(db, table):
+    cursor = db.execute(f"PRAGMA table_info({table})")
+    return {row["name"] for row in cursor.fetchall()}
+
+def get_tables(db):
+    cursor = db.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    return {row["name"] for row in cursor.fetchall()}
+
+class TestTablesExist:
+    def test_deployment_table_exists(self, db):
+        assert "deployment" in get_tables(db)
+
+    def test_events_table_exists(self, db):
+        assert "events" in get_tables(db)
+
+    def test_radar_table_exists(self, db):
+        assert "radar" in get_tables(db)
+
+class TestDeploymentColumns:
+    REQUIRED = {"id", "label", "bearing", "created_at"}
+
+    def test_required_columns_present(self, db):
+        cols = get_columns(db, "deployment")
+        missing = self.REQUIRED - cols
+        assert not missing, f"deployment table missing columns: {missing}"
+    
+class TestEventsColumns:
+    REQUIRED = {
+        "id", "camera", "label", "score", "best_timestamp", "start_timestamp",
+        "end_timestamp", "zones", "deployment_id", "created_at",
+    }
+
+    def test_required_columns_present(self, db):
+        cols = get_columns(db, "events")
+        missing = self.REQUIRED - cols
+        assert not missing, f"events table missing columns: {missing}"
+
+class TestRadarColumns:
+    REQUIRED = {
+        "id", "sensor", "direction", "max_speed", "avg_speed", "dov_count",
+        "speeds", "duration_ms", "frame_count", "delta_speed", "est_length",
+        "units", "classification", "start_time", "end_time", "deployment_id",
+        "created_at",
+    }
+
+    def test_required_columns_present(self, db):
+        cols = get_columns(db, "radar")
+        missing = self.REQUIRED - cols
+        assert not missing, f"radar table missing columns: {missing}"

--- a/tests/test_event_payload.py
+++ b/tests/test_event_payload.py
@@ -1,0 +1,117 @@
+"""
+test_event_payload.py
+
+Tests for event payload structure, field types, and DB insertion.
+Based on the documented Events Payload:
+  https://docs.trafficmonitor.ai/sensor-payloads/events-payload
+"""
+
+import json
+import time
+import pytest
+from conftest import make_event_payload
+
+def insert_event(db, payload):
+    db.execute(
+        """
+        INSERT INTO events
+            (id, camera, label, sub_label, score, best_timestamp,
+             start_timestamp, end_timestamp, zones, deployment_id, created_at)
+        VALUES
+            (:id, :camera, :label, :sub_label, :score, :best_timestamp,
+             :start_timestamp, :end_timestamp, :zones, :deployment_id, :created_at)
+        """,
+        payload,
+    )
+    db.commit()
+
+class TestEventInsertion:
+    def test_valid_event_inserts(self, db_with_deployment):
+        payload = make_event_payload()
+        insert_event(db_with_deployment, payload)
+        row = db_with_deployment.execute(
+            "SELECT * FROM events WHERE id = ?", (payload["id"],)
+        ).fetchone()
+        assert row is not None
+        assert row["label"] == "car"
+
+    def test_duplicate_id_raises(self, db_with_deployment):
+        payload = make_event_payload()
+        insert_event(db_with_deployment, payload)
+        with pytest.raises(Exception):
+            insert_event(db_with_deployment, payload)
+
+    def test_missing_camera_raises(self, db_with_deployment):
+        payload = make_event_payload(camera=None)
+        with pytest.raises(Exception):
+            insert_event(db_with_deployment, payload)
+
+    def test_missing_label_raises(self, db_with_deployment):
+        payload = make_event_payload(label=None)
+        with pytest.raises(Exception):
+            insert_event(db_with_deployment, payload)
+
+class TestEventTimestamps:
+    def test_end_after_start(self):
+        payload = make_event_payload()
+        assert payload["end_timestamp"] >= payload["start_timestamp"]
+
+    def test_inverted_timestamps_stored_but_invalid(self, db_with_deployment):
+        now = int(time.time())
+        payload = make_event_payload(
+            start_timestamp=now,
+            end_timestamp=now - 10
+        )
+        insert_event(db_with_deployment, payload)
+        row = db_with_deployment.execute(
+            "SELECT * FROM events WHERE id=?", (payload["id"],)
+        ).fetchone()
+        assert row["end_timestamp"] < row["start_timestamp"]
+
+    def test_best_timestamp_between_start_and_end(self):
+        now = int(time.time())
+        payload = make_event_payload(
+            start_timestamp=now - 5,
+            best_timestamp=now - 2,
+            end_timestamp=now,
+        )
+        assert payload["start_timestamp"] <= payload["best_timestamp"] <= payload["end_timestamp"]
+
+class TestEventScore:
+    def test_score_between_0_and_1(self):
+        payload = make_event_payload(score=0.87)
+        assert 0.0 <= payload["score"] <= 1.0
+
+    def test_score_above_1_stored_without_constraint(self, db_with_deployment):
+        payload = make_event_payload(score=1.5)
+        insert_event(db_with_deployment, payload)
+        row = db_with_deployment.execute(
+            "SELECT score FROM events WHERE id=?", (payload["id"],)
+        ).fetchone()
+        assert row["score"] == 1.5
+
+class TestEventZones:
+    def test_zones_is_valid_json_array(self):
+        payload = make_event_payload(zones=json.dumps(["zone_road", "zone_sidewalk"]))
+        parsed = json.loads(payload["zones"])
+        assert isinstance(parsed, list)
+        assert all(isinstance(z, str) for z in parsed)
+
+    def test_empty_zones_allowed(self, db_with_deployment):
+        payload = make_event_payload(zones=json.dumps([]))
+        insert_event(db_with_deployment, payload)
+        row = db_with_deployment.execute(
+            "SELECT zones FROM events WHERE id=?", (payload["id"],)
+        ).fetchone()
+        assert json.loads(row["zones"]) == []
+
+class TestKnownObjectLabels:
+    VALID_LABELS = {"car", "bicycle", "person", "motorcycle", "truck", "bus", "dog", "cat"}
+
+    def test_car_is_valid_label(self):
+        payload = make_event_payload(label="car")
+        assert payload["label"] in self.VALID_LABELS
+
+    def test_unknown_label_not_in_expected_set(self):
+        payload = make_event_payload(label="ufo")
+        assert payload["label"] not in self.VALID_LABELS

--- a/tests/test_radar_payload.py
+++ b/tests/test_radar_payload.py
@@ -1,0 +1,132 @@
+"""
+test_radar_payload.py
+
+Tests for radar payload structure, field types, and DB insertion.
+Based on the documented Radar Payload:
+  https://docs.trafficmonitor.ai/sensor-payloads/radar-payload
+
+Radar sensor: OmniPreSence OPS243-A Doppler Radar
+"""
+
+import json
+import pytest
+from conftest import make_radar_payload
+
+def insert_radar(db, payload):
+    db.execute(
+        """
+        INSERT INTO radar
+            (id, sensor, direction, max_speed, avg_speed, dov_count, speeds,
+             duration_ms, frame_count, delta_speed, est_length, units,
+             classification, start_time, end_time, deployment_id, created_at)
+        VALUES
+            (:id, :sensor, :direction, :max_speed, :avg_speed, :dov_count, :speeds,
+             :duration_ms, :frame_count, :delta_speed, :est_length, :units,
+             :classification, :start_time, :end_time, :deployment_id, :created_at)
+        """,
+        payload,
+    )
+    db.commit()
+
+class TestRadarInsertion:
+    def test_valid_reading_inserts(self, db_with_deployment):
+        payload = make_radar_payload()
+        insert_radar(db_with_deployment, payload)
+        row = db_with_deployment.execute(
+            "SELECT * FROM radar WHERE id=?", (payload["id"],)
+        ).fetchone()
+        assert row is not None
+        assert row["sensor"] == "radar_front"
+
+    def test_missing_sensor_raises(self, db_with_deployment):
+        payload = make_radar_payload(sensor=None)
+        with pytest.raises(Exception):
+            insert_radar(db_with_deployment, payload)
+
+    def test_duplicate_id_raises(self, db_with_deployment):
+        payload = make_radar_payload()
+        insert_radar(db_with_deployment, payload)
+        with pytest.raises(Exception):
+            insert_radar(db_with_deployment, payload)
+
+class TestRadarDirection:
+    VALID_DIRECTIONS = {"inbound", "outbound"}
+
+    def test_inbound_is_valid(self):
+        payload = make_radar_payload(direction="inbound")
+        assert payload["direction"] in self.VALID_DIRECTIONS
+
+    def test_outbound_is_valid(self):
+        payload = make_radar_payload(direction="outbound")
+        assert payload["direction"] in self.VALID_DIRECTIONS
+
+    def test_invalid_direction_stored_without_constraint(self, db_with_deployment):
+        payload = make_radar_payload(direction="sideways")
+        insert_radar(db_with_deployment, payload)
+        row = db_with_deployment.execute(
+            "SELECT direction FROM radar WHERE id=?", (payload["id"],)
+        ).fetchone()
+        assert row["direction"] == "sideways"
+
+class TestRadarSpeedFields:
+    def test_max_speed_gte_avg_speed(self):
+        payload = make_radar_payload(max_speed=30.0, avg_speed=25.0)
+        assert payload["max_speed"] >= payload["avg_speed"]
+
+    def test_delta_speed_equals_max_minus_min(self):
+        speeds = [28.5, 27.2, 26.1]
+        delta = max(speeds) - min(speeds)
+        payload = make_radar_payload(
+            speeds=json.dumps(speeds),
+            delta_speed=round(delta, 2),
+        )
+        parsed_speeds = json.loads(payload["speeds"])
+        assert abs((max(parsed_speeds) - min(parsed_speeds)) - payload["delta_speed"]) < 0.01
+
+    def test_negative_speed_stored_without_constraint(self, db_with_deployment):
+        payload = make_radar_payload(max_speed=-5.0, avg_speed=-5.0)
+        insert_radar(db_with_deployment, payload)
+        row = db_with_deployment.execute(
+            "SELECT max_speed FROM radar WHERE id=?", (payload["id"],)
+        ).fetchone()
+        assert row["max_speed"] < 0
+
+    def test_speeds_array_is_valid_json(self):
+        payload = make_radar_payload(speeds=json.dumps([28.5, 27.2, 26.1]))
+        parsed = json.loads(payload["speeds"])
+        assert isinstance(parsed, list)
+        assert all(isinstance(s, (int, float)) for s in parsed)
+
+    def test_dov_count_matches_speeds_array_length(self):
+        speeds = [28.5, 27.2, 26.1]
+        payload = make_radar_payload(
+            speeds=json.dumps(speeds),
+            dov_count=len(speeds),
+        )
+        assert payload["dov_count"] == len(json.loads(payload["speeds"]))
+
+class TestRadarUnits:
+    VALID_UNITS = {"mph", "kph"}
+
+    def test_mph_is_valid(self):
+        payload = make_radar_payload(units="mph")
+        assert payload["units"] in self.VALID_UNITS
+
+    def test_kph_is_valid(self):
+        payload = make_radar_payload(units="kph")
+        assert payload["units"] in self.VALID_UNITS
+
+class TestRadarClassification:
+    def test_classification_is_valid_json_object(self):
+        payload = make_radar_payload(
+            classification=json.dumps({"car": 0.86, "bike": 0.05, "person": 0.10})
+        )
+        parsed = json.loads(payload["classification"])
+        assert isinstance(parsed, dict)
+
+    def test_classification_scores_between_0_and_1(self):
+        clf = {"car": 0.86, "bike": 0.05, "person": 0.10}
+        payload = make_radar_payload(classification=json.dumps(clf))
+        parsed = json.loads(payload["classification"])
+        for label, score in parsed.items():
+            assert 0.0 <= score <= 1.0, f"{label} score {score} out of range"


### PR DESCRIPTION
-- this is my first PR. Saw a testing framework was needed so I built one.

44 pytest tests that cover:
- the SQLite schema (checks if the right tables and columns exist)
- event payload validation (insertion, timestamps, scores, zones, object labels)
- radar payload validation (insertion, direction, speed math, units, classification)
- cross-table relationships (foreign keys, joins, aggregations)

No hardware needed. It runs against an in-memory SQLite database that mirrors the documented schema from docs.trafficmonitor.ai

I also added a GitHub Actions workflow so tests run automatically on every PR

A couple tests intentionally store bad data to document places where the schema could use CHECK constraints in the future. Basically a "to-do" list for schema hardening.

All 44 tests passed in .06 seconds