### PR TITLE
create hevc device script and assignment

### DIFF
--- a/container/frigate/frigate.container.j2
+++ b/container/frigate/frigate.container.j2
@@ -1,26 +1,27 @@
-[Unit]
-Description=Frigate container for Traffic Monitor
-After=go2rtc_server.service podman.socket
-Wants=go2rtc_server.service
-
-[Container]
-ContainerName=frigate
-Image=frigate-tm.build
-Pod=traffic-monitor.pod
-ShmSize=512m
-{% for name, detector in tmsetup_detectors.items() %}{% if (detector.dev_path_available | default(false) and detector.exists | default(false)) or detector.fresh_install | default(false) %}
-AddDevice={{ detector.dev_path }}:{{ detector.dev_path }}
-{% endif %}{% endfor %}
-AddDevice=/dev/media3:/dev/media3
-AddDevice=/dev/video19:/dev/video19
-Volume=/etc/localtime:/etc/localtime:ro
-Volume={{ tmsetup_codedir }}/frigate/config:/config
-Volume={{ tmsetup_codedir }}/frigate/storage:/media/frigate
-Tmpfs=/tmp/cache:size=1g,rw,mode=1777
-EnvironmentFile={{ tmsetup_codedir }}/frigate/frigate.env
-
-[Service]
-Restart=on-failure
-
-[Install]
-WantedBy=default.target node-red-tm.service
+1	[Unit]
+2	Description=Frigate container for Traffic Monitor
+3	After=go2rtc_server.service podman.socket
+4	Wants=go2rtc_server.service
+5
+6	[Container]
+7	ContainerName=frigate
+8	Image=frigate-tm.build
+9	Pod=traffic-monitor.pod
+10	ShmSize=512m
+11	{% for name, detector in tmsetup_detectors.items() %}{% if (detector.dev_path_available | default(false) and detector.exists | default(false)) or detector.fresh_install | default(false) %}
+12	AddDevice={{ detector.dev_path }}:{{ detector.dev_path }}
+13	{% endif %}{% endfor %}
+14	AddDevice={{ tmsetup_hevc_device }}:{{ tmsetup_hevc_device }}
+15	AddDevice=/dev/video19:/dev/video19
+16	Volume=/etc/localtime:/etc/localtime:ro
+17	Volume={{ tmsetup_codedir }}/frigate/config:/config
+18	Volume={{ tmsetup_codedir }}/frigate/storage:/media/frigate
+19	Tmpfs=/tmp/cache:size=1g,rw,mode=1777
+20	EnvironmentFile={{ tmsetup_codedir }}/frigate/frigate.env
+21
+22	[Service]
+23	Restart=on-failure
+24
+25	[Install]
+26	WantedBy=default.target node-red-tm.service
+27

--- a/script/ansible/roles/tmsetup/defaults/main.yml
+++ b/script/ansible/roles/tmsetup/defaults/main.yml
@@ -46,6 +46,8 @@ tmsetup_radar_paths:
   - /dev/ttyACM2
   - /dev/ttyACM3
 
+tmsetup_hevc_device: '/dev/media3'
+
 tmsetup_thingsboard_server: 'tb.server.com'
 tmsetup_thingsboard_protocol: 'https'
 tmsetup_thingsboard_port: '443'

--- a/script/ansible/roles/tmsetup/tasks/set_vars.yml
+++ b/script/ansible/roles/tmsetup/tasks/set_vars.yml
@@ -1,25 +1,37 @@
----
-- name: TMSetup - Main - Perform minimum ansible fact gathering
-  tags:
-    - always
-  ansible.builtin.setup:
-    gather_subset: min
-  when: not ansible_facts.keys() | list |
-    intersect(tmsetup_base_required_facts) == tmsetup_base_required_facts
-
-- name: TMSetup - Main - Set Architecture specific variables
-  tags:
-    - always
-  ansible.builtin.include_vars:
-    file: "{{ ansible_facts['architecture'] }}_vars.yml"
-
-- name: TMSetup - Main - Set var for Raspberry Pi serial number
-  ansible.builtin.slurp:
-    src: /sys/firmware/devicetree/base/serial-number
-  register: __tmsetup_slurp_devtree_register
-
-- name: TMSetup - Main - Set RPi serial number fact
-  ansible.builtin.set_fact:
-    tmsetup_raspberry_pi_serial: "{{ (__tmsetup_slurp_devtree_register['content'] | b64decode)[:-1] }}"
-
-...
+1	---
+2	- name: TMSetup - Main - Perform minimum ansible fact gathering
+3	  tags:
+4	    - always
+5	  ansible.builtin.setup:
+6	    gather_subset: min
+7	  when: not ansible_facts.keys() | list |
+8	    intersect(tmsetup_base_required_facts) == tmsetup_base_required_facts
+9
+10	- name: TMSetup - Main - Set Architecture specific variables
+11	  tags:
+12	    - always
+13	  ansible.builtin.include_vars:
+14	    file: "{{ ansible_facts['architecture'] }}_vars.yml"
+15
+16	- name: TMSetup - Main - Set var for Raspberry Pi serial number
+17	  ansible.builtin.slurp:
+18	    src: /sys/firmware/devicetree/base/serial-number
+19	  register: __tmsetup_slurp_devtree_register
+20
+21	- name: TMSetup - Main - Set RPi serial number fact
+22	  ansible.builtin.set_fact:
+23	    tmsetup_raspberry_pi_serial: "{{ (__tmsetup_slurp_devtree_register['content'] | b64decode)[:-1] }}"
+24
+25	- name: TMSetup - Main - Find HEVC hardware device
+26	  become: true
+27	  shell: /bin/bash files/utils/find_hevc_device.sh
+28	  register: hevc_device_scan
+29	  changed_when: false
+30	  ignore_errors: true
+31
+32	- name: TMSetup - Main - Set HEVC device fact
+33	  ansible.builtin.set_fact:
+34	    tmsetup_hevc_device: "{{ hevc_device_scan.stdout | trim if hevc_device_scan.stdout != '' else tmsetup_hevc_device }}"
+35	  when: hevc_device_scan.stdout != ''
+36
+37	...

--- a/utils/find_hevc_device.sh
+++ b/utils/find_hevc_device.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Scan for /dev/media* devices and find one with model rpi-hevc-dec
+for device in /dev/media*; do
+    if udevadm info -a -n "$device" 2>/dev/null | grep -q 'ATTR{model}=="rpi-hevc-dec"'; then
+        echo "$device"
+        break
+    fi
+done


### PR DESCRIPTION
Added a bash shell script to iterate through `/dev/media*` to grep for the line: `ATTR{model}=="rpi-hevc-dec"` and pull that device into the Ansible `tmsetup` script for assignment on the Frigate container `AddDevice=` line.