### PR TITLE
added sysstat package and service configs

### DIFF
--- a/script/ansible/roles/tmsetup/files/logrotate-systat
+++ b/script/ansible/roles/tmsetup/files/logrotate-systat
@@ -1,0 +1,9 @@
+/var/log/sysstat/*.log {
+    daily
+    rotate 15
+    compress
+    delaycompress
+    missingok
+    notifempty
+    create 0644 root root
+}

--- a/script/ansible/roles/tmsetup/handlers/main.yml
+++ b/script/ansible/roles/tmsetup/handlers/main.yml
@@ -19,6 +19,13 @@
     state: restarted
   notify: Pause for 10 seconds
 
+- name: Restart sysstat service
+  become: true
+  ansible.builtin.systemd_service:
+    daemon_reload: true
+    name: sysstat.service
+    state: restarted
+
 - name: Restart go2rtc_server service
   become: true
   ansible.builtin.systemd_service:

--- a/script/ansible/roles/tmsetup/tasks/base_setup.yml
+++ b/script/ansible/roles/tmsetup/tasks/base_setup.yml
@@ -91,4 +91,23 @@
     mode: '0755'
   notify: Restart journald service
 
+- name: TMSetup - Base Setup - Enable sysstat collection
+  become: true
+  ansible.builtin.lineinfile:
+    path: /etc/default/sysstat
+    state: present
+    backrefs: true
+    regexp: '^ENABLED="false"'
+    line: 'ENABLED="true"'
+
+- name: TMSetup - Base Setup - Create logrotate configuration for sysstat
+  become: true
+  ansible.builtin.copy:
+    src: logrotate-systat
+    dest: /etc/logrotate.d/sysstat
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Restart sysstat service
+
 ...

--- a/script/ansible/roles/tmsetup/tasks/start_services.yml
+++ b/script/ansible/roles/tmsetup/tasks/start_services.yml
@@ -8,6 +8,14 @@
     name: NetworkManager.service
     state: started
 
+- name: TMSetup - Start Services - Start and enable sysstat.service
+  become: true
+  ansible.builtin.systemd_service:
+    daemon_reload: true
+    enabled: true
+    name: sysstat.service
+    state: started
+
 - name: TMSetup - Start Services - Start and enable traffic-monitor services
   become: true
   loop:

--- a/script/ansible/roles/tmsetup/vars/main.yml
+++ b/script/ansible/roles/tmsetup/vars/main.yml
@@ -21,6 +21,7 @@ tmsetup_packages:
   - cmake
   - cron
   - rpicam-apps
+  - sysstat
 
 tmsetup_base_required_facts:
   - 'os_family'


### PR DESCRIPTION
closes #181 

Adding system resource reporting package `sysstat` as a default option for all devices. It's lightweight collection and has an included reporting mechanism with `sar`; e.g. `sar -u 1 1`.  This should allow more immediate investigation into historical performance.

Created a default logrotate configuration that rotates daily and should have a 15-month deletion policy.

References:
- http://wikieduonline.com/wiki/Installing_sysstat_using_Ansible
- https://serverfault.com/questions/913087/sar-enable-data-collecting